### PR TITLE
Feature: Enable auto-deletion of SST / AWS CloudFormation stacks when the feature branch merges

### DIFF
--- a/.github/workflows/remove-feature.yml
+++ b/.github/workflows/remove-feature.yml
@@ -1,0 +1,30 @@
+name: Remove Feature Branch (SST)
+on:
+  delete:
+    branches:
+      - 'feature/**'
+jobs:
+  DeleteFeatureSST:
+    if:
+      github.event.ref_type == 'branch' && startsWith(github.ref,
+      'refs/heads/feature/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract and format branch name
+        shell: bash
+        run: |
+          BRANCH_NAME=${GITHUB_REF#refs/heads/}
+          FORMATTED_BRANCH_NAME=$(echo "$BRANCH_NAME" | sed 's|/|-|g')
+          echo "FORMATTED_BRANCH_NAME=$FORMATTED_BRANCH_NAME" >> $GITHUB_ENV
+        id: extract_branch
+      - name: Run SST remove
+        run: |
+          echo "Clean up for branch $FORMATTED_BRANCH_NAME"
+          npm i && npx sst remove --stage $FORMATTED_BRANCH_NAME
+
+# Concurrency group name ensures concurrent workflow runs wait for any in-progress job to finish
+concurrency:
+  group: delete-${{ github.event.ref }}
+
+permissions:
+  contents: read # This is required for actions/checkout


### PR DESCRIPTION
Add `.github/workflows/remove-feature.yml` to enable auto-deletion of SST / AWS CloudFormation stacks that begin with `feature-*` when a branch of that name is deleted (a side effect of merge)

Note this is one of those PRs that has to merge and be in `main` in order for the `on: delete: branches: 'feature/**' to work. It could get messy if I don't know what I'm doing, but I think it might be lined up to work properly with what I have here already