### PR TITLE
Added service user middleware for data APIs

### DIFF
--- a/functions/gateway/handlers/partial_handlers.go
+++ b/functions/gateway/handlers/partial_handlers.go
@@ -101,7 +101,6 @@ func GetEventsPartial(w http.ResponseWriter, r *http.Request) http.HandlerFunc {
 		ownerIds = []string{subdomainValue}
 	}
 
-
 	res, err := services.SearchMarqoEvents(marqoClient, q, userLocation, radius, startTimeUnix, endTimeUnix, ownerIds, categories)
 	if err != nil {
 		return transport.SendServerRes(w, []byte("Failed to get events via search: "+err.Error()), http.StatusInternalServerError, err)
@@ -544,17 +543,17 @@ func UpdateUserInterests(w http.ResponseWriter, r *http.Request) http.HandlerFun
 
 	// Flatten and split by "|", then add to the map to remove duplicates
 	for key, values := range categories {
-    if strings.HasSuffix(key, "category") || strings.HasSuffix(key, "subCategory") {
-        for _, value := range values {
-            // Split by comma and trim spaces, in case there are multiple values
-            for _, item := range strings.Split(value, ",") {
-                trimmedItem := strings.TrimSpace(item)
-                if trimmedItem != "" {
-										flattenedCategories =	append(flattenedCategories, trimmedItem)
-                }
-            }
-        }
-    }
+		if strings.HasSuffix(key, "category") || strings.HasSuffix(key, "subCategory") {
+			for _, value := range values {
+				// Split by comma and trim spaces, in case there are multiple values
+				for _, item := range strings.Split(value, ",") {
+					trimmedItem := strings.TrimSpace(item)
+					if trimmedItem != "" {
+						flattenedCategories = append(flattenedCategories, trimmedItem)
+					}
+				}
+			}
+		}
 	}
 
 	flattenedCategoriesString := strings.Join(flattenedCategories, "|")

--- a/functions/gateway/helpers/constants.go
+++ b/functions/gateway/helpers/constants.go
@@ -15,6 +15,8 @@ const MOCK_CLOUDFLARE_URL = "http://localhost:8999"
 const MOCK_ZITADEL_HOST = "localhost:8998"
 const MOCK_MARQO_URL = "http://localhost:8997"
 
+const JWT_ASSERTION_TYPE = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
+
 const PROJECT_ID_ROLE_CLAIMS_KEY = "urn:zitadel:iam:org:project:<project-id>:roles"
 
 type UserInfo struct {
@@ -63,14 +65,15 @@ type SitePage struct {
 }
 
 var SitePages = map[string]SitePage{
-	"home":          {Slug: "home", Name: "Home", SubnavItems: []string{SubnavItems[NvMain],SubnavItems[NvFilters]}},
-	"about":          {Slug: "about", Name: "About", SubnavItems: []string{SubnavItems[NvMain]}},
-	"profile":         {Slug: "admin/profile", Name: "Profile", SubnavItems: []string{SubnavItems[NvMain]}},
+	"home":             {Slug: "home", Name: "Home", SubnavItems: []string{SubnavItems[NvMain], SubnavItems[NvFilters]}},
+	"about":            {Slug: "about", Name: "About", SubnavItems: []string{SubnavItems[NvMain]}},
+	"profile":          {Slug: "admin/profile", Name: "Profile", SubnavItems: []string{SubnavItems[NvMain]}},
 	"add-event-source": {Slug: "admin/add-event-source", Name: "Add Event Source", SubnavItems: []string{SubnavItems[NvMain]}},
-	"settings":      {Slug: "settings", Name: "Settings", SubnavItems: []string{SubnavItems[NvMain]}},
-	"embed":         {Slug: "embed", Name: "Embed", SubnavItems: []string{SubnavItems[NvMain]}},
-	"events": 			 {Slug: "events", Name: "Event Details", SubnavItems: []string{SubnavItems[NvMain],SubnavItems[NvCart]}},
+	"settings":         {Slug: "settings", Name: "Settings", SubnavItems: []string{SubnavItems[NvMain]}},
+	"embed":            {Slug: "embed", Name: "Embed", SubnavItems: []string{SubnavItems[NvMain]}},
+	"events":           {Slug: "events", Name: "Event Details", SubnavItems: []string{SubnavItems[NvMain], SubnavItems[NvCart]}},
 }
+
 type Subcategory struct {
 	Name, Desc, Slug string
 }

--- a/functions/gateway/main.go
+++ b/functions/gateway/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
 	"github.com/awslabs/aws-lambda-go-api-proxy/gorillamux"
+	"github.com/golang-jwt/jwt/v4"
 	"github.com/gorilla/mux"
 	"github.com/zitadel/zitadel-go/v3/pkg/authorization"
 	"github.com/zitadel/zitadel-go/v3/pkg/authorization/oauth"
@@ -25,9 +26,10 @@ import (
 type AuthType string
 
 const (
-	None    AuthType = "none"
-	Check   AuthType = "check"
-	Require AuthType = "require"
+	None               AuthType = "none"
+	Check              AuthType = "check"
+	Require            AuthType = "require"
+	RequireServiceUser AuthType = "require_service_user"
 )
 
 type Route struct {
@@ -60,13 +62,13 @@ func init() {
 		// API routes
 
 		// == START == need to expose these via permanent key for headless clients
-		{"/api/event", "POST", handlers.PostEventHandler, None},
-		{"/api/events", "POST", handlers.PostBatchEventsHandler, None},
-		{"/api/events", "GET", handlers.SearchEventsHandler, None},
-		{"/api/events", "PATCH", handlers.BulkUpdateEventsHandler, None},
-		{"/api/events/{" + helpers.EVENT_ID_KEY + "}", "GET", handlers.GetOneEventHandler, None},
-		{"/api/events/{" + helpers.EVENT_ID_KEY + "}", "PATCH", handlers.UpdateOneEventHandler, None},
-		{"/api/locations", "GET", handlers.SearchLocationsHandler, None},
+		{"/api/event", "POST", handlers.PostEventHandler, RequireServiceUser},
+		{"/api/events", "POST", handlers.PostBatchEventsHandler, RequireServiceUser},
+		{"/api/events", "GET", handlers.SearchEventsHandler, RequireServiceUser},
+		{"/api/events", "PATCH", handlers.BulkUpdateEventsHandler, RequireServiceUser},
+		{"/api/events/{" + helpers.EVENT_ID_KEY + "}", "GET", handlers.GetOneEventHandler, RequireServiceUser},
+		{"/api/events/{" + helpers.EVENT_ID_KEY + "}", "PATCH", handlers.UpdateOneEventHandler, RequireServiceUser},
+		{"/api/locations", "GET", handlers.SearchLocationsHandler, RequireServiceUser},
 		//  == END == need to expose these via permanent key for headless clients
 
 		{"/api/auth/users/set-subdomain", "POST", handlers.SetUserSubdomain, Check},
@@ -81,27 +83,26 @@ func init() {
 
 		// TODO: assign proper require, check authorizations
 		// User routes
-		{"/api/users", "GET", rds_handlers.GetUsersHandler, None},                // Get all users
-		{"/api/users/{id:[0-9a-fA-F-]+}", "GET", rds_handlers.GetUserHandler, None}, // Get a specific user
-		{"/api/users", "POST", rds_handlers.CreateUserHandler, None},           // Create a new user
-		{"/api/users/{id:[0-9a-fA-F-]+}", "PUT", rds_handlers.UpdateUserHandler, None}, // Update an existing user
+		{"/api/users", "GET", rds_handlers.GetUsersHandler, None},                         // Get all users
+		{"/api/users/{id:[0-9a-fA-F-]+}", "GET", rds_handlers.GetUserHandler, None},       // Get a specific user
+		{"/api/users", "POST", rds_handlers.CreateUserHandler, None},                      // Create a new user
+		{"/api/users/{id:[0-9a-fA-F-]+}", "PUT", rds_handlers.UpdateUserHandler, None},    // Update an existing user
 		{"/api/users/{id:[0-9a-fA-F-]+}", "DELETE", rds_handlers.DeleteUserHandler, None}, // Delete a user
-
 
 		// // Purchasables routes
 		{"/api/purchasables/user/{user_id:[0-9a-fA-F-]+}", "GET", rds_handlers.GetPurchasablesHandler, None}, // Get all purchasables
-		{"/api/purchasables/{id:[0-9a-fA-F-]+}", "GET", rds_handlers.GetPurchasableHandler, None}, // Get a specific purchasable
-		{"/api/purchasables", "POST", rds_handlers.CreatePurchasableHandler, None}, // Create a new purchasable
-		{"/api/purchasables/{id:[0-9a-fA-F-]+}", "PUT", rds_handlers.UpdatePurchasableHandler, None}, // Update an existing purchasable
-		{"/api/purchasables/{id:[0-9a-fA-F-]+}", "DELETE", rds_handlers.DeletePurchasableHandler, None}, // Delete a purchasable
+		{"/api/purchasables/{id:[0-9a-fA-F-]+}", "GET", rds_handlers.GetPurchasableHandler, None},            // Get a specific purchasable
+		{"/api/purchasables", "POST", rds_handlers.CreatePurchasableHandler, None},                           // Create a new purchasable
+		{"/api/purchasables/{id:[0-9a-fA-F-]+}", "PUT", rds_handlers.UpdatePurchasableHandler, None},         // Update an existing purchasable
+		{"/api/purchasables/{id:[0-9a-fA-F-]+}", "DELETE", rds_handlers.DeletePurchasableHandler, None},      // Delete a purchasable
 
 		// // Event RSVPs routes
 		{"/api/event-rsvps/event/{event_id:[0-9a-fA-F-]+}", "GET", rds_handlers.GetEventRsvpsByEventIDHandler, None}, // Get all event RSVPs
-		{"/api/event-rsvps/{id:[0-9a-fA-F-]+}", "GET", rds_handlers.GetEventRsvpHandler, None}, // Get a specific event RSVP
-		{"/api/event-rsvps/user/{user_id:[0-9a-fA-F-]+}", "GET", rds_handlers.GetEventRsvpsByUserIDHandler, None}, // Get a specific event RSVP
-		{"/api/event-rsvps", "POST", rds_handlers.CreateEventRsvpHandler, None}, // Create a new event RSVP
-		{"/api/event-rsvps/{id:[0-9a-fA-F-]+}", "PUT", rds_handlers.UpdateEventRsvpHandler, None}, // Update an existing event RSVP
-		{"/api/event-rsvps/{id:[0-9a-fA-F-]+}", "DELETE", rds_handlers.DeleteEventRsvpHandler, None}, // Delete an event RSVP
+		{"/api/event-rsvps/{id:[0-9a-fA-F-]+}", "GET", rds_handlers.GetEventRsvpHandler, None},                       // Get a specific event RSVP
+		{"/api/event-rsvps/user/{user_id:[0-9a-fA-F-]+}", "GET", rds_handlers.GetEventRsvpsByUserIDHandler, None},    // Get a specific event RSVP
+		{"/api/event-rsvps", "POST", rds_handlers.CreateEventRsvpHandler, None},                                      // Create a new event RSVP
+		{"/api/event-rsvps/{id:[0-9a-fA-F-]+}", "PUT", rds_handlers.UpdateEventRsvpHandler, None},                    // Update an existing event RSVP
+		{"/api/event-rsvps/{id:[0-9a-fA-F-]+}", "DELETE", rds_handlers.DeleteEventRsvpHandler, None},                 // Delete an event RSVP
 	}
 }
 
@@ -256,6 +257,59 @@ func (app *App) addRoute(route Route) {
 				ctx = context.WithValue(ctx, "roleClaims", roleClaims)
 			}
 			r = r.WithContext(ctx)
+			route.Handler(w, r).ServeHTTP(w, r)
+		}
+	case RequireServiceUser:
+		handler = func(w http.ResponseWriter, r *http.Request) {
+			accessTokenCookie, err = r.Cookie("access_token")
+			if err != nil {
+				http.Error(w, "Invalid token", http.StatusUnauthorized)
+				return
+			}
+
+			tokenString := accessTokenCookie.Value
+
+			jwks, err := services.FetchJWKS()
+			if err != nil {
+				http.Error(w, "Error fetching JWKS", http.StatusInternalServerError)
+				return
+			}
+
+			token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
+				if _, ok := token.Method.(*jwt.SigningMethodRSA); !ok {
+					return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
+				}
+
+				kid, ok := token.Header["kid"].(string)
+				if !ok {
+					return nil, fmt.Errorf("kid not found in token header")
+				}
+
+				return services.GetPublicKey(jwks, kid)
+			})
+
+			if err != nil || !token.Valid {
+				http.Error(w, "Invalid token", http.StatusUnauthorized)
+				return
+			}
+
+			// Extract claims
+			if claims, ok := token.Claims.(jwt.MapClaims); ok && token.Valid {
+				// Extract roles, metadata, and user information
+				userID := claims["sub"]
+
+				log.Printf("Claims: %v", claims)
+				log.Printf("User ID: %v", userID)
+
+				// Add extracted information to the request context
+				ctx := r.Context()
+				ctx = context.WithValue(ctx, "userID", userID)
+				r = r.WithContext(ctx)
+			} else {
+				http.Error(w, "Invalid token claims", http.StatusUnauthorized)
+				return
+			}
+
 			route.Handler(w, r).ServeHTTP(w, r)
 		}
 	default:

--- a/functions/gateway/services/auth_service.go
+++ b/functions/gateway/services/auth_service.go
@@ -3,6 +3,7 @@ package services
 import (
 	"context"
 	"crypto/rand"
+	"crypto/rsa"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
@@ -11,6 +12,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"math/big"
 	"net/http"
 	"net/url"
 	"os"
@@ -18,21 +20,30 @@ import (
 	"sync"
 	"time"
 
+	"github.com/golang-jwt/jwt/v4"
 	"github.com/meetnearme/api/functions/gateway/helpers"
 	"github.com/zitadel/zitadel-go/v3/pkg/authorization"
 	"github.com/zitadel/zitadel-go/v3/pkg/authorization/oauth"
 	"github.com/zitadel/zitadel-go/v3/pkg/zitadel"
 )
 
+type JWKS struct {
+	Keys []json.RawMessage `json:"keys"`
+}
+
 var (
 	domain        = flag.String("domain", os.Getenv("ZITADEL_INSTANCE_HOST"), "your ZITADEL instance domain (in the form: https://<instance>.zitadel.cloud or https://<yourdomain>)")
 	key           = flag.String("key", os.Getenv("ZITADEL_ENCRYPTION_KEY"), "encryption key")
 	clientID      = flag.String("clientID", os.Getenv("ZITADEL_CLIENT_ID"), "clientID provided by ZITADEL")
 	clientSecret  = flag.String("clientSecret", os.Getenv("ZITADEL_CLIENT_SECRET"), "clientSecret provided by ZITADEL")
+	jwtClientID   = flag.String("jwtClientID", os.Getenv("ZITADEL_JWT_CLIENT_ID"), "Client ID for JWT app for service user auth in ZITADEL")
+	apiPvtKeyID   = flag.String("apiPvtKeyID", os.Getenv("API_PRIVATE_KEY_ID"), "Private key ID for JWT app for service user auth in ZITADEL")
+	apiPvtKey     = flag.String("apiPvtKey", os.Getenv("API_PRIVATE_KEY"), "Private key ID for JWT app for service user auth in ZITADEL")
 	projectID     = flag.String("projectID", os.Getenv("ZITADEL_PROJECT_ID"), "zitadel project ID for MeetNearMe")
 	redirectURI   = flag.String("redirectURI", string(os.Getenv("APEX_URL")+"/auth/callback"), "redirect URI registered with ZITADEL")
 	loginPageURI  = flag.String("loginPageURI", string(os.Getenv("APEX_URL")), "App login page URI")
 	authorizeURI  = flag.String("authorizeURI", string("https://"+os.Getenv("ZITADEL_INSTANCE_HOST")+"/oauth/v2/authorize"), "Zitadel authorizeURL")
+	jwksURI       = flag.String("jwksURI", string("https://"+os.Getenv("ZITADEL_INSTANCE_HOST")+"/oauth/v2/keys"), "Zitadel endpoint to get public keys")
 	tokenURI      = flag.String("tokenURI", string("https://"+os.Getenv("ZITADEL_INSTANCE_HOST")+"/oauth/v2/token"), "Zitadel endpoint to exchange code challenge and verifier for token")
 	endSessionURI = flag.String("endSessionURI", string("https://"+os.Getenv("ZITADEL_INSTANCE_HOST")+"/oidc/v1/end_session"), "Zitadel logout URI")
 	authZ         *authorization.Authorizer[*oauth.IntrospectionContext]
@@ -208,4 +219,62 @@ func clearCookie(w http.ResponseWriter, cookieName string) {
 		HttpOnly: true,
 		Secure:   true,
 	})
+}
+
+func FetchJWKS() (*JWKS, error) {
+	resp, err := http.Get(*jwksURI)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var jwks JWKS
+	if err := json.Unmarshal(body, &jwks); err != nil {
+		return nil, err
+	}
+
+	return &jwks, nil
+}
+
+func GetPublicKey(jwks *JWKS, kid string) (*rsa.PublicKey, error) {
+	for _, key := range jwks.Keys {
+		var k map[string]interface{}
+		if err := json.Unmarshal(key, &k); err != nil {
+			return nil, err
+		}
+
+		if k["kid"] == kid && k["kty"] == "RSA" {
+			nStr, _ := k["n"].(string)
+			eStr, _ := k["e"].(string)
+
+			nBytes, err := jwt.DecodeSegment(nStr)
+			if err != nil {
+				return nil, err
+			}
+
+			eBytes, err := jwt.DecodeSegment(eStr)
+			if err != nil {
+				return nil, err
+			}
+
+			e := 0
+			for _, b := range eBytes {
+				e = e*256 + int(b)
+			}
+
+			pubKey := &rsa.PublicKey{
+				N: new(big.Int).SetBytes(nBytes),
+				E: e,
+			}
+
+			return pubKey, nil
+		}
+	}
+
+	return nil, fmt.Errorf("no matching RSA key found in JWKS")
 }

--- a/go.mod
+++ b/go.mod
@@ -58,6 +58,8 @@ require (
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-playground/validator/v10 v10.22.0 // indirect
 	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
+	github.com/golang-jwt/jwt/v4 v4.5.0 // indirect
+	github.com/golang-jwt/jwt/v5 v5.2.1 // indirect
 	github.com/google/pprof v0.0.0-20240903155634-a8630aee4ab9 // indirect
 	github.com/gorilla/securecookie v1.1.2 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -100,6 +100,10 @@ github.com/go-playground/validator/v10 v10.22.0 h1:k6HsTZ0sTnROkhS//R0O+55JgM8C4
 github.com/go-playground/validator/v10 v10.22.0/go.mod h1:dbuPbCMFw/DrkbEynArYaCwl3amGuJotoKCe95atGMM=
 github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1vB6EwHI=
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
+github.com/golang-jwt/jwt/v4 v4.5.0 h1:7cYmW1XlMY7h7ii7UhUyChSgS5wUJEnm9uZVTGqOWzg=
+github.com/golang-jwt/jwt/v4 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
+github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
+github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=


### PR DESCRIPTION
This PR adds authentication for zitadel service accounts to allow machine to machine access for data APIs

## How to test drive this PR

### Create a service user on Zitadel
Use this guide to create a service user and get private key (key.json) file for the account. The corresponding public key is stored in zitadel: https://zitadel.com/docs/guides/manage/console/users

### Generate a JWT using [zitadel-tools](https://github.com/zitadel/zitadel-tools) and signed access token from the key file
- Install zitadel-tools: Run `go install github.com/zitadel/zitadel-tools@latest`
- Generate a JWT: Run `zitadel-tools key2jwt --audience=https://meet-near-me-production-8baqim.zitadel.cloud --key=key.json`
- Get a signed JWT using the zitadel token endpoint
     - Make a POST request to: `https://meet-near-me-production-8baqim.zitadel.cloud/oauth/v2/token`
     - Set body as `x-www-form-urlencoded`
     - Set `grant_type` to `urn:ietf:params:oauth:grant-type:jwt-bearer`
     - Set `scope` to `openid profile email offline_access address`
     - Set `token` to JWT from previous step
Sample Response:
```
{
    "access_token": "eyJhbGciOiJSUzI1NiIsImtpZCI6IjI4NjI2ODAzOTc4NjEzNTk5MCIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL21lZXQtbmVhci1tZS1wcm9kdWN0aW9uLThiYXFpbS56aXRhZGVsLmNsb3VkIiwic3ViIjoiMjg2MTIyMzQ2ODk1NDMyNzYxIiwiYXVkIjpbIjI4NjEyMjM0Njg5NTQzMjc2MSJdLCJleHAiOjE3MzQ5MDYyNDEsImlhdCI6MTcyNzEzMDI0MSwibmJmIjoxNzI3MTMwMjQxLCJqdGkiOiJWMl8yODYyNzY3NTIzNjIxNzY5NTAtYXRfMjg2Mjc2NzUyMzYyMjQyNDg2In0.W-8aiowGc5lEaplp82TeT4WYburm5pr96ZRwx3t0jZnUVH46owjLCOk0t06YIvpd5leDneDwKfM3OL7JbHqJdXfjGJ2JZjL8dumyddIVodSnx7xKRSWwysSguiUreRDmjdwtUpzdCelAzQ-R4wFp-bxm8POHAH_UBTeFpkAuXYUOpJKZtYJA1ZNg851Up5qclIB90nzJh9DIDfLfC7mczGeBIRApAWLCRD7184DweSDRR_xylvll3JN-DNHCmgGudDR6tVgZnXVbQFQ08koDYdGBtJd0fFycvSRJYn1b-j6GTHKKkN8MdIGetBQ7E_oD9MbCrqbJYQAeCbah-SC8fQ",
    "token_type": "Bearer",
    "expires_in": 7775999,
    "id_token": "eyJhbGciOiJSUzI1NiIsImtpZCI6IjI4NjI2ODAzOTc4NjEzNTk5MCIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL21lZXQtbmVhci1tZS1wcm9kdWN0aW9uLThiYXFpbS56aXRhZGVsLmNsb3VkIiwic3ViIjoiMjg2MTIyMzQ2ODk1NDMyNzYxIiwiYXVkIjpbIjI4NjEyMjM0Njg5NTQzMjc2MSJdLCJleHAiOjE3MjcxMzAyNDEsImlhdCI6MTcyNzEzMDI0MSwiYXV0aF90aW1lIjoxNzI3MTMwMjQxLCJhenAiOiIyODYxMjIzNDY4OTU0MzI3NjEiLCJjbGllbnRfaWQiOiIyODYxMjIzNDY4OTU0MzI3NjEiLCJhdF9oYXNoIjoiVGhCUm8yaE5sOVJkMHVJWlY1VEpVdyJ9.l_JYu5H777-RZOimK9KsDiKfB_4E0tl16_aitAZZjl00djv8LisKOV4pn4pONnPrC8tWG3YOwsP05i9yNlhi7yauDu_tw3TxtzkQGa6oUNDtZSSokBhOsJbU2N6GxvEsrIB_Imc2lmAAV4J2atPmRV0RbFIRw4MdMNvAHCRYpSNMT3QrrCEwEnutSoDNZVlels_fBlFM_iAqs7O8sn2o18w3HBIjetwUHSPwZOKIaDsWC_dbFiInmiQlOShKtlyU3Vb152LhPvb6Yvs15F4XXT2lk9soKrA7QGkwqLDkU5q-3o4kErwfISjT4ltW-g7auq0WIcbvmaskHo-UMdDjIg"
}
```

- Use the access_token to set access_token cookie to make calls to data API

- You can protect data APIs using `RequireServiceUser` auth type when defining routes in main.go