### PR TITLE
parameterize dynamodb table naem

### DIFF
--- a/functions/lambda/dynamodb.go
+++ b/functions/lambda/dynamodb.go
@@ -16,7 +16,7 @@ import (
 )
 
 func getDbTableName (tableName string) string {
-    var SST_Table_tableName_Events = os.Getenv("SST_Table_tableName_Events")
+    var SST_Table_tableName_Events = os.Getenv("SST_Table_tableName_" + shared.EventsTablePrefix)
     if (os.Getenv("SST_STAGE") != "prod") {
         return tableName
     }


### PR DESCRIPTION
the dynamodb table name has an implicit value `Events` that we want to control with a const / var of some kind, the remainder (the prefix bit) is an implicit part of the SST naming convention, we want to separate them