### PR TITLE
Fix prop-drilling on `undefined` blocking auto-delete / cleanup of feature/* AWS envs

### DIFF
--- a/stacks/StaticSiteStack.ts
+++ b/stacks/StaticSiteStack.ts
@@ -21,8 +21,8 @@ export function StaticSiteStack({ stack }: StackContext) {
     // },
   });
   stack.addOutputs({
-    StaticEndpoint: staticSite.url,
-    BucketDomainName: staticSite.bucket.bucketDomainName,
+    StaticEndpoint: staticSite?.url,
+    BucketDomainName: staticSite?.bucket?.bucketDomainName,
   });
 
   return { staticSite };


### PR DESCRIPTION
Using optional chaining here should be enough to fix. 

Fixes #27 