### PR TITLE
Update SST setup instructions in the readme

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,4 @@
 MEETNEARME_TEST_SECRET=anything
 ZENROWS_API_KEY=ask_for_key
+aws_access_key_id="<YOUR_AWS_IAM_ACCESS_KEY_ID>"
+aws_secret_access_key="<YOUR_AWS_IAM_ACCESS_KEY_SECRET>"

--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,2 @@
 MEETNEARME_TEST_SECRET=anything
 ZENROWS_API_KEY=ask_for_key
-aws_access_key_id="<YOUR_AWS_IAM_ACCESS_KEY_ID>"
-aws_secret_access_key="<YOUR_AWS_IAM_ACCESS_KEY_SECRET>"

--- a/README.md
+++ b/README.md
@@ -11,18 +11,8 @@
 
 1. `npm i`
 1. Create an AWS account if you don't have one.
-1. Create an IAM Role: `meetnearme-bot`.
-1. [Optional] Assign IAM User to User group: `meetnearme`
-1. Under the IAM Role > Select the **Permissions** Tab
-1. Select _Attach existing policies directly_.
-1. Search for **AdministratorAccess** and select the policy by checking the checkbox, then select **Next**.
-1. Click **Add Permissions**
-1. Navigate back to the IAM Role
-1. Go to **Security Credentials** Tab
-1. Select **Create access key**
-1. Select **Other** and select **Next**
-1. Optionally add a tag and select **Create Access Key**
-1. Create an `.env` file using `.env.example` to add needed keys.
+1. [Create an IAM User](https://sst.dev/chapters/create-an-iam-user.html)
+1. Export `aws_access_key_id` and `aws_secret_access_key` env variables.
 1. Run `brew install awscli` in the terminal to install AWS CLI
 1. Run `aws configure` to [Authorize SST via AWS CLI](https://sst.dev/chapters/configure-the-aws-cli.html)
 17. Run `npm run dev` to run the Go Lambda Gateway V2 server locally, proxied through

--- a/README.md
+++ b/README.md
@@ -5,26 +5,26 @@
 ### Running the local SAM dynamodb docker container
 
 1. `$ docker compose build`
-2. `$ docker compose up`
+1. `$ docker compose up`
 
 ### Running the Lambda project
 
 1. `npm i`
-2. Create an AWS account if you don't have one.
-3. Create an IAM Role: `meetnearme-bot`.
-4. [Optional] Assign IAM User to User group: `meetnearme`
-5. Under the IAM Role > Select the **Permissions** Tab
-6. Select _Attach existing policies directly_.
-7. Search for **AdministratorAccess** and select the policy by checking the checkbox, then select **Next**.
-8. Click **Add Permissions**
-9. Navigate back to the IAM Role
-10. Go to **Security Credentials** Tab
-11. Select **Create access key**
-12. Select **Other** and select **Next**
-13. Optionally add a tag and select **Create Access Key**
-14. Create an `.env` file using `.env.example` to add needed keys.
-15. Run `brew install awscli` in the terminal to install AWS CLI
-16. Run `aws configure` to [Authorize SST via AWS CLI](https://sst.dev/chapters/configure-the-aws-cli.html)
+1. Create an AWS account if you don't have one.
+1. Create an IAM Role: `meetnearme-bot`.
+1. [Optional] Assign IAM User to User group: `meetnearme`
+1. Under the IAM Role > Select the **Permissions** Tab
+1. Select _Attach existing policies directly_.
+1. Search for **AdministratorAccess** and select the policy by checking the checkbox, then select **Next**.
+1. Click **Add Permissions**
+1. Navigate back to the IAM Role
+1. Go to **Security Credentials** Tab
+1. Select **Create access key**
+1. Select **Other** and select **Next**
+1. Optionally add a tag and select **Create Access Key**
+1. Create an `.env` file using `.env.example` to add needed keys.
+1. Run `brew install awscli` in the terminal to install AWS CLI
+1. Run `aws configure` to [Authorize SST via AWS CLI](https://sst.dev/chapters/configure-the-aws-cli.html)
 17. Run `npm run dev` to run the Go Lambda Gateway V2 server locally, proxied through
    Lambda to your local
 
@@ -37,8 +37,8 @@ export GOPATH=$HOME/go
 export PATH=$PATH:$GOROOT/bin:$GOPATH/bin
 ```
 
-2. `go install github.com/a-h/templ`
-3. Run `templ generate`
+1. `go install github.com/a-h/templ`
+1. Run `templ generate`
 
 ### Validate home page is working + data-connected
 
@@ -64,8 +64,8 @@ https://awscli.amazonaws.com/v2/documentation/api/latest/reference/dynamodb/inde
 When updating env vars, the changes need to be made in 4 places:
 
 1. `stacks/ApiStack.ts`
-2. `.github/actions/set_aws_creds_env_vars/action.yml` (`inputs` section)
-3. `.github/actions/set_aws_creds_env_vars/action.yml` (`run` section where vars
+1. `.github/actions/set_aws_creds_env_vars/action.yml` (`inputs` section)
+1. `.github/actions/set_aws_creds_env_vars/action.yml` (`run` section where vars
    are `echo`d)
-4. `.env.example` to clarify in version control what our currently-used env vars
+1. `.env.example` to clarify in version control what our currently-used env vars
    are

--- a/README.md
+++ b/README.md
@@ -5,16 +5,27 @@
 ### Running the local SAM dynamodb docker container
 
 1. `$ docker compose build`
-1. `$ docker compose up`
+2. `$ docker compose up`
 
 ### Running the Lambda project
 
 1. `npm i`
-1. Create an `.env` file using `.env.example` to add needed keys (for the secret
-   values, ask someone on the team)
-1. Create an AWS account if you don't have one
-1. [Authorize SST via AWS CLI](https://sst.dev/chapters/configure-the-aws-cli.html)
-1. `npm run dev` runs the Go Lambda Gateway V2 server locally, proxied through
+2. Create an AWS account if you don't have one.
+3. Create an IAM Role: `meetnearme-bot`.
+4. [Optional] Assign IAM User to User group: `meetnearme`
+5. Under the IAM Role > Select the **Permissions** Tab
+6. Select _Attach existing policies directly_.
+7. Search for **AdministratorAccess** and select the policy by checking the checkbox, then select **Next**.
+8. Click **Add Permissions**
+9. Navigate back to the IAM Role
+10. Go to **Security Credentials** Tab
+11. Select **Create access key**
+12. Select **Other** and select **Next**
+13. Optionally add a tag and select **Create Access Key**
+14. Create an `.env` file using `.env.example` to add needed keys.
+15. Run `brew install awscli` in the terminal to install AWS CLI
+16. Run `aws configure` to [Authorize SST via AWS CLI](https://sst.dev/chapters/configure-the-aws-cli.html)
+17. Run `npm run dev` to run the Go Lambda Gateway V2 server locally, proxied through
    Lambda to your local
 
 ### Generate Go templates from \*.templ files
@@ -26,8 +37,8 @@ export GOPATH=$HOME/go
 export PATH=$PATH:$GOROOT/bin:$GOPATH/bin
 ```
 
-1. `go install github.com/a-h/templ`
-1. Run `templ generate`
+2. `go install github.com/a-h/templ`
+3. Run `templ generate`
 
 ### Validate home page is working + data-connected
 
@@ -53,8 +64,8 @@ https://awscli.amazonaws.com/v2/documentation/api/latest/reference/dynamodb/inde
 When updating env vars, the changes need to be made in 4 places:
 
 1. `stacks/ApiStack.ts`
-1. `.github/actions/set_aws_creds_env_vars/action.yml` (`inputs` section)
-1. `.github/actions/set_aws_creds_env_vars/action.yml` (`run` section where vars
+2. `.github/actions/set_aws_creds_env_vars/action.yml` (`inputs` section)
+3. `.github/actions/set_aws_creds_env_vars/action.yml` (`run` section where vars
    are `echo`d)
-1. `.env.example` to clarify in version control what our currently-used env vars
+4. `.env.example` to clarify in version control what our currently-used env vars
    are


### PR DESCRIPTION
For devs setting up this repo for the first time, the instructions to link SST using AWS is missing important steps.
This PR adds instructions directly to the README and updates .env.example to be in-line with the instructions