### PR TITLE
Feature/ Home Page Time Filters UI, Start / End Time query facets

### DIFF
--- a/functions/gateway/handlers/data_handlers.go
+++ b/functions/gateway/handlers/data_handlers.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"log"
 	"net/http"
-	"strconv"
 
 	"github.com/go-playground/validator"
 	"github.com/gorilla/mux"
@@ -323,32 +322,17 @@ func UpdateOneEventHandler(w http.ResponseWriter, r *http.Request) http.HandlerF
 }
 
 func (h *MarqoHandler) SearchEvents(w http.ResponseWriter, r *http.Request) {
+    // Extract parameter values from the request query parameters
+    q, userLocation, radius, startTimeUnix, endTimeUnix, _ := GetSearchParamsFromReq(r)
+
     marqoClient, err := services.GetMarqoClient()
     if err != nil {
         transport.SendServerRes(w, []byte("Failed to get marqo client: "+err.Error()), http.StatusInternalServerError, err)
         return
     }
 
-    // NOTE: these defaults are random, we should fix
-    latFloat := float64(38.8951)
-    longFloat := float64(-77.0364)
-    maxDistance := float64(300)
-
-    query := r.URL.Query().Get("q")
-    lat := r.URL.Query().Get("lat")
-    if lat != "" {
-        latFloat, _ = strconv.ParseFloat(lat, 64)
-    }
-    long := r.URL.Query().Get("lon")
-    if long != "" {
-        longFloat, _ = strconv.ParseFloat(long, 64)
-    }
-
-    // TODO: add start time here,
-    // need to convert marqo DB index to unix for `startTime` / `endTime`
-
     var res services.EventSearchResponse
-    res, err = services.SearchMarqoEvents(marqoClient, query, []float64{latFloat, longFloat}, maxDistance, []string{})
+    res, err = services.SearchMarqoEvents(marqoClient, q, userLocation, radius, startTimeUnix, endTimeUnix, []string{})
     if err != nil {
         transport.SendServerRes(w, []byte("Failed to search marqo events: "+err.Error()), http.StatusInternalServerError, err)
         return

--- a/functions/gateway/handlers/data_handlers_test.go
+++ b/functions/gateway/handlers/data_handlers_test.go
@@ -592,8 +592,8 @@ func TestSearchEvents(t *testing.T) {
 			}
 
 			mockService := &services.MockMarqoService{
-				SearchEventsFunc: func(client *marqo.Client, query string, userLocation []float64, maxDistance float64, ownerIds []string) (services.EventSearchResponse, error) {
-                    return services.SearchMarqoEvents(client, query, userLocation, maxDistance, ownerIds)
+				SearchEventsFunc: func(client *marqo.Client, query string, userLocation []float64, maxDistance float64, startTime int64, endTime int64, ownerIds []string) (services.EventSearchResponse, error) {
+                    return services.SearchMarqoEvents(client, query, userLocation, maxDistance, startTime, endTime, ownerIds)
 				},
 			}
 

--- a/functions/gateway/handlers/page_handlers.go
+++ b/functions/gateway/handlers/page_handlers.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"bytes"
 	"fmt"
+	"log"
 	"net/http"
 	"strconv"
 	"strings"
@@ -64,7 +65,7 @@ func ParseStartEndTime(startTimeStr, endTimeStr string) (_startTimeUnix, _endTim
 		endTime, _ = time.Parse(time.RFC3339, endTimeStr)
 	} else if endTimeUnix, err = strconv.ParseInt(endTimeStr, 10, 64); err == nil {
 		endTime = time.Unix(endTimeUnix, 0)
-		endTime = endTime.Add(24 * time.Hour) // Set end time to 24 hours after start time
+	// Set end time to 24 hours after start time
 	// default wrong query string usage to PLUS ONE MONTH for endTime
 	} else {
 		endTime = startTime.AddDate(0,1,0)
@@ -88,6 +89,7 @@ func GetSearchParamsFromReq(r *http.Request) (query string, userLocation []float
 
 	cfLocationLat := services.InitialEmptyLatLong
 	cfLocationLon := services.InitialEmptyLatLong
+
 	if len(cfRay) > 2 {
 		rayCode = cfRay[len(cfRay)-3:]
 		cfLocation = helpers.CfLocationMap[rayCode]
@@ -97,7 +99,7 @@ func GetSearchParamsFromReq(r *http.Request) (query string, userLocation []float
 
 	lat := float64(39.8283)
 	long := float64(-98.5795)
-	radius := float64(2500.0)
+	radius := float64(150.0)
 
 	// Parse parameter values if provided
 	if latStr != "" {
@@ -195,7 +197,8 @@ func GetMapEmbedPage(w http.ResponseWriter, r *http.Request) http.HandlerFunc {
 }
 
 func GetCfRay(r *http.Request) string {
-	if cfRay := r.Header.Get("cf-ray"); cfRay != "" {
+	log.Printf(`r.Header.Get("Cf-Ray"): %+v`,r.Header.Get("Cf-Ray"))
+	if cfRay := r.Header.Get("Cf-Ray"); cfRay != "" {
 		return cfRay
 	}
 	return ""

--- a/functions/gateway/handlers/page_handlers.go
+++ b/functions/gateway/handlers/page_handlers.go
@@ -2,11 +2,10 @@ package handlers
 
 import (
 	"bytes"
-	"context"
 	"fmt"
-	"log"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -18,26 +17,75 @@ import (
 	"github.com/meetnearme/api/functions/gateway/transport"
 )
 
-func GetHomePage(w http.ResponseWriter, r *http.Request) http.HandlerFunc {
-	// Extract parameter values from the request query parameters
-	ctx := r.Context()
-	apiGwV2Req, ok := ctx.Value(helpers.ApiGwV2ReqKey).(events.APIGatewayV2HTTPRequest)
-	if !ok {
-		log.Println("APIGatewayV2HTTPRequest not found in context, creating default")
-		// For testing or non-API gateway envs
-		apiGwV2Req = events.APIGatewayV2HTTPRequest{
-			RequestContext: events.APIGatewayV2HTTPRequestContext{
-				HTTP: events.APIGatewayV2HTTPRequestContextHTTPDescription{
-					Method: r.Method,
-					Path:   r.URL.Path,
-				},
-			},
-		}
+func ParseStartEndTime(startTimeStr, endTimeStr string) (_startTimeUnix, _endTimeUnix int64) {
+	var startTime time.Time
+	var endTime time.Time
+
+	var startTimeUnix int64
+	var endTimeUnix int64
+
+	// NOTE: This assumes the UI home page default is "THIS MONTH" and the absence
+	// of an explicit start_time query param ...
+	if (startTimeStr == "" && endTimeStr == "" )|| strings.ToLower(startTimeStr) == "this_month" {
+		startTime = time.Now()
+		endTime = startTime.AddDate(0,1,0)
+	} else if strings.ToLower(startTimeStr) == "today" {
+		startTime = time.Now()
+		endTime = startTime.AddDate(0,0,1)
+	// NOTE: "tomorrow" is a time-bound concept that should eventually be timezone relative
+	// to the user, this is currently simplistic and is just 24 - 48hrs from the current time
+	} else if strings.ToLower(startTimeStr) == "tomorrow" {
+		startTime = time.Now().AddDate(0,0,1)
+		endTime = startTime.AddDate(0,0,1)
+	} else if strings.ToLower(startTimeStr) == "this_week" {
+		startTime = time.Now()
+		endTime = startTime.AddDate(0,0,7)
 	}
 
-	cfRay := GetCfRay(ctx)
+	// return early if one of the above are found
+	if !startTime.IsZero() && !endTime.IsZero() {
+		return startTime.Unix(), endTime.Unix()
+	}
+
+	// convert startTime either UTC / time.RFC3339 or integer
+	// string (presumed unix) to int64
+	if	_, err := time.Parse(time.RFC3339, startTimeStr); err == nil {
+		startTime, _ = time.Parse(time.RFC3339, startTimeStr)
+	} else if startTimeUnix, err = strconv.ParseInt(startTimeStr, 10, 64); err == nil {
+		startTime = time.Unix(startTimeUnix, 0)
+	// default wrong query string usage to NOW for startTime
+	} else {
+		startTime = time.Now()
+	}
+
+	// convert endTime either UTC / time.RFC3339 or integer
+	// string (presumed unix) to int64
+	if	_, err = time.Parse(time.RFC3339, endTimeStr); err == nil {
+		endTime, _ = time.Parse(time.RFC3339, endTimeStr)
+	} else if endTimeUnix, err = strconv.ParseInt(endTimeStr, 10, 64); err == nil {
+		endTime = time.Unix(endTimeUnix, 0)
+		endTime = endTime.Add(24 * time.Hour) // Set end time to 24 hours after start time
+	// default wrong query string usage to PLUS ONE MONTH for endTime
+	} else {
+		endTime = startTime.AddDate(0,1,0)
+	}
+
+	startTimeUnix = startTime.Unix()
+	endTimeUnix = endTime.Unix()
+
+	return startTimeUnix, endTimeUnix
+}
+
+func GetSearchParamsFromReq(r *http.Request) (query string, userLocation []float64, maxDistance float64, startTime int64, endTime int64, cfLocation helpers.CdnLocation)  {
+	startTimeStr := r.URL.Query().Get("start_time")
+	endTimeStr := r.URL.Query().Get("end_time")
+	latStr := r.URL.Query().Get("lat")
+	longStr := r.URL.Query().Get("lon")
+	radiusStr := r.URL.Query().Get("radius")
+	q := r.URL.Query().Get("q")
+	cfRay := GetCfRay(r)
 	rayCode := ""
-	var cfLocation helpers.CdnLocation
+
 	cfLocationLat := services.InitialEmptyLatLong
 	cfLocationLon := services.InitialEmptyLatLong
 	if len(cfRay) > 2 {
@@ -47,28 +95,11 @@ func GetHomePage(w http.ResponseWriter, r *http.Request) http.HandlerFunc {
 		cfLocationLon = cfLocation.Lon
 	}
 
-	queryParameters := apiGwV2Req.QueryStringParameters
-	startTimeStr := queryParameters["start_time"]
-	endTimeStr := queryParameters["end_time"]
-	latStr := queryParameters["lat"]
-	longStr := queryParameters["lon"]
-	radiusStr := queryParameters["radius"]
-	q := queryParameters["q"]
-
-	// Set default values if query parameters are not provided
-	startTime := time.Now()
-	endTime := startTime.AddDate(100, 0, 0)
 	lat := float64(39.8283)
 	long := float64(-98.5795)
 	radius := float64(2500.0)
 
 	// Parse parameter values if provided
-	if startTimeStr != "" {
-		startTime, _ = time.Parse(time.RFC3339, startTimeStr)
-	}
-	if endTimeStr != "" {
-		endTime, _ = time.Parse(time.RFC3339, endTimeStr)
-	}
 	if latStr != "" {
 		lat64, _ := strconv.ParseFloat(latStr, 32)
 		lat = float64(lat64)
@@ -86,15 +117,20 @@ func GetHomePage(w http.ResponseWriter, r *http.Request) http.HandlerFunc {
 		radius = float64(radius64)
 	}
 
+	startTimeUnix, endTimeUnix := ParseStartEndTime(startTimeStr, endTimeStr)
+
+	return q, []float64{lat, long}, radius, startTimeUnix, endTimeUnix, cfLocation
+}
+
+func GetHomePage(w http.ResponseWriter, r *http.Request) http.HandlerFunc {
+	// Extract parameter values from the request query parameters
+	ctx := r.Context()
+	q, userLocation, radius, startTimeUnix, endTimeUnix, cfLocation := GetSearchParamsFromReq(r)
+
 	marqoClient, err := services.GetMarqoClient()
 	if err != nil {
 		return transport.SendServerRes(w, []byte("Failed to get marqo client: "+err.Error()), http.StatusInternalServerError, err)
 	}
-
-	// startTime, endTime, lat, lon, radius
-	// TODO: Use startTime / endTime in query and remove this log before merging
-	log.Printf("startTime: %v, endTime: %v, lat: %v, long: %v, radius: %v", startTime, endTime, lat, long, radius)
-	userLocation := []float64{lat, long}
 
 	subdomainValue := r.Header.Get("X-Mnm-Subdomain-Value")
 
@@ -103,7 +139,7 @@ func GetHomePage(w http.ResponseWriter, r *http.Request) http.HandlerFunc {
 		ownerIds = append(ownerIds, subdomainValue)
 	}
 
-	res, err := services.SearchMarqoEvents(marqoClient, q, userLocation, radius, ownerIds)
+	res, err := services.SearchMarqoEvents(marqoClient, q, userLocation, radius, startTimeUnix, endTimeUnix, ownerIds)
 	if err != nil {
 		return transport.SendServerRes(w, []byte("Failed to get events via search: "+err.Error()), http.StatusInternalServerError, err)
 	}
@@ -114,7 +150,7 @@ func GetHomePage(w http.ResponseWriter, r *http.Request) http.HandlerFunc {
 	if ctx.Value("userInfo") != nil {
 		userInfo = ctx.Value("userInfo").(helpers.UserInfo)
 	}
-	homePage := pages.HomePage(events, cfLocation, latStr, longStr)
+	homePage := pages.HomePage(events, cfLocation, fmt.Sprint(userLocation[0]), fmt.Sprint(userLocation[1]))
 	layoutTemplate := pages.Layout("Home", userInfo, homePage)
 
 	var buf bytes.Buffer
@@ -158,18 +194,8 @@ func GetMapEmbedPage(w http.ResponseWriter, r *http.Request) http.HandlerFunc {
 	return transport.SendHtmlRes(w, buf.Bytes(), http.StatusOK, nil)
 }
 
-func GetCfRay(c context.Context) string {
-	apiGwV2Req, ok := c.Value(helpers.ApiGwV2ReqKey).(events.APIGatewayV2HTTPRequest)
-	if !ok {
-		log.Println(("APIGatewayV2HTTPRequest not found in context"))
-		return ""
-	}
-	if apiGwV2Req.Headers == nil {
-		log.Println(("Headers not found in APIGatewayV2HTTPRequest"))
-		return ""
-	}
-	if cfRay := apiGwV2Req.Headers["cf-ray"]; cfRay != "" {
-		log.Println(("cf-ray found in APIGatewayV2HTTPRequest: " + fmt.Sprint(cfRay)))
+func GetCfRay(r *http.Request) string {
+	if cfRay := r.Header.Get("cf-ray"); cfRay != "" {
 		return cfRay
 	}
 	return ""

--- a/functions/gateway/handlers/page_handlers_test.go
+++ b/functions/gateway/handlers/page_handlers_test.go
@@ -440,7 +440,7 @@ func TestGetSearchParamsFromReq(t *testing.T) {
 			cfRay:          "",
 			expectedQuery:  "",
 			expectedLoc:    []float64{39.8283, -98.5795},
-			expectedRadius: 150.0,
+			expectedRadius: 2500.0,
 			expectedStart:  0, // This will be the current time in Unix seconds
 			expectedEnd:    0, // This will be one month from now in Unix seconds
 			expectedCfLoc:  helpers.CdnLocation{},
@@ -469,7 +469,7 @@ func TestGetSearchParamsFromReq(t *testing.T) {
 			cfRay:          "",
 			expectedQuery:  "",
 			expectedLoc:    []float64{39.8283, -98.5795},
-			expectedRadius: 150.0,
+			expectedRadius: 2500.0,
 			expectedStart:  0, // This will be the current time in Unix seconds
 			expectedEnd:    0, // This will be 7 days from now in Unix seconds
 			expectedCfLoc:  helpers.CdnLocation{},

--- a/functions/gateway/main.go
+++ b/functions/gateway/main.go
@@ -70,6 +70,7 @@ func init() {
 		// TODO: delete this comment once user location is implemented in profile,
 		// "/api/location/geo" is for use there
 		{"/api/location/geo", "POST", handlers.GeoLookup, None},
+		{"/api/html/events", "GET", handlers.GetEventsPartial, None},
 		{"/api/html/seshu/session/submit", "POST", handlers.SubmitSeshuSession, None},
 		{"/api/html/seshu/session/location", "PATCH", handlers.GeoThenPatchSeshuSession, None},
 		{"/api/html/seshu/session/events", "PATCH", handlers.SubmitSeshuEvents, None},

--- a/functions/gateway/services/marqo_service.go
+++ b/functions/gateway/services/marqo_service.go
@@ -178,14 +178,14 @@ func ConvertEventsToDocuments(events []Event, hasIds bool) (documents []interfac
 			"eventOwners": event.EventOwners,
 			"name":        event.Name,
 			"description": event.Description,
-			"startTime":    event.StartTime,
+			"startTime":    int64(event.StartTime),
 			"address":     event.Address,
 			"lat":    float64(event.Lat),
 			"long":   float64(event.Long),
 		}
 		// because nil and zero (int64 unix timestamp for jan 1, 1970) are conflated we must be careful
 		if event.EndTime != nil {
-			document["endTime"] = event.EndTime
+			document["endTime"] = int64(*event.EndTime)
 		}
 
 		documents = append(documents, document)

--- a/functions/gateway/services/marqo_service.go
+++ b/functions/gateway/services/marqo_service.go
@@ -215,7 +215,7 @@ func BulkUpsertEventToMarqo(client *marqo.Client, events []Event, hasIds bool) (
 // SearchMarqoEvents searches for events based on the given query, user location, and maximum distance.
 // It returns a list of events that match the search criteria.
 // EX : SearchMarqoEvents(client, "music", []float64{37.7749, -122.4194}, 10)
-func SearchMarqoEvents(client *marqo.Client, query string, userLocation []float64, maxDistance float64, ownerIds []string) (EventSearchResponse, error) {
+func SearchMarqoEvents(client *marqo.Client, query string, userLocation []float64, maxDistance float64, startTime, endTime int64, ownerIds []string) (EventSearchResponse, error) {
 	// Calculate the maximum and minimum latitude and longitude based on the user's location and maximum distance
 	maxLat := userLocation[0] + miToLat(maxDistance)
 	maxLong := userLocation[1] + miToLong(maxDistance, userLocation[0])
@@ -228,7 +228,7 @@ func SearchMarqoEvents(client *marqo.Client, query string, userLocation []float6
 	if len(ownerIds) > 0 {
 		ownerFilter = fmt.Sprintf("eventOwners IN (%s) AND ", strings.Join(ownerIds, ","))
 	}
-	filter := fmt.Sprintf("%s long:[* TO %f] AND long:[%f TO *] AND lat:[* TO %f] AND lat:[%f TO *]", ownerFilter, maxLong, minLong, maxLat, minLat)
+	filter := fmt.Sprintf("%s startTime:[%v TO %v] AND long:[* TO %f] AND long:[%f TO *] AND lat:[* TO %f] AND lat:[%f TO *]", ownerFilter, startTime, endTime, maxLong, minLong, maxLat, minLat)
 	indexName := GetMarqoIndexName()
 	searchRequest := marqo.SearchRequest{
 		IndexName:    indexName,

--- a/functions/gateway/services/marqo_service_test.go
+++ b/functions/gateway/services/marqo_service_test.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"os"
 	"testing"
+	"time"
 
 	// marqo-go is an unofficial Go client library for Marqo
 	"github.com/ganeshdipdumbare/marqo-go"
@@ -445,6 +446,8 @@ func TestSearchMarqoEvents(t *testing.T) {
 		query          string
 		userLocation   []float64
 		maxDistance    float64
+		startTime      int64
+		endTime        int64
 		ownerIds       []string
 		expectedEvents int
 		expectedError  bool
@@ -454,6 +457,8 @@ func TestSearchMarqoEvents(t *testing.T) {
 			query:          "test search",
 			userLocation:   []float64{51.5074, -0.1278},
 			maxDistance:    10000,
+			startTime: 			time.Now().Unix(),
+			endTime:        time.Now().AddDate(1,0,0).Unix(),
 			ownerIds:       []string{},
 			expectedEvents: 2,
 			expectedError:  false,
@@ -463,6 +468,8 @@ func TestSearchMarqoEvents(t *testing.T) {
 			query:          "",
 			userLocation:   []float64{51.5074, -0.1278},
 			maxDistance:    10000,
+			startTime: 			time.Now().Unix(),
+			endTime:        time.Now().AddDate(1,0,0).Unix(),
 			ownerIds:       []string{},
 			expectedEvents: 2,
 			expectedError:  false,
@@ -476,7 +483,7 @@ func TestSearchMarqoEvents(t *testing.T) {
 				t.Fatalf("Failed to get Marqo client: %v", err)
 			}
 
-			result, err := SearchMarqoEvents(client, tt.query, tt.userLocation, tt.maxDistance, tt.ownerIds)
+			result, err := SearchMarqoEvents(client, tt.query, tt.userLocation, tt.maxDistance, tt.startTime, tt.endTime, tt.ownerIds)
 
 			if tt.expectedError && err == nil {
 				t.Errorf("Expected an error, but got none")

--- a/functions/gateway/services/marqo_service_types.go
+++ b/functions/gateway/services/marqo_service_types.go
@@ -27,7 +27,7 @@ type MockMarqoService struct {
         client *marqo.Client, event Event) (*marqo.UpsertDocumentsResponse, error)
     BulkUpsertEventToMarqoFunc func(
             client *marqo.Client, events []Event) (*marqo.UpsertDocumentsResponse, error)
-    SearchEventsFunc       func(client *marqo.Client, query string, userLocation []float64, maxDistance float64, ownerIds []string) (EventSearchResponse, error)
+    SearchEventsFunc       func(client *marqo.Client, query string, userLocation []float64, maxDistance float64, startTime int64, endTime int64, ownerIds []string) (EventSearchResponse, error)
     UpdateOneEventFunc     func(client *marqo.Client, eventId string, event Event) (*marqo.UpsertDocumentsResponse, error)
     BulkUpdateEventsFunc   func(client *marqo.Client, events []Event) (*marqo.UpsertDocumentsResponse, error)
 }
@@ -42,8 +42,8 @@ func (m *MockMarqoService) BulkUpsertEventToMarqo(
     return m.BulkUpsertEventToMarqoFunc(client, events)
 }
 
-func (m *MockMarqoService) SearchEvents(client *marqo.Client, query string, userLocation []float64, maxDistance float64, ownerIds []string) (EventSearchResponse, error) {
-	return m.SearchEventsFunc(client, query, userLocation, maxDistance, ownerIds)
+func (m *MockMarqoService) SearchEvents(client *marqo.Client, query string, userLocation []float64, maxDistance float64, startTime int64, endTime int64, ownerIds []string) (EventSearchResponse, error) {
+	return m.SearchEventsFunc(client, query, userLocation, maxDistance, startTime, endTime, ownerIds)
 }
 
 func (m *MockMarqoService) UpdateOneEvent(client *marqo.Client, eventId string, event Event) (*marqo.UpsertDocumentsResponse, error) {

--- a/functions/gateway/templates/pages/home.templ
+++ b/functions/gateway/templates/pages/home.templ
@@ -205,6 +205,37 @@ var cityStateArray = []string{
 
 var cityStateJsonString, err = templ.JSONString(cityStateArray)
 
+templ EventsInner(events []services.Event) {
+	if (len(events) < 1) {
+		<p class="text-md md:text-lg text-center mt-5">
+			No events found, try enabling geolocation or changing your filters like location, date, and time
+		</p>
+	} else {
+		for _, ev := range events {
+			<div class="flex w-full relative">
+				<a class="flex w-full" href={ templ.URL("/events/" + ev.Id) }>
+					<img
+						src={ templ.EscapeString(helpers.GetImgUrlFromHash(ev.Id)) }
+						alt=""
+						class="object-cover w-full aspect-[4/3] md:aspect-[16/9] opacity-30 hover:opacity-75 transition-all"
+					/>
+				</a>
+				<div class="flex flex-col justify-between w-full p-4 md:p-12 bg-gradient-to-t from-black/70 from-80% to-transparent absolute bottom-0 left-0">
+					<div class="mb-2">
+						<h2 class="text-2xl md:text-3xl">{ ev.Name }</h2>
+						<p class="text-sm md:text-base">{ GetDateOrShowNone(ev.StartTime) } | { GetTimeOrShowNone(ev.StartTime) } &commat; { ev.Address }</p>
+					</div>
+					<br/>
+					<a href={ templ.URL("/events/" + ev.Id) } class="btn btn-primary btn-block">
+						LEARN MORE
+						&rarr;
+					</a>
+				</div>
+			</div>
+		}
+	}
+}
+
 func GetCityCountryFromLocation(cfLocation helpers.CdnLocation, latStr string, lonStr string) string {
 	if latStr != "" && lonStr != "" {
 		return "Geocoordinates: " + latStr + ", " + lonStr
@@ -261,44 +292,6 @@ templ HomePage(events []services.Event, cfLocation helpers.CdnLocation, latStr s
 				FILTER <svg class="svg-icon" style="width: 1em; height: 1em;vertical-align: middle;fill: currentColor;overflow: hidden; display: inline-block;" viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg"><path d="M640 288a64 64 0 1 1 0.032-128.032A64 64 0 0 1 640 288z m123.456-96c-14.304-55.04-64-96-123.456-96s-109.152 40.96-123.456 96H128v64h388.544c14.304 55.04 64 96 123.456 96s109.152-40.96 123.456-96H896V192h-132.544zM640 864a64 64 0 1 1 0.032-128.032A64 64 0 0 1 640 864m0-192c-59.456 0-109.152 40.96-123.456 96H128v64h388.544c14.304 55.04 64 96 123.456 96s109.152-40.96 123.456-96H896v-64h-132.544c-14.304-55.04-64-96-123.456-96M384 576a64 64 0 1 1 0.032-128.032A64 64 0 0 1 384 576m0-192c-59.456 0-109.152 40.96-123.456 96H128v64h132.544c14.304 55.04 64 96 123.456 96s109.152-40.96 123.456-96H896v-64H507.456c-14.304-55.04-64-96-123.456-96" fill="#FFFFFF"></path></svg>
 			</button>
 		</header>
-		<script id="alpine-state" data-maps-default-list={ cityStateJsonString }>
-			function getLocationSearchData() {
-				return {
-					allOptions: JSON.parse(
-						document.querySelector('#alpine-state').getAttribute('data-maps-default-list')
-						).map((cityState) => ({
-							label: cityState,
-							value: cityState,
-						})),
-					options: [],
-					isOpen: false,
-					openedWithKeyboard: false,
-					selectedOption: null,
-					setSelectedOption(option) {
-							this.selectedOption = option
-							this.isOpen = false
-							this.openedWithKeyboard = false
-							this.$refs.hiddenTextField.value = option.value
-					},
-					getFilteredOptions(query) {
-							this.options = this.allOptions.filter((option) =>
-									option.label.toLowerCase().includes(query.toLowerCase()),
-							)
-							if (this.options.length === 0) {
-									this.$refs.noResultsMessage.classList.remove('hidden')
-							} else {
-									this.$refs.noResultsMessage.classList.add('hidden')
-							}
-					},
-					handleKeydownOnOptions(event) {
-							// if the user presses backspace or the alpha-numeric keys, focus on the search field
-							if ((event.keyCode >= 65 && event.keyCode <= 90) || (event.keyCode >= 48 && event.keyCode <= 57) || event.keyCode === 8) {
-									this.$refs.searchField.focus()
-							}
-					},
-				}
-			}
-		</script>
 		// Source: https://www.penguinui.com/components/combobox
 		<div x-data="getLocationSearchData()" class="flex w-full max-w-xs flex-col gap-1" x-on:keydown="handleKeydownOnOptions($event)" x-on:keydown.esc.window="isOpen = false, openedWithKeyboard = false" x-init="options = allOptions">
 			<div class="relative px-4">
@@ -372,46 +365,183 @@ templ HomePage(events []services.Event, cfLocation helpers.CdnLocation, latStr s
 				</div>
 			</div>
 		</div>
-		<div class="flex p-4 bg-black">
-			<div class="flex flex-auto space-x-2">
-				<button class="grow px-4 py-2 text-md md:text-xl btn btn-primary">THIS MONTH</button>
-				<button class="grow px-4 py-2 text-md md:text-xl btn hover:text-black hover:bg-gray-500 text-black bg-gray-200">TODAY</button>
-				<button class="grow px-4 py-2 text-md md:text-xl btn hover:text-black hover:bg-gray-500 text-black bg-gray-200">TOMORROW</button>
-				<button class="grow px-4 py-2 text-md md:text-xl btn hover:text-black hover:bg-gray-500 text-black bg-gray-200">THIS WEEK</button>
-			</div>
+		<div x-data="getHomeState()" class="p-4">
+			<form class="flex" novalidate hx-get="/api/html/events" hx-params="*" hx-indicator="#events-container" hx-ext="json-enc" hx-target="#events-container-inner" hx-disabled-elt="button[type='submit']" @submit.prevent="">
+				<input
+					x-model="start_time"
+					name="start_time"
+					id="start_time"
+					type="hidden"
+				/>
+				<input
+					x-model="end_time"
+					name="end_time"
+					id="end_time"
+					type="hidden"
+				/>
+				<input
+					x-model="q"
+					name="q"
+					id="q"
+					type="hidden"
+				/>
+				<input
+					x-model="radius"
+					name="radius"
+					id="radius"
+					type="hidden"
+				/>
+				<input
+					x-model="lat"
+					name="lat"
+					id="lat"
+					type="hidden"
+				/>
+				<input
+					x-model="lon"
+					name="lon"
+					id="lon"
+					type="hidden"
+				/>
+				<div class="flex flex-auto space-x-2">
+					<button
+						type="submit"
+						:class="{
+							'btn-primary': start_time === 'this_month',
+							'hover:text-black hover:bg-gray-500 text-black bg-gray-200': start_time !== 'this_month'
+						}"
+						class="btn grow px-4 py-2 text-md md:text-xl "
+						@click="pushToQueryParams('start_time', 'this_month')"
+					>
+						THIS MONTH
+					</button>
+					<button
+						type="submit"
+						:class="{
+							'btn-primary': start_time === 'today',
+							'hover:text-black hover:bg-gray-500 text-black bg-gray-200': start_time !== 'today'
+						}"
+						class="btn grow px-4 py-2 text-md md:text-xl "
+						@click="pushToQueryParams('start_time', 'today')"
+					>
+						TODAY
+					</button>
+					<button
+						type="submit"
+						:class="{
+							'btn-primary': start_time === 'tomorrow',
+							'hover:text-black hover:bg-gray-500 text-black bg-gray-200': start_time !== 'tomorrow'
+						}"
+						class="btn grow px-4 py-2 text-md md:text-xl "
+						@click="pushToQueryParams('start_time', 'tomorrow')"
+					>
+						TOMORROW
+					</button>
+					<button
+						type="submit"
+						:class="{
+							'btn-primary': start_time === 'this_week',
+							'hover:text-black hover:bg-gray-500 text-black bg-gray-200': start_time !== 'this_week'
+						}"
+						class="btn grow px-4 py-2 text-md md:text-xl "
+						@click="pushToQueryParams('start_time', 'this_week')"
+					>
+						THIS WEEK
+					</button>
+				</div>
+			</form>
 		</div>
-		if (len(events) < 1) {
-			<p class="text-md md:text-lg text-center mt-5">
-				No events found, try enabling geolocation or changing your location, date, or time
-			</p>
-		} else {
-			<main>
-				for _, ev := range events {
-					<div class="flex w-full relative">
-						<a class="flex w-full" href={ templ.URL("/events/" + ev.Id) }>
-							<img
-								src={ templ.EscapeString(helpers.GetImgUrlFromHash(ev.Id)) }
-								alt=""
-								class="object-cover w-full aspect-[4/3] md:aspect-[16/9]"
-								width="400"
-								height="200"
-								style="opacity: 0.3; object-fit: cover;"
-							/>
-						</a>
-						<div class="flex flex-col justify-between w-full p-4 md:p-12 bg-gradient-to-t from-black/70 from-80% to-transparent absolute bottom-0 left-0">
-							<div class="mb-2">
-								<h2 class="text-2xl md:text-3xl">{ ev.Name }</h2>
-								<p class="text-sm md:text-base">{ GetDateOrShowNone(ev.StartTime) } | { GetTimeOrShowNone(ev.StartTime) } &commat; { ev.Address }</p>
-							</div>
-							<br/>
-							<a href={ templ.URL("/events/" + ev.Id) } class="btn btn-primary btn-block">
-								LEARN MORE
-								&rarr;
-							</a>
-						</div>
-					</div>
-				}
-			</main>
-		}
+		<main id="events-container">
+			<div class="htmx-indicator flex flex-wrap items-center justify-center my-4">
+				<span class="loading loading-spinner loading-lg text-primary"></span>
+			</div>
+			<div id="events-container-inner">
+				@EventsInner(events)
+			</div>
+		</main>
 	</div>
+	<script id="alpine-state" data-maps-default-list={ cityStateJsonString }>
+		function getLocationSearchData() {
+			return {
+				allOptions: JSON.parse(
+					document.querySelector('#alpine-state').getAttribute('data-maps-default-list')
+					).map((cityState) => ({
+						label: cityState,
+						value: cityState,
+					})),
+				options: [],
+				isOpen: false,
+				openedWithKeyboard: false,
+				selectedOption: null,
+				setSelectedOption(option) {
+						this.selectedOption = option
+						this.isOpen = false
+						this.openedWithKeyboard = false
+						this.$refs.hiddenTextField.value = option.value
+				},
+				getFilteredOptions(query) {
+						this.options = this.allOptions.filter((option) =>
+								option.label.toLowerCase().includes(query.toLowerCase()),
+						)
+						if (this.options.length === 0) {
+								this.$refs.noResultsMessage.classList.remove('hidden')
+						} else {
+								this.$refs.noResultsMessage.classList.add('hidden')
+						}
+				},
+				handleKeydownOnOptions(event) {
+						// if the user presses backspace or the alpha-numeric keys, focus on the search field
+						if ((event.keyCode >= 65 && event.keyCode <= 90) || (event.keyCode >= 48 && event.keyCode <= 57) || event.keyCode === 8) {
+								this.$refs.searchField.focus()
+						}
+				},
+			}
+		}
+
+		function getHomeState() {
+				const url = new URL(window.location.href);
+				const params = new URLSearchParams(url.search);
+
+				return {
+						start_time: params.get('start_time') ?? 'this_month',
+						end_time: params.get('end_time') ?? '',
+						q: params.get('q') ?? '',
+						radius: params.get('radius') ?? '',
+						lat: params.get('lat') ?? '',
+						lon: params.get('lon') ?? '',
+						allParams: [
+							'start_time',
+							'end_time',
+							'q',
+							'radius',
+							'lat',
+							'lon',
+						],
+						pushToQueryParams(param, selected) {
+								// Get current URL and parse its query parameters
+								const url = new URL(window.location.href);
+								const params = new URLSearchParams(url.search);
+
+								this.allParams.forEach(key => {
+									if ( key !== param && this[key] !== '' && this[key] !== null ) {
+										params.set(key, this[key])
+									}
+								})
+
+								this[param] = selected;
+								params.set(param, selected);
+
+								window.history.pushState({}, '', `${url.pathname}?${params.toString()}`);
+						},
+						updateHasEvents(event) {
+							if (event.detail.successful && document.querySelector('#event-candidates-inner').querySelectorAll('input[type="checkbox"]').length > 0 ){
+								this.hasEvents = true;
+							} else {
+								this.hasEvents = false;
+							}
+							console.log('this.hasEvents', this.hasEvents)
+						},
+			}
+		}
+	</script>
 }

--- a/static/assets/global.css
+++ b/static/assets/global.css
@@ -90,6 +90,10 @@
   display: inherit;
 }
 
+.htmx-request .htmx-indicator.flex {
+  display: flex;
+}
+
 .htmx-show-in-flight {
   display: none;
 }


### PR DESCRIPTION
Introduce faceted serach via Marqo DB layer and query params for both the data API (used by The Regular) and also the home page event listing

* Add UI to browser events "this month" / "today" / "tomorrow" / "this week"
* Standardize / refactor to centralize query param and fallback search param logic decisions. Query capabilities
  * lat / lon
  * radius
  * start / end time (with magic ranges `this_month` / `today` / `tomorrow` / `this_week`
  * `q` (query) ... e.g `?q=organic`
  * `ownerId` (not part of this PR, but added previously, still part of search facets)

## Video demo

https://www.youtube.com/watch?v=jaVUhrWABow


An example URL to play with:
https://devnear.me/?start_time=2024-09-15T18:30:00Z&end_time=2099-02-15T18:30:00Z&start_time=this_month&radius=3200
