### PR TITLE
Setup GitHub actions deploy

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,5 +1,8 @@
 name: Deploy Prod (SST)
- on: push
+ on:
+  push:
+   branches:
+    - main
 
  # Concurrency group name ensures concurrent workflow runs wait for any in-progress job to finish
  concurrency:

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,0 +1,30 @@
+name: Deploy Prod (SST)
+ on: push
+
+ # Concurrency group name ensures concurrent workflow runs wait for any in-progress job to finish
+ concurrency:
+   group: merge-${{ github.ref }}
+
+ permissions:
+   id-token: write # This is required for requesting the JWT
+   contents: read # This is required for actions/checkout
+
+ jobs:
+   DeployApp:
+     runs-on: ubuntu-latest
+     env:
+     #Define your envs needed for static generation:
+     # ENV_NAME: ${{ secrets.ENV_NAME }}
+     steps:
+       - name: Git clone the repository
+         uses: actions/checkout@v3
+       - name: Configure AWS credentials
+         uses: aws-actions/configure-aws-credentials@v2
+         with:
+           role-to-assume: arn:aws:iam::1234567890:role/GitHub
+           role-duration-seconds: 14390 #adjust as needed for your build time
+           aws-region: us-east-1
+       - name: Deploy app
+         run: |
+           npm i && npx sst deploy --stage prod
+

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "dev": "sst dev",
     "build": "sst build",
     "deploy": "sst deploy",
+    "deploy:prod": "sst deploy --stage prod",
     "remove": "sst remove",
     "console": "sst console",
     "typecheck": "tsc --noEmit"

--- a/stacks/DeployProd.ts
+++ b/stacks/DeployProd.ts
@@ -1,0 +1,72 @@
+import { Duration } from 'aws-cdk-lib';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import { StackContext } from 'sst/constructs';
+
+export function IAM({ app, stack }: StackContext) {
+  if (app.stage === 'prod') {
+
+    const provider = new iam.OpenIdConnectProvider(stack, 'GitHub', {
+      url: 'https://token.actions.githubusercontent.com',
+      clientIds: ['sts.amazonaws.com'],
+    });
+
+    const organization = 'meetnearme'; // Use your GitHub organization
+    const repository = 'api'; // Use your GitHub repository
+
+    new iam.Role(stack, 'GitHubActionsRole', {
+      assumedBy: new iam.OpenIdConnectPrincipal(provider).withConditions({
+        StringLike: {
+          'token.actions.githubusercontent.com:sub': `repo:${organization}/${repository}:*`,
+        },
+      }),
+      description: 'Role assumed for deploying from GitHub CI using AWS CDK',
+      roleName: 'GitHub', // Change this to match the role name in the GitHub workflow file
+      maxSessionDuration: Duration.hours(1),
+      inlinePolicies: { // You could attach AdministratorAccess here or constrain it even more, but this uses more granular permissions used by SST
+        SSTDeploymentPolicy: new iam.PolicyDocument({
+          assignSids: true,
+          statements: [
+            new iam.PolicyStatement({
+              effect: iam.Effect.ALLOW,
+              actions: [
+                'cloudformation:DeleteStack',
+                'cloudformation:DescribeStackEvents',
+                'cloudformation:DescribeStackResources',
+                'cloudformation:DescribeStacks',
+                'cloudformation:GetTemplate',
+                'cloudformation:ListImports',
+                'ecr:CreateRepository',
+                'iam:PassRole',
+                'iot:Connect',
+                'iot:DescribeEndpoint',
+                'iot:Publish',
+                'iot:Receive',
+                'iot:Subscribe',
+                'lambda:GetFunction',
+                'lambda:GetFunctionConfiguration',
+                'lambda:UpdateFunctionConfiguration',
+                's3:ListBucket',
+                's3:PutObjectAcl',
+                's3:GetObject',
+                's3:PutObject',
+                's3:DeleteObject',
+                's3:ListObjectsV2',
+                's3:CreateBucket',
+                's3:PutBucketPolicy',
+                'ssm:DeleteParameter',
+                'ssm:GetParameter',
+                'ssm:GetParameters',
+                'ssm:GetParametersByPath',
+                'ssm:PutParameter',
+                'sts:AssumeRole',
+              ],
+              resources: [
+                '*',
+              ],
+            }),
+          ],
+        }),
+      },
+    });
+  }
+}


### PR DESCRIPTION
In this PR, I've followed the guidance in the following docs to setup github actions to deploy via SST 

The `on` trigger is scoped down to `on:push:branches: - main` so that only merges to `main` trigger a deploy

* https://docs.sst.dev/going-to-production
* https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services
* https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc.html