### PR TITLE
Update schema to new marqo-indexed fields, move `purchasable` & `registrationFields` out of event schema

### DIFF
--- a/schemas/event.schema.json
+++ b/schemas/event.schema.json
@@ -1,50 +1,9 @@
 {
   "$id": "https://github.com/meetnearme/api/architecture/Event.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "definitions": {
-    "registrationFields": {
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "type": {
-          "type": "string",
-          "enum": [
-            "text",
-            "url",
-            "email",
-            "phone",
-            "number",
-            "select",
-            "checkbox",
-            "radio"
-          ]
-        },
-        "options": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "required": {
-          "type": "boolean"
-        },
-        "default": {
-          "type": "string"
-        },
-        "placeholder": {
-          "type": "string"
-        },
-        "description": {
-          "type": "string"
-        }
-      }
-    }
-  },
   "type": "object",
   "properties": {
-    "id": {
+    "_id": {
       "$ref": "https://github.com/meetnearme/api/architecture/Shared.json#definitions/UUID"
     },
     "eventSourceId": {
@@ -52,6 +11,13 @@
     },
     "eventSourceType": {
       "$ref": "https://github.com/meetnearme/api/architecture/Shared.json#definitions/EventSourceType"
+    },
+    "eventOwners": {
+      "type": "array",
+      "items": {
+        "$ref": "https://github.com/meetnearme/api/architecture/Shared.json#definitions/UUID"
+      },
+      "minItems": 1
     },
     "name": {
       "type": "string"
@@ -68,16 +34,11 @@
     "recurrenceRule": {
       "type": "string"
     },
-    "registrationFields": {
-      "$ref": "#/definitions/registrationFields",
-      "default": []
+    "hasRegistrationFields": {
+      "type": "boolean"
     },
-    "purchasable": {
-      "type": "array",
-      "items": {
-        "$ref": "https://github.com/meetnearme/api/architecture/Purchasable.json"
-      },
-      "default": []
+    "hasPurchasable": {
+      "type": "boolean"
     },
     "url": {
       "$ref": "https://github.com/meetnearme/api/architecture/Shared.json#definitions/Url"
@@ -108,9 +69,6 @@
       },
       "default": []
     },
-    "zOrderIndex": {
-      "type": "string"
-    },
     "externalEventUrl": {
       "$ref": "https://github.com/meetnearme/api/architecture/Shared.json#definitions/Url"
     },
@@ -128,6 +86,7 @@
     "id",
     "eventSourceId",
     "eventSourceType",
+    "eventOwners",
     "name",
     "startTime",
     "url",

--- a/schemas/event.schema.json
+++ b/schemas/event.schema.json
@@ -46,13 +46,13 @@
     "imageUrl": {
       "$ref": "https://github.com/meetnearme/api/architecture/Shared.json#definitions/Url"
     },
-    "locationLatitude": {
+    "lat": {
       "type": ["number", "null"]
     },
-    "locationLongitude": {
+    "long": {
       "type": ["number", "null"]
     },
-    "locationAddress": {
+    "address": {
       "type": ["string", "null"]
     },
     "tags": {
@@ -69,7 +69,7 @@
       },
       "default": []
     },
-    "externalEventUrl": {
+    "externalUrl": {
       "$ref": "https://github.com/meetnearme/api/architecture/Shared.json#definitions/Url"
     },
     "createdAt": {

--- a/schemas/purchasable.schema.json
+++ b/schemas/purchasable.schema.json
@@ -30,39 +30,48 @@
   },
   "type": "object",
   "properties": {
-    "name": {
-      "type": "string"
+    "id": {
+      "$ref": "https://github.com/meetnearme/api/architecture/Shared.json#definitions/UUID"
     },
-    "itemType": {
-      "$ref": "#/definitions/itemType"
-    },
-    "cost": {
-      "type": "number"
-    },
-    "currency": {
-      "type": "string"
-    },
-    "donationRatio": {
-      "type": "number"
-    },
-    "inventory": {
-      "type": "number"
-    },
-    "chargeRecurrence": {
-      "$ref": "#/definitions/chargeRecurrence"
-    }
-  },
-  "required": ["name", "itemType", "cost", "currency"],
-  "allOf": [
-    {
-      "if": {
-        "properties": {
-          "itemType": { "const": "partialDonation" }
+    "items": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "itemType": {
+          "$ref": "#/definitions/itemType"
+        },
+        "cost": {
+          "type": "number"
+        },
+        "currency": {
+          "type": "string"
+        },
+        "donationRatio": {
+          "type": "number"
+        },
+        "inventory": {
+          "type": "number"
+        },
+        "chargeRecurrence": {
+          "$ref": "#/definitions/chargeRecurrence"
         }
       },
-      "then": {
-        "required": ["donationRatio"]
-      }
+      "required": ["name", "itemType", "cost", "currency"],
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "itemType": { "const": "partialDonation" }
+            }
+          },
+          "then": {
+            "required": ["donationRatio"]
+          }
+        }
+      ]
     }
-  ]
+  },
+  "required": ["id", "items"]
 }

--- a/schemas/registrationFields.schema.json
+++ b/schemas/registrationFields.schema.json
@@ -1,0 +1,45 @@
+{
+  "$id": "https://github.com/meetnearme/api/architecture/RegistrationFields.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "properties": {
+      "name": {
+        "type": "string"
+      },
+      "type": {
+        "type": "string",
+        "enum": [
+          "text",
+          "url",
+          "email",
+          "phone",
+          "number",
+          "select",
+          "checkbox",
+          "radio"
+        ]
+      },
+      "options": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "required": {
+        "type": "boolean"
+      },
+      "default": {
+        "type": "string"
+      },
+      "placeholder": {
+        "type": "string"
+      },
+      "description": {
+        "type": "string"
+      }
+    }
+  },
+  "required": ["name", "type"]
+}

--- a/schemas/shared.schema.json
+++ b/schemas/shared.schema.json
@@ -17,6 +17,10 @@
       "type": "string",
       "format": "uuid"
     },
+    "EventOwnerType": {
+      "type": "string",
+      "enum": ["user", "org"]
+    },
     "EventSourceType": {
       "type": "string",
       "enum": ["internalRecurrence", "internalSingle", "seshuJob"]


### PR DESCRIPTION
I'm implementing Marqo, which means we want this data to be fast and light, focusing only on what we want to index on. Fortunately, both `purchasable` and also `registrationFields` are data calls that we can resolve async (either via HTMX on load, or via `templ` http streaming if Lambda API Gateway allows it) so we want to move those out.

Also some adjustments are made based on the following marqo index configuration:

```

{
  "type": "structured",
  "vectorNumericType": "float",
  "model": "hf/bge-large-en-v1.5",
  "normalizeEmbeddings": true,
  "textPreprocessing": {
    "splitLength": 2,
    "splitOverlap": 0,
    "splitMethod": "sentence"
  },
  "imagePreprocessing": {
    "patchMethod": null
  },
  "annParameters": {
    "spaceType": "prenormalized-angular",
    "parameters": {
      "efConstruction": 512,
      "m": 16
    }
  },
  "tensorFields": ["name_description_address"],
  "allFields": [
    {
      "name": "name_description_address",
      "type": "multimodal_combination",
      "dependentFields": {"name": 0.3, "address": 0.2, "description": 0.5}
    },
    {"name": "eventOwners", "type": "text", "features": ["filter", "lexical_search"]},
    {"name": "tags", "type": "text", "features": ["filter", "lexical_search"]},
    {"name": "categories", "type": "text", "features": ["filter", "lexical_search"]}
  ]
}
```