### PR TITLE
SST remove workflow: git clone repo and checkout main for sst binary

### DIFF
--- a/.github/workflows/remove-feature.yml
+++ b/.github/workflows/remove-feature.yml
@@ -10,6 +10,15 @@ jobs:
       'feature/') }}
     runs-on: ubuntu-latest
     steps:
+      - name: Git clone the repository
+        uses: actions/checkout@v4
+        ref: 'main'
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::626762246796:role/GitHub
+          role-duration-seconds: 1200 #adjust as needed for your build time
+          aws-region: us-east-1
       - name: Extract and format branch name
         shell: bash
         run: |


### PR DESCRIPTION
self-merging once again, since there's no reasonable path for debugging github actions and hence it needs to merge to `main`