### PR TITLE
Feature: Event Series Pt 2

### DIFF
--- a/functions/gateway/handlers/data_handlers.go
+++ b/functions/gateway/handlers/data_handlers.go
@@ -48,19 +48,21 @@ func NewPurchasableWebhookHandler(purchasableService internal_types.PurchasableS
 
 // Create a new struct for raw JSON operations
 type rawEventData struct {
-	Id             string   `json:"id"`
-	EventOwners    []string `json:"eventOwners" validate:"required,min=1"`
-	EventOwnerName string   `json:"eventOwnerName" validate:"required"`
-	Name           string   `json:"name" validate:"required"`
-	Description    string   `json:"description"`
-	Address        string   `json:"address"`
-	Lat            float64  `json:"lat"`
-	Long           float64  `json:"long"`
-	Timezone       string   `json:"timezone"`
+	Id              string   `json:"id"`
+	EventOwners     []string `json:"eventOwners" validate:"required,min=1"`
+	EventOwnerName  string   `json:"eventOwnerName" validate:"required"`
+	EventSourceType string   `json:"eventSourceType" validate:"required"`
+	Name            string   `json:"name" validate:"required"`
+	Description     string   `json:"description" validate:"required"`
+	Address         string   `json:"address" validate:"required"`
+	Lat             float64  `json:"lat" validate:"required"`
+	Long            float64  `json:"long" validate:"required"`
+	Timezone        string   `json:"timezone" validate:"required"`
 }
 
 type rawEvent struct {
 	rawEventData
+	EventSourceId         *string     `json:"eventSourceId,omitempty"`
 	StartTime             interface{} `json:"startTime" validate:"required"`
 	EndTime               interface{} `json:"endTime,omitempty"`
 	StartingPrice         *int32      `json:"startingPrice,omitempty"`
@@ -79,15 +81,16 @@ type rawEvent struct {
 
 func ConvertRawEventToEvent(raw rawEvent, requireId bool) (types.Event, error) {
 	event := types.Event{
-		Id:             raw.Id,
-		EventOwners:    raw.EventOwners,
-		EventOwnerName: raw.EventOwnerName,
-		Name:           raw.Name,
-		Description:    raw.Description,
-		Address:        raw.Address,
-		Lat:            raw.Lat,
-		Long:           raw.Long,
-		Timezone:       raw.Timezone,
+		Id:              raw.Id,
+		EventOwners:     raw.EventOwners,
+		EventOwnerName:  raw.EventOwnerName,
+		EventSourceType: raw.EventSourceType,
+		Name:            raw.Name,
+		Description:     raw.Description,
+		Address:         raw.Address,
+		Lat:             raw.Lat,
+		Long:            raw.Long,
+		Timezone:        raw.Timezone,
 	}
 
 	// Safely assign pointer values
@@ -127,7 +130,9 @@ func ConvertRawEventToEvent(raw rawEvent, requireId bool) (types.Event, error) {
 	if raw.HideCrossPromo != nil {
 		event.HideCrossPromo = *raw.HideCrossPromo
 	}
-
+	if raw.EventSourceId != nil {
+		event.EventSourceId = *raw.EventSourceId
+	}
 	if raw.StartTime == nil {
 		return types.Event{}, fmt.Errorf("startTime is required")
 	}
@@ -175,14 +180,9 @@ func ValidateSingleEventPaylod(w http.ResponseWriter, r *http.Request, requireId
 		return types.Event{}, http.StatusUnprocessableEntity, fmt.Errorf("invalid JSON payload: %w", err)
 	}
 
-	event, err = ConvertRawEventToEvent(raw, requireId)
+	event, status, err = HandleSingleEventValidation(raw, requireId)
 	if err != nil {
-		return types.Event{}, http.StatusBadRequest, fmt.Errorf("failed to convert raw event: %w", err)
-	}
-
-	err = validate.Struct(&event)
-	if err != nil {
-		return types.Event{}, http.StatusBadRequest, fmt.Errorf("invalid body: %w", err)
+		return types.Event{}, status, fmt.Errorf("invalid body: %w", err)
 	}
 
 	return event, status, nil
@@ -226,6 +226,49 @@ func PostEventHandler(w http.ResponseWriter, r *http.Request) http.HandlerFunc {
 	}
 }
 
+func HandleSingleEventValidation(rawEvent rawEvent, requireId bool) (types.Event, int, error) {
+	if err := validate.Struct(rawEvent); err != nil {
+		// Type assert to get validation errors
+		if validationErrors, ok := err.(validator.ValidationErrors); ok {
+			// Get just the first validation error
+			firstErr := validationErrors[0]
+			// Extract just the field name and error
+			return types.Event{}, http.StatusBadRequest,
+				fmt.Errorf("Field validation for '%s' failed on the '%s' tag",
+					firstErr.Field(), firstErr.Tag())
+		}
+		return types.Event{}, http.StatusBadRequest, err
+	}
+	if requireId && rawEvent.Id == "" {
+		return types.Event{}, http.StatusBadRequest, fmt.Errorf("event has no id")
+	}
+	if len(rawEvent.EventOwners) == 0 {
+		return types.Event{}, http.StatusBadRequest, fmt.Errorf("event is missing eventOwners")
+	}
+	if requireId && rawEvent.Id == "" {
+		return types.Event{}, http.StatusBadRequest, fmt.Errorf("event has no id")
+	}
+	if len(rawEvent.EventOwners) == 0 {
+		return types.Event{}, http.StatusBadRequest, fmt.Errorf("event is missing eventOwners")
+	}
+
+	if rawEvent.EventOwnerName == "" {
+		return types.Event{}, http.StatusBadRequest, fmt.Errorf("event is missing eventOwnerName")
+	}
+
+	if rawEvent.Timezone == "" {
+		return types.Event{}, http.StatusBadRequest, fmt.Errorf("event is missing timezone")
+	}
+	if helpers.ArrFindFirst([]string{rawEvent.EventSourceType}, helpers.ALL_EVENT_SOURCE_TYPES) == "" {
+		return types.Event{}, http.StatusBadRequest, fmt.Errorf("invalid eventSourceType: %s", rawEvent.EventSourceType)
+	}
+	event, err := ConvertRawEventToEvent(rawEvent, requireId)
+	if err != nil {
+		return types.Event{}, http.StatusBadRequest, fmt.Errorf("invalid event : %s", err.Error())
+	}
+	return event, http.StatusOK, nil
+}
+
 func HandleBatchEventValidation(w http.ResponseWriter, r *http.Request, requireIds bool) ([]types.Event, int, error) {
 	var payload struct {
 		Events []rawEvent `json:"events"`
@@ -247,23 +290,9 @@ func HandleBatchEventValidation(w http.ResponseWriter, r *http.Request, requireI
 
 	events := make([]types.Event, len(payload.Events))
 	for i, rawEvent := range payload.Events {
-		if requireIds && rawEvent.Id == "" {
-			return nil, http.StatusBadRequest, fmt.Errorf("invalid body: Event at index %d has no id", i)
-		}
-		if len(rawEvent.EventOwners) == 0 {
-			return nil, http.StatusBadRequest, fmt.Errorf("invalid body: Event at index %d is missing eventOwners", i)
-		}
-
-		if rawEvent.EventOwnerName == "" {
-			return nil, http.StatusBadRequest, fmt.Errorf("invalid body: Event at index %d is missing eventOwnerName", i)
-		}
-
-		if rawEvent.Timezone == "" {
-			return nil, http.StatusBadRequest, fmt.Errorf("invalid body: Event at index %d is missing timezone", i)
-		}
-		event, err := ConvertRawEventToEvent(rawEvent, requireIds)
+		event, statusCode, err := HandleSingleEventValidation(rawEvent, requireIds)
 		if err != nil {
-			return nil, http.StatusBadRequest, fmt.Errorf("invalid event at index %d: %s", i, err.Error())
+			return nil, statusCode, fmt.Errorf("invalid body: invalid event at index %d: %w", i, err)
 		}
 		events[i] = event
 	}
@@ -318,7 +347,7 @@ func (h *MarqoHandler) GetOneEvent(w http.ResponseWriter, r *http.Request) {
 	var event *types.Event
 	event, err = services.GetMarqoEventByID(marqoClient, eventId, parseDates)
 	if err != nil {
-		transport.SendServerRes(w, []byte("Failed to get marqo event: "+err.Error()), http.StatusInternalServerError, err)
+		transport.SendServerRes(w, []byte("Failed to get event: "+err.Error()), http.StatusInternalServerError, err)
 		return
 	}
 
@@ -350,10 +379,9 @@ func (h *MarqoHandler) BulkUpdateEvents(w http.ResponseWriter, r *http.Request) 
 		transport.SendServerRes(w, []byte("Failed to extract event from payload: "+err.Error()), status, err)
 		return
 	}
-
 	res, err := services.BulkUpdateMarqoEventByID(marqoClient, events)
 	if err != nil {
-		transport.SendServerRes(w, []byte("Failed to get marqo event: "+err.Error()), http.StatusInternalServerError, err)
+		transport.SendServerRes(w, []byte("Failed to upsert event: "+err.Error()), http.StatusInternalServerError, err)
 		return
 	}
 
@@ -521,7 +549,7 @@ func (h *MarqoHandler) UpdateOneEvent(w http.ResponseWriter, r *http.Request) {
 
 	res, err := services.BulkUpdateMarqoEventByID(marqoClient, updateEvents)
 	if err != nil {
-		transport.SendServerRes(w, []byte("Failed to get marqo event: "+err.Error()), http.StatusInternalServerError, err)
+		transport.SendServerRes(w, []byte("Failed to upsert event: "+err.Error()), http.StatusInternalServerError, err)
 		return
 	}
 
@@ -543,7 +571,7 @@ func UpdateOneEventHandler(w http.ResponseWriter, r *http.Request) http.HandlerF
 
 func (h *MarqoHandler) SearchEvents(w http.ResponseWriter, r *http.Request) {
 	// Extract parameter values from the request query parameters
-	q, userLocation, radius, startTimeUnix, endTimeUnix, _, ownerIds, categories, address, parseDates := GetSearchParamsFromReq(r)
+	q, userLocation, radius, startTimeUnix, endTimeUnix, _, ownerIds, categories, address, parseDates, eventSourceTypes, eventSourceIds := GetSearchParamsFromReq(r)
 
 	marqoClient, err := services.GetMarqoClient()
 	if err != nil {
@@ -552,9 +580,9 @@ func (h *MarqoHandler) SearchEvents(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var res types.EventSearchResponse
-	res, err = services.SearchMarqoEvents(marqoClient, q, userLocation, radius, startTimeUnix, endTimeUnix, ownerIds, categories, address, parseDates)
+	res, err = services.SearchMarqoEvents(marqoClient, q, userLocation, radius, startTimeUnix, endTimeUnix, ownerIds, categories, address, parseDates, eventSourceTypes, eventSourceIds)
 	if err != nil {
-		transport.SendServerRes(w, []byte("Failed to search marqo events: "+err.Error()), http.StatusInternalServerError, err)
+		transport.SendServerRes(w, []byte("Failed to search events: "+err.Error()), http.StatusInternalServerError, err)
 		return
 	}
 	json, err := json.Marshal(res)

--- a/functions/gateway/handlers/data_handlers_test.go
+++ b/functions/gateway/handlers/data_handlers_test.go
@@ -1893,7 +1893,7 @@ func TestSearchUsersHandler(t *testing.T) {
 				}
 			} else {
 				// For error responses, compare strings directly
-				if gotBody != tt.expectedBody {
+				if !strings.Contains(gotBody, tt.expectedBody) {
 					t.Errorf("expected body %q, got %q", tt.expectedBody, gotBody)
 				}
 			}

--- a/functions/gateway/handlers/data_handlers_test.go
+++ b/functions/gateway/handlers/data_handlers_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gorilla/mux"
 	internal_types "github.com/meetnearme/api/functions/gateway/types"
 
 	"github.com/aws/aws-lambda-go/events"
@@ -67,6 +68,7 @@ func TestPostEvent(t *testing.T) {
 		// library implements `WithMarqoCloudAuth` as an option expected in our
 		// implementation, so omitting the auth header will result a lib failure
 		if authHeader == "" {
+			http.Error(w, "Unauthorized, missing x-api-key header", http.StatusUnauthorized)
 			return
 		}
 
@@ -114,7 +116,7 @@ func TestPostEvent(t *testing.T) {
 	}{
 		{
 			name:        "Valid event",
-			requestBody: `{"eventOwnerName": "Event Owner", "eventOwners":["123"],"name":"Test Event","description":"A test event","startTime":"2099-05-01T12:00:00Z","address":"123 Test St","lat":51.5074,"long":-0.1278,"timezone":"America/New_York"}`,
+			requestBody: `{"eventOwnerName": "Event Owner", "eventOwners":["123"],"eventSourceType":"SLF","name":"Test Event","description":"A test event","startTime":"2099-05-01T12:00:00Z","address":"123 Test St","lat":51.5074,"long":-0.1278,"timezone":"America/New_York"}`,
 			mockUpsertFunc: func(client *marqo.Client, events []types.Event) (*marqo.UpsertDocumentsResponse, error) {
 				res, err := services.BulkUpsertEventToMarqo(client, events, false)
 				if err != nil {
@@ -153,7 +155,7 @@ func TestPostEvent(t *testing.T) {
 		{
 			name:                    "Valid payload, missing auth header",
 			expectMissingAuthHeader: true,
-			requestBody:             `{ "eventOwnerName": "Event Owner", "eventOwners":["123"],"name":"Test Event","description":"A test event","startTime":"2099-05-01T12:00:00Z","address":"123 Test St","lat":51.5074,"long":-0.1278,"timezone":"America/New_York"}`,
+			requestBody:             `{ "eventOwnerName": "Event Owner", "eventOwners":["123"],"eventSourceType":"SLF","name":"Test Event","description":"A test event","startTime":"2099-05-01T12:00:00Z","address":"123 Test St","lat":51.5074,"long":-0.1278,"timezone":"America/New_York"}`,
 			mockUpsertFunc: func(client *marqo.Client, events []types.Event) (*marqo.UpsertDocumentsResponse, error) {
 				res, err := services.BulkUpsertEventToMarqo(client, events, false)
 				if err != nil {
@@ -183,19 +185,19 @@ func TestPostEvent(t *testing.T) {
 		},
 		{
 			name:           "Missing start time field",
-			requestBody:    `{"description":"A test event", "eventOwnerName": "Event Owner",  "eventOwners":["123"],"lat":51.5074,"long":-0.1278,"timezone":"America/New_York"}`,
+			requestBody:    `{"description":"A test event", "eventOwnerName": "Event Owner",  "eventOwners":["123"],"name":"Test Event","eventSourceType":"SLF","address":"123 Test St","lat":51.5074,"long":-0.1278,"timezone":"America/New_York"}`,
 			mockUpsertFunc: nil,
 			expectedStatus: http.StatusBadRequest,
 			expectedBodyCheck: func(body string) error {
-				if !strings.Contains(body, "startTime is required") {
-					return fmt.Errorf("expected 'startTime is required', got '%s'", body)
+				if !strings.Contains(body, "Field validation for 'StartTime' failed on the 'required' tag") {
+					return fmt.Errorf("expected 'Field validation for 'StartTime' failed on the 'required' tag', got '%s'", body)
 				}
 				return nil
 			},
 		},
 		{
 			name:           "Missing name field",
-			requestBody:    `{"eventOwnerName": "Event Owner", "eventOwners":["123"],"startTime":"2099-05-01T12:00:00Z","description":"A test event","lat":51.5074,"long":-0.1278,"timezone":"America/New_York"}`,
+			requestBody:    `{"eventOwnerName": "Event Owner", "eventOwners":["123"],"eventSourceType":"SLF","startTime":"2099-05-01T12:00:00Z","description":"A test event","lat":51.5074,"long":-0.1278,"timezone":"America/New_York"}`,
 			mockUpsertFunc: nil,
 			expectedStatus: http.StatusBadRequest,
 			expectedBodyCheck: func(body string) error {
@@ -207,7 +209,7 @@ func TestPostEvent(t *testing.T) {
 		},
 		{
 			name:           "Missing eventOwners field",
-			requestBody:    `{"eventOwnerName":"Event Owner","name":"Test Event","description":"A test event","startTime":"2099-05-01T12:00:00Z","address":"123 Test St","lat":51.5074,"long":-0.1278,"timezone":"America/New_York"}`,
+			requestBody:    `{"eventOwnerName":"Event Owner","eventSourceType":"SLF","name":"Test Event","description":"A test event","startTime":"2099-05-01T12:00:00Z","address":"123 Test St","lat":51.5074,"long":-0.1278,"timezone":"America/New_York"}`,
 			mockUpsertFunc: nil,
 			expectedStatus: http.StatusBadRequest,
 			expectedBodyCheck: func(body string) error {
@@ -231,7 +233,7 @@ func TestPostEvent(t *testing.T) {
 		},
 		{
 			name:           "Missing timezone field",
-			requestBody:    `{"eventOwnerName":"Event Owner","eventOwners":["123"], "name":"Test Event","description":"A test event","startTime":"2099-05-01T12:00:00Z","address":"123 Test St","lat":51.5074,"long":-0.1278}`,
+			requestBody:    `{"eventOwnerName":"Event Owner","eventOwners":["123"], "eventSourceType":"SLF","name":"Test Event","description":"A test event","startTime":"2099-05-01T12:00:00Z","address":"123 Test St","lat":51.5074,"long":-0.1278}`,
 			mockUpsertFunc: nil,
 			expectedStatus: http.StatusBadRequest,
 			expectedBodyCheck: func(body string) error {
@@ -381,7 +383,7 @@ func TestPostBatchEvents(t *testing.T) {
 	}{
 		{
 			name:        "Valid events",
-			requestBody: `{"events":[ {"eventOwnerName": "Event Owner 1", "eventOwners":["123"],"name":"Test Event","description":"A test event","startTime":"2099-05-01T12:00:00Z","address":"123 Test St","lat":51.5074,"long":-0.1278,"timezone":"America/New_York"}, { "eventOwnerName": "Event Owner 2", "eventOwners":["456"],"name":"Another Test Event","description":"Another test event","startTime":"2099-05-02T12:00:00Z","address":"456 Test St","lat":51.5075,"long":-0.1279,"timezone":"America/New_York"}]}`,
+			requestBody: `{"events":[ {"eventOwnerName": "Event Owner 1", "eventOwners":["123"],"eventSourceType":"SLF","name":"Test Event","description":"A test event","startTime":"2099-05-01T12:00:00Z","address":"123 Test St","lat":51.5074,"long":-0.1278,"timezone":"America/New_York"}, { "eventOwnerName": "Event Owner 2", "eventOwners":["456"],"eventSourceType":"SLF","name":"Another Test Event","description":"Another test event","startTime":"2099-05-02T12:00:00Z","address":"456 Test St","lat":51.5075,"long":-0.1279,"timezone":"America/New_York"}]}`,
 			mockUpsertFunc: func(client *marqo.Client, events []types.Event) (*marqo.UpsertDocumentsResponse, error) {
 				res, err := services.BulkUpsertEventToMarqo(client, events, false)
 				if err != nil {
@@ -420,7 +422,7 @@ func TestPostBatchEvents(t *testing.T) {
 		{
 			name:                    "Valid payload, missing auth header",
 			expectMissingAuthHeader: true,
-			requestBody:             `{"events":[ {"eventOwnerName": "Event Owner 1", "eventOwners":["123"],"name":"Test Event","description":"A test event","startTime":"2099-05-01T12:00:00Z","address":"123 Test St","lat":51.5074,"long":-0.1278,"timezone":"America/New_York"},{ "eventOwnerName": "Event Owner 2", "eventOwners":["456"],"name":"Another Test Event","description":"Another test event","startTime":"2099-05-02T12:00:00Z","address":"456 Test St","lat":51.5075,"long":-0.1279,"timezone":"America/New_York"}]}`,
+			requestBody:             `{"events":[ {"eventOwnerName": "Event Owner 1", "eventOwners":["123"],"eventSourceType":"SLF","name":"Test Event","description":"A test event","startTime":"2099-05-01T12:00:00Z","address":"123 Test St","lat":51.5074,"long":-0.1278,"timezone":"America/New_York"},{ "eventOwnerName": "Event Owner 2", "eventOwners":["456"],"eventSourceType":"SLF","name":"Another Test Event","description":"Another test event","startTime":"2099-05-02T12:00:00Z","address":"456 Test St","lat":51.5075,"long":-0.1279,"timezone":"America/New_York"}]}`,
 			mockUpsertFunc: func(client *marqo.Client, events []types.Event) (*marqo.UpsertDocumentsResponse, error) {
 				res, err := services.BulkUpsertEventToMarqo(client, events, false)
 				if err != nil {
@@ -454,8 +456,8 @@ func TestPostBatchEvents(t *testing.T) {
 			mockUpsertFunc: nil,
 			expectedStatus: http.StatusBadRequest,
 			expectedBodyCheck: func(body string) error {
-				if !strings.Contains(body, "Event at index 0 is missing eventOwners") {
-					return fmt.Errorf("expected 'Event at index 0 is missing eventOwners, got '%s'", body)
+				if !strings.Contains(body, "invalid event at index 0: Field validation for 'EventOwners' failed on the 'required' tag") {
+					return fmt.Errorf("expected 'invalid event at index 0: Field validation for 'EventOwners' failed on the 'required' tag, got '%s'", body)
 				}
 				return nil
 			},
@@ -633,7 +635,7 @@ func TestSearchEvents(t *testing.T) {
 
 			mockService := &services.MockMarqoService{
 				SearchEventsFunc: func(client *marqo.Client, query string, userLocation []float64, maxDistance float64, startTime int64, endTime int64, ownerIds []string) (types.EventSearchResponse, error) {
-					return services.SearchMarqoEvents(client, query, userLocation, maxDistance, startTime, endTime, ownerIds, string(""), string(""), "0")
+					return services.SearchMarqoEvents(client, query, userLocation, maxDistance, startTime, endTime, ownerIds, string(""), string(""), "0", []string{helpers.DEFAULT_SEARCHABLE_EVENT_SOURCE_TYPES[0]}, []string{})
 				},
 			}
 
@@ -750,23 +752,23 @@ func TestBulkUpdateEvents(t *testing.T) {
 	}{
 		{
 			name:                    "Invalid payload (missing ID in one event)",
-			payload:                 `{"events":[{"id":"abc", "eventOwnerName": "Event Owner 1", "eventOwners":["123"],"name":"DC Bocce Ball Semifinals","description":"DC Bocce event description","startTime":"2099-02-15T18:30:00Z","address":"National Mall, Washington, DC","lat":38.8951,"long":-77.0364,"timezone":"America/New_York"}, {"eventOwnerName": "Event Owner 2", "eventOwners":["456"],"name":"New York City Marathon","description":"NYC Marathon event description","startTime":"2099-11-02T08:00:00Z","address":"Fort Wadsworth, Staten Island, NY","lat":40.6075,"long":-74.0544,"timezone":"America/New_York"}]}`,
+			payload:                 `{"events":[{"id":"abc", "eventOwnerName": "Event Owner 1", "eventOwners":["123"],"eventSourceType":"SLF","name":"DC Bocce Ball Semifinals","description":"DC Bocce event description","startTime":"2099-02-15T18:30:00Z","address":"National Mall, Washington, DC","lat":38.8951,"long":-77.0364,"timezone":"America/New_York"}, {"eventOwnerName": "Event Owner 2", "eventOwners":["456"],"eventSourceType":"SLF","name":"New York City Marathon","description":"NYC Marathon event description","startTime":"2099-11-02T08:00:00Z","address":"Fort Wadsworth, Staten Island, NY","lat":40.6075,"long":-74.0544,"timezone":"America/New_York"}]}`,
 			expectedStatus:          http.StatusBadRequest,
-			expectedBody:            `Failed to extract event from payload: invalid body: Event at index 1 has no id`,
+			expectedBody:            `invalid event at index 1: event has no id`,
 			expectMissingAuthHeader: false,
 			mockUpsertFunc:          nil,
 		},
 		{
 			name:                    "Valid payload, missing auth header",
-			payload:                 `{"events":[{"id":"abc", "eventOwnerName": "Event Owner 1", "eventOwners":["123"],"name":"DC Bocce Ball Semifinals","description":"DC Bocce event description","startTime":"2099-02-15T18:30:00Z","address":"National Mall, Washington, DC","lat":38.8951,"long":-77.0364,"timezone":"America/New_York"},{"id":"xyz", "eventOwnerName": "Event Owner 2", "eventOwners":["456"],"name":"New York City Marathon","description":"NYC Marathon event description","startTime":"2099-11-02T08:00:00Z","address":"Fort Wadsworth, Staten Island, NY","lat":40.6075,"long":-74.0544,"timezone":"America/New_York"}]}`,
+			payload:                 `{"events":[{"id":"abc", "eventOwnerName": "Event Owner 1", "eventOwners":["123"],"eventSourceType":"SLF","name":"DC Bocce Ball Semifinals","description":"DC Bocce event description","startTime":"2099-02-15T18:30:00Z","address":"National Mall, Washington, DC","lat":38.8951,"long":-77.0364,"timezone":"America/New_York"},{"id":"xyz", "eventOwnerName": "Event Owner 2", "eventOwners":["456"],"eventSourceType":"SLF","name":"New York City Marathon","description":"NYC Marathon event description","startTime":"2099-11-02T08:00:00Z","address":"Fort Wadsworth, Staten Island, NY","lat":40.6075,"long":-74.0544,"timezone":"America/New_York"}]}`,
 			expectedStatus:          http.StatusInternalServerError,
-			expectedBody:            `Failed to get marqo event: error upserting documents: status code: 401`,
+			expectedBody:            `Failed to upsert event: error upserting documents: status code: 401`,
 			expectMissingAuthHeader: true,
 			mockUpsertFunc:          nil,
 		},
 		{
 			name:                    "Valid payload",
-			payload:                 `{"events":[{"id":"abc", "eventOwnerName": "Event Owner 1", "eventOwners":["123"], "name":"DC Bocce Ball Semifinals","description":"DC Bocce event description","startTime":"2099-02-15T18:30:00Z","address":"National Mall, Washington, DC","lat":38.8951,"long":-77.0364,"timezone":"America/New_York"},{"id":"xyz", "eventOwnerName": "Event Owner 2", "eventOwners":["456"],"name":"New York City Marathon","description":"NYC Marathon event description","startTime":"2099-11-02T08:00:00Z","address":"Fort Wadsworth, Staten Island, NY","lat":40.6075,"long":-74.0544,"timezone":"America/New_York"}]}`,
+			payload:                 `{"events":[{"id":"abc", "eventOwnerName": "Event Owner 1", "eventOwners":["123"], "eventSourceType":"SLF","name":"DC Bocce Ball Semifinals","description":"DC Bocce event description","startTime":"2099-02-15T18:30:00Z","address":"National Mall, Washington, DC","lat":38.8951,"long":-77.0364,"timezone":"America/New_York"},{"id":"xyz", "eventOwnerName": "Event Owner 2", "eventOwners":["456"],"eventSourceType":"SLF","name":"New York City Marathon","description":"NYC Marathon event description","startTime":"2099-11-02T08:00:00Z","address":"Fort Wadsworth, Staten Island, NY","lat":40.6075,"long":-74.0544,"timezone":"America/New_York"}]}`,
 			expectedStatus:          http.StatusOK,
 			expectedBody:            `"errors":false`,
 			expectMissingAuthHeader: false,
@@ -845,6 +847,7 @@ func TestUpdateOneEvent(t *testing.T) {
 		// library implements `WithMarqoCloudAuth` as an option expected in our
 		// implementation, so omitting the auth header will result a lib failure
 		if authHeader == "" {
+			http.Error(w, "Unauthorized, missing x-api-key header", http.StatusUnauthorized)
 			return
 		}
 
@@ -892,17 +895,11 @@ func TestUpdateOneEvent(t *testing.T) {
 		expectMissingAuthHeader bool
 	}{
 		{
-			name:        "Valid event",
-			apiPath:     `/test-id`,
-			requestBody: `{ "eventOwnerName": "Event Owner", "eventOwners":["123"],"name":"Test Event","description":"A test event","startTime":"2099-05-01T12:00:00Z","address":"123 Test St","lat":51.5074,"long":-0.1278,"timezone":"America/New_York"}`,
-			mockUpsertFunc: func(client *marqo.Client, events []types.Event) (*marqo.UpsertDocumentsResponse, error) {
-				res, err := services.BulkUpsertEventToMarqo(client, events, false)
-				if err != nil {
-					log.Printf("mocked request to upsert event failed: %v", err)
-				}
-				return &marqo.UpsertDocumentsResponse{}, fmt.Errorf("mocked request to upsert event res: %v", res)
-			},
-			expectedStatus: http.StatusCreated,
+			name:           "Valid event",
+			apiPath:        `/test-id`,
+			requestBody:    `{ "id":"abc-789", "eventOwnerName": "Event Owner", "eventOwners":["123"],"eventSourceType":"SLF","name":"Test Event","description":"A test event","startTime":"2099-05-01T12:00:00Z","address":"123 Test St","lat":51.5074,"long":-0.1278,"timezone":"America/New_York"}`,
+			mockUpsertFunc: nil,
+			expectedStatus: http.StatusOK,
 			expectedBodyCheck: func(body string) error {
 				var response map[string]interface{}
 				if err := json.Unmarshal([]byte(body), &response); err != nil {
@@ -934,17 +931,11 @@ func TestUpdateOneEvent(t *testing.T) {
 			name:                    "Valid payload, missing event path parameter",
 			apiPath:                 `/`,
 			expectMissingAuthHeader: true,
-			requestBody:             `{"eventOwnerName": "Event Owner", "eventOwners":["123"],"name":"Test Event","description":"A test event","startTime":"2099-05-01T12:00:00Z","address":"123 Test St","lat":51.5074,"long":-0.1278,"timezone":"America/New_York"}`,
-			mockUpsertFunc: func(client *marqo.Client, events []types.Event) (*marqo.UpsertDocumentsResponse, error) {
-				res, err := services.BulkUpsertEventToMarqo(client, events, false)
-				if err != nil {
-					log.Printf("mocked request to upsert event failed: %v", err)
-				}
-				return res, nil
-			},
-			expectedStatus: http.StatusInternalServerError,
+			requestBody:             `{ "id":"abc-789", "eventOwnerName": "Event Owner", "eventOwners":["123"],"eventSourceType":"SLF","name":"Test Event","description":"A test event","startTime":"2099-05-01T12:00:00Z","address":"123 Test St","lat":51.5074,"long":-0.1278,"timezone":"America/New_York"}`,
+			mockUpsertFunc:          nil,
+			expectedStatus:          http.StatusInternalServerError,
 			expectedBodyCheck: func(body string) error {
-				if strings.Contains(body, "ERR: Failed to upsert event") {
+				if strings.Contains(body, "ERR: Event must have an id") {
 					return nil
 				}
 				return fmt.Errorf("Expected error message, but none present")
@@ -954,15 +945,9 @@ func TestUpdateOneEvent(t *testing.T) {
 			name:                    "Valid payload, missing auth header",
 			apiPath:                 `/test-id`,
 			expectMissingAuthHeader: true,
-			requestBody:             `{ "eventOwnerName": "Event Owner", "eventOwners":["123"],"name":"Test Event","description":"A test event","startTime":"2099-05-01T12:00:00Z","address":"123 Test St","lat":51.5074,"long":-0.1278,"timezone":"America/New_York"}`,
-			mockUpsertFunc: func(client *marqo.Client, events []types.Event) (*marqo.UpsertDocumentsResponse, error) {
-				res, err := services.BulkUpsertEventToMarqo(client, events, false)
-				if err != nil {
-					log.Printf("mocked request to upsert event failed: %v", err)
-				}
-				return res, nil
-			},
-			expectedStatus: http.StatusInternalServerError,
+			requestBody:             `{ "id":"abc-789", "eventOwnerName": "Event Owner", "eventOwners":["123"],"eventSourceType":"SLF","name":"Test Event","description":"A test event","startTime":"2099-05-01T12:00:00Z","address":"123 Test St","lat":51.5074,"long":-0.1278,"timezone":"America/New_York"}`,
+			mockUpsertFunc:          nil,
+			expectedStatus:          http.StatusInternalServerError,
 			expectedBodyCheck: func(body string) error {
 				if strings.Contains(body, "ERR: Failed to upsert event") {
 					return nil
@@ -984,14 +969,27 @@ func TestUpdateOneEvent(t *testing.T) {
 			},
 		},
 		{
+			name:           "Missing id in api path",
+			apiPath:        ``,
+			requestBody:    `{"eventOwnerName": "Event Owner",  "eventOwners":["123"],"eventSourceType":"SLF","name":"Test Event","description":"A test event", "startTime":"2099-05-01T12:00:00Z","address":"123 Test St","lat":51.5074,"long":-0.1278,"timezone":"America/New_York"}`,
+			mockUpsertFunc: nil,
+			expectedStatus: http.StatusInternalServerError,
+			expectedBodyCheck: func(body string) error {
+				if !strings.Contains(body, "Event must have an id") {
+					return fmt.Errorf("expected 'Event must have an id', got '%s'", body)
+				}
+				return nil
+			},
+		},
+		{
 			name:           "Missing start time field",
 			apiPath:        `/test-id`,
-			requestBody:    `{"description":"A test event", "eventOwnerName": "Event Owner",  "eventOwners":["123"],"lat":51.5074,"long":-0.1278,"timezone":"America/New_York"}`,
+			requestBody:    `{"id":"abc-789","eventOwnerName": "Event Owner",  "eventOwners":["123"],"eventSourceType":"SLF","name":"Test Event","description":"A test event", "address":"123 Test St","lat":51.5074,"long":-0.1278,"timezone":"America/New_York"}`,
 			mockUpsertFunc: nil,
 			expectedStatus: http.StatusBadRequest,
 			expectedBodyCheck: func(body string) error {
-				if !strings.Contains(body, "startTime is required") {
-					return fmt.Errorf("expected 'startTime is required', got '%s'", body)
+				if !strings.Contains(body, "invalid body: Field validation for 'StartTime' failed on the 'required' tag") {
+					return fmt.Errorf("expected 'invalid body: Field validation for 'StartTime' failed on the 'required' tag', got '%s'", body)
 				}
 				return nil
 			},
@@ -999,7 +997,7 @@ func TestUpdateOneEvent(t *testing.T) {
 		{
 			name:           "Missing name field",
 			apiPath:        `/test-id`,
-			requestBody:    `{ "eventOwnerName": "Event Owner", "eventOwners":["123"],"startTime":"2099-05-01T12:00:00Z","description":"A test event","lat":51.5074,"long":-0.1278,"timezone":"America/New_York"}`,
+			requestBody:    `{ "id":"abc-789","eventOwnerName": "Event Owner", "eventOwners":["123"],"eventSourceType":"SLF","startTime":"2099-05-01T12:00:00Z","description":"A test event","lat":51.5074,"long":-0.1278,"timezone":"America/New_York"}`,
 			mockUpsertFunc: nil,
 			expectedStatus: http.StatusBadRequest,
 			expectedBodyCheck: func(body string) error {
@@ -1012,7 +1010,7 @@ func TestUpdateOneEvent(t *testing.T) {
 		{
 			name:           "Missing eventOwners field",
 			apiPath:        `/test-id`,
-			requestBody:    `{ "eventOwnerName": "Event Owner", "name":"Test Event","description":"A test event","startTime":"2099-05-01T12:00:00Z","address":"123 Test St","lat":51.5074,"long":-0.1278,"timezone":"America/New_York"}`,
+			requestBody:    `{ "id":"abc-789","eventOwnerName": "Event Owner","eventSourceType":"SLF","name":"Test Event","description":"A test event","startTime":"2099-05-01T12:00:00Z","address":"123 Test St","lat":51.5074,"long":-0.1278,"timezone":"America/New_York"}`,
 			mockUpsertFunc: nil,
 			expectedStatus: http.StatusBadRequest,
 			expectedBodyCheck: func(body string) error {
@@ -1025,7 +1023,7 @@ func TestUpdateOneEvent(t *testing.T) {
 		{
 			name:           "Missing eventOwnerName field",
 			apiPath:        `/test-id`,
-			requestBody:    `{ "eventOwners": ["123"], "name":"Test Event","description":"A test event","startTime":"2099-05-01T12:00:00Z","address":"123 Test St","lat":51.5074,"long":-0.1278,"timezone":"America/New_York"}`,
+			requestBody:    `{ "id":"abc-789", "eventOwners": ["123"], "eventSourceType":"SLF","name":"Test Event","description":"A test event","startTime":"2099-05-01T12:00:00Z","address":"123 Test St","lat":51.5074,"long":-0.1278,"timezone":"America/New_York"}`,
 			mockUpsertFunc: nil,
 			expectedStatus: http.StatusBadRequest,
 			expectedBodyCheck: func(body string) error {
@@ -1038,12 +1036,38 @@ func TestUpdateOneEvent(t *testing.T) {
 		{
 			name:           "Missing timezone field",
 			apiPath:        `/test-id`,
-			requestBody:    `{ "eventOwners": ["123"], "name":"Test Event","name":"Test Event","description":"A test event","startTime":"2099-05-01T12:00:00Z","address":"123 Test St","lat":51.5074,"long":-0.1278}`,
+			requestBody:    `{ "id":"abc-789", "eventOwners": ["123"], "eventOwnerName":"Event Owner","eventSourceType":"SLF","name":"Test Event","description":"A test event","startTime":"2099-05-01T12:00:00Z","address":"123 Test St","lat":51.5074,"long":-0.1278}`,
 			mockUpsertFunc: nil,
 			expectedStatus: http.StatusBadRequest,
 			expectedBodyCheck: func(body string) error {
 				if !strings.Contains(body, `Field validation for 'Timezone' failed on the 'required' tag`) {
 					return fmt.Errorf("expected `Field validation for 'Timezone' failed on the 'required' tag`, got '%s'", body)
+				}
+				return nil
+			},
+		},
+		{
+			name:           "Missing eventSourceType field",
+			apiPath:        `/abc-789`,
+			requestBody:    `{ "id":"abc-789", "eventOwners": ["123"],"eventOwnerName":"Event Owner","name":"Test Event","description":"A test event","startTime":"2099-05-01T12:00:00Z","address":"123 Test St","lat":51.5074,"long":-0.1278,"timezone":"America/New_York"}`,
+			mockUpsertFunc: nil,
+			expectedStatus: http.StatusBadRequest,
+			expectedBodyCheck: func(body string) error {
+				if !strings.Contains(body, `Field validation for 'EventSourceType' failed on the 'required' tag`) {
+					return fmt.Errorf("expected `Field validation for 'EventSourceType' failed on the 'required' tag`, got '%s'", body)
+				}
+				return nil
+			},
+		},
+		{
+			name:           "Invalid eventSourceType field",
+			apiPath:        `/test-id`,
+			requestBody:    `{ "id":"abc-789", "eventOwners": ["123"],"eventOwnerName":"Event Owner","eventSourceType":"NONEXISTENT","name":"Test Event","description":"A test event","startTime":"2099-05-01T12:00:00Z","address":"123 Test St","lat":51.5074,"long":-0.1278,"timezone":"America/New_York"}`,
+			mockUpsertFunc: nil,
+			expectedStatus: http.StatusBadRequest,
+			expectedBodyCheck: func(body string) error {
+				if !strings.Contains(body, "invalid body: invalid eventSourceType: NONEXISTENT") {
+					return fmt.Errorf("expected 'invalid body: invalid eventSourceType: NONEXISTENT', got '%s'", body)
 				}
 				return nil
 			},
@@ -1070,20 +1094,27 @@ func TestUpdateOneEvent(t *testing.T) {
 				},
 			}
 
+			// In TestUpdateOneEvent, modify the request creation:
 			req, err := http.NewRequestWithContext(context.Background(), "PUT", "/events/"+tt.apiPath, bytes.NewBufferString(tt.requestBody))
 			if err != nil {
 				t.Fatalf("Unexpected error: %v", err)
 			}
 
+			// Add mux vars to request context
+			vars := map[string]string{
+				helpers.EVENT_ID_KEY: strings.TrimPrefix(tt.apiPath, "/"),
+			}
+			req = mux.SetURLVars(req, vars)
+
 			rr := httptest.NewRecorder()
 			handler := NewMarqoHandler(mockService)
 
-			handler.PostEvent(rr, req)
+			handler.UpdateOneEvent(rr, req)
 
 			if status := rr.Code; status != tt.expectedStatus {
 				t.Errorf("Handler returned wrong status code: got %v want %v", status, tt.expectedStatus)
 			}
-
+			log.Printf(`rr.Body.String() %+v`, rr.Body.String())
 			if err := tt.expectedBodyCheck(rr.Body.String()); err != nil {
 				t.Errorf("Body check failed: %v", err)
 			}

--- a/functions/gateway/handlers/dynamodb_handlers/purchasable_handlers_test.go
+++ b/functions/gateway/handlers/dynamodb_handlers/purchasable_handlers_test.go
@@ -29,27 +29,30 @@ func TestGetPurchasable(t *testing.T) {
 		fmt.Println("Error parsing event time:", err)
 	}
 
+	createdAt, _ := time.Parse(time.RFC3339, "2024-09-01T12:00:00Z")
+	updatedAt, _ := time.Parse(time.RFC3339, "2024-09-01T12:00:00Z")
+
 	mockService := &dynamodb_service.MockPurchasableService{
 		GetPurchasablesByEventIDFunc: func(ctx context.Context, dynamodbClient internal_types.DynamoDBAPI, eventId string) (*internal_types.Purchasable, error) { // Change to return []*Purchasable
 			return &internal_types.Purchasable{ // Return a pointer to Purchasable
 				EventId: eventId,
 				PurchasableItems: []internal_types.PurchasableItemInsert{ // Corrected initialization of slice
 					{
-						Name:                      "Sample Item",
-						ItemType:                 "Type A",
-						Cost:                     100.0,
-						Inventory:                50,
-						StartingQuantity:         100,
-						Currency:                 "USD",
-						ChargeRecurrenceInterval:  "monthly",
+						Name:                          "Sample Item",
+						ItemType:                      "Type A",
+						Cost:                          100.0,
+						Inventory:                     50,
+						StartingQuantity:              100,
+						Currency:                      "USD",
+						ChargeRecurrenceInterval:      "monthly",
 						ChargeRecurrenceIntervalCount: 3,
-						ChargeRecurrenceEndDate:  eventTime.Format(time.RFC3339), // Format if necessary
-						DonationRatio:            0.1,
-						RegistrationFields: []string{"field1", "field2"},
-						CreatedAt:				"2024-09-01T12:00:00Z",  // Use time.Time type
-						UpdatedAt:              "2024-09-01T12:00:00Z", // Use time.Time type
-						},
+						ChargeRecurrenceEndDate:       eventTime, // Format if necessary
+						DonationRatio:                 0.1,
+						RegistrationFields:            []string{"field1", "field2"},
+						CreatedAt:                     createdAt, // Use time.Time type
+						UpdatedAt:                     updatedAt, // Use time.Time type
 					},
+				},
 				CreatedAt: eventTime, // Use time.Time type
 				UpdatedAt: eventTime, // Use time.Time type
 			}, nil
@@ -145,4 +148,3 @@ func TestDeletePurchasable(t *testing.T) {
 		t.Errorf("Expected response body %q, got %q", expectedMessage, string(body))
 	}
 }
-

--- a/functions/gateway/handlers/dynamodb_handlers/registration_field_handlers.go
+++ b/functions/gateway/handlers/dynamodb_handlers/registration_field_handlers.go
@@ -31,7 +31,6 @@ func NewRegistrationFieldsHandler(registrationFieldsService internal_types.Regis
 }
 
 func (h *RegistrationFieldsHandler) CreateRegistrationFields(w http.ResponseWriter, r *http.Request) {
-	log.Printf("hitting the registration fields")
 	vars := mux.Vars(r)
 	eventId := vars["event_id"]
     if eventId == "" {

--- a/functions/gateway/handlers/page_handlers.go
+++ b/functions/gateway/handlers/page_handlers.go
@@ -405,8 +405,7 @@ func GetEventDetailsPage(w http.ResponseWriter, r *http.Request) http.HandlerFun
 	checkoutParamVal := r.URL.Query().Get("checkout")
 
 	eventDetailsPage := pages.EventDetailsPage(*event, checkoutParamVal, canEdit)
-
-	layoutTemplate := pages.Layout(helpers.SitePages["events"], userInfo, eventDetailsPage, *event)
+	layoutTemplate := pages.Layout(helpers.SitePages["event-detail"], userInfo, eventDetailsPage, *event)
 	var buf bytes.Buffer
 	err = layoutTemplate.Render(ctx, &buf)
 	if err != nil {

--- a/functions/gateway/handlers/page_handlers.go
+++ b/functions/gateway/handlers/page_handlers.go
@@ -86,7 +86,7 @@ func ParseStartEndTime(startTimeStr, endTimeStr string) (_startTimeUnix, _endTim
 	return startTimeUnix, endTimeUnix
 }
 
-func GetSearchParamsFromReq(r *http.Request) (query string, userLocation []float64, maxDistance float64, startTime int64, endTime int64, cfLocation helpers.CdnLocation, ownerIds []string, categories string, address string, parseDatesBool string) {
+func GetSearchParamsFromReq(r *http.Request) (query string, userLocation []float64, maxDistance float64, startTime int64, endTime int64, cfLocation helpers.CdnLocation, ownerIds []string, categories string, address string, parseDatesBool string, eventSourceTypes []string, eventSourceIds []string) {
 	startTimeStr := r.URL.Query().Get("start_time")
 	endTimeStr := r.URL.Query().Get("end_time")
 	latStr := r.URL.Query().Get("lat")
@@ -95,8 +95,10 @@ func GetSearchParamsFromReq(r *http.Request) (query string, userLocation []float
 	q := r.URL.Query().Get("q")
 	owners := r.URL.Query().Get("owners")
 	categoriesStr := r.URL.Query().Get("categories")
-	addressStr := r.URL.Query().Get("address")
+	address = r.URL.Query().Get("address")
 	parseDates := r.URL.Query().Get("parse_dates")
+	eventSourceTypesStr := r.URL.Query().Get("event_source_types")
+	eventSourceIdsStr := r.URL.Query().Get("event_source_ids")
 	cfRay := GetCfRay(r)
 	rayCode := ""
 
@@ -167,13 +169,21 @@ func GetSearchParamsFromReq(r *http.Request) (query string, userLocation []float
 		decodedCategories = categories // Use the original string if decoding fails
 	}
 
-	return q, []float64{lat, long}, radius, startTimeUnix, endTimeUnix, cfLocation, ownerIds, decodedCategories, addressStr, parseDates
+	// Split comma-separated values into slices
+	if eventSourceTypesStr != "" {
+		eventSourceTypes = strings.Split(eventSourceTypesStr, ",")
+	}
+	if eventSourceIdsStr != "" {
+		eventSourceIds = strings.Split(eventSourceIdsStr, ",")
+	}
+
+	return q, []float64{lat, long}, radius, startTimeUnix, endTimeUnix, cfLocation, ownerIds, decodedCategories, address, parseDates, eventSourceTypes, eventSourceIds
 }
 
 func GetHomePage(w http.ResponseWriter, r *http.Request) http.HandlerFunc {
 	// Extract parameter values from the request query parameters
 	ctx := r.Context()
-	q, userLocation, radius, startTimeUnix, endTimeUnix, cfLocation, ownerIds, categories, address, parseDates := GetSearchParamsFromReq(r)
+	q, userLocation, radius, startTimeUnix, endTimeUnix, cfLocation, ownerIds, categories, address, parseDates, eventSourceTypes, eventSourceIds := GetSearchParamsFromReq(r)
 
 	originalQueryLat := r.URL.Query().Get("lat")
 	originalQueryLong := r.URL.Query().Get("lon")
@@ -191,7 +201,7 @@ func GetHomePage(w http.ResponseWriter, r *http.Request) http.HandlerFunc {
 		ownerIds = []string{subdomainValue}
 	}
 
-	res, err := services.SearchMarqoEvents(marqoClient, q, userLocation, radius, startTimeUnix, endTimeUnix, ownerIds, categories, address, parseDates)
+	res, err := services.SearchMarqoEvents(marqoClient, q, userLocation, radius, startTimeUnix, endTimeUnix, ownerIds, categories, address, parseDates, eventSourceTypes, eventSourceIds)
 	if err != nil {
 		return transport.SendServerRes(w, []byte("Failed to get events via search: "+err.Error()), http.StatusInternalServerError, err)
 	}

--- a/functions/gateway/handlers/page_handlers_test.go
+++ b/functions/gateway/handlers/page_handlers_test.go
@@ -540,7 +540,7 @@ func TestGetSearchParamsFromReq(t *testing.T) {
 			}
 
 			// TODO: need to test `categories` and `ownerIds` returned here
-			query, loc, radius, start, end, cfLoc, _, _, _, _ := GetSearchParamsFromReq(req)
+			query, loc, radius, start, end, cfLoc, _, _, _, _, _, _ := GetSearchParamsFromReq(req)
 
 			if query != tt.expectedQuery {
 				t.Errorf("Expected query %s, got %s", tt.expectedQuery, query)

--- a/functions/gateway/handlers/partial_handlers.go
+++ b/functions/gateway/handlers/partial_handlers.go
@@ -86,7 +86,7 @@ func GetEventsPartial(w http.ResponseWriter, r *http.Request) http.HandlerFunc {
 	// Extract parameter values from the request query parameters
 	ctx := r.Context()
 
-	q, userLocation, radius, startTimeUnix, endTimeUnix, _, ownerIds, categories, address, parseDates := GetSearchParamsFromReq(r)
+	q, userLocation, radius, startTimeUnix, endTimeUnix, _, ownerIds, categories, address, parseDates, eventSourceTypes, eventSourceIds := GetSearchParamsFromReq(r)
 
 	marqoClient, err := services.GetMarqoClient()
 	if err != nil {
@@ -101,7 +101,7 @@ func GetEventsPartial(w http.ResponseWriter, r *http.Request) http.HandlerFunc {
 		ownerIds = []string{subdomainValue}
 	}
 
-	res, err := services.SearchMarqoEvents(marqoClient, q, userLocation, radius, startTimeUnix, endTimeUnix, ownerIds, categories, address, parseDates)
+	res, err := services.SearchMarqoEvents(marqoClient, q, userLocation, radius, startTimeUnix, endTimeUnix, ownerIds, categories, address, parseDates, eventSourceTypes, eventSourceIds)
 	if err != nil {
 		return transport.SendServerRes(w, []byte("Failed to get events via search: "+err.Error()), http.StatusInternalServerError, err)
 	}

--- a/functions/gateway/handlers/partial_handlers.go
+++ b/functions/gateway/handlers/partial_handlers.go
@@ -107,12 +107,12 @@ func GetEventsPartial(w http.ResponseWriter, r *http.Request) http.HandlerFunc {
 	}
 
 	events := res.Events
-
-	if err != nil {
-		return transport.SendHtmlRes(w, []byte(string("Error getting geocoordinates: ")+err.Error()), http.StatusInternalServerError, err)
+	listMode := r.URL.Query().Get("list_mode")
+	if listMode == "" {
+		// TODO: make this an enum / type
+		listMode = "DETAILED"
 	}
-
-	eventListPartial := pages.EventsInner(events)
+	eventListPartial := pages.EventsInner(events, listMode)
 
 	var buf bytes.Buffer
 	err = eventListPartial.Render(ctx, &buf)

--- a/functions/gateway/helpers/constants.go
+++ b/functions/gateway/helpers/constants.go
@@ -24,6 +24,29 @@ const JWT_ASSERTION_TYPE = "urn:ietf:params:oauth:client-assertion-type:jwt-bear
 const AUTH_ROLE_CLAIMS_KEY = "urn:zitadel:iam:org:project:<project-id>:roles"
 const AUTH_METADATA_KEY = "urn:zitadel:iam:user:metadata"
 
+// NOTE: this ensures that only SLF (self) event source types are searchable by default
+var DEFAULT_SEARCHABLE_EVENT_SOURCE_TYPES = []string{"SLF"}
+
+// SLF_EVS => Self -> Event Series
+var DEFAULT_NON_SEARCHABLE_EVENT_SOURCE_TYPES = []string{"SLF_EVS"}
+
+var ALL_EVENT_SOURCE_TYPES []string
+
+func init() {
+	ALL_EVENT_SOURCE_TYPES = append(DEFAULT_SEARCHABLE_EVENT_SOURCE_TYPES, DEFAULT_NON_SEARCHABLE_EVENT_SOURCE_TYPES...)
+
+	seen := make(map[string]bool)
+	uniqueTypes := []string{}
+	for _, sourceType := range ALL_EVENT_SOURCE_TYPES {
+		if !seen[sourceType] {
+			seen[sourceType] = true
+			uniqueTypes = append(uniqueTypes, sourceType)
+		}
+	}
+
+	ALL_EVENT_SOURCE_TYPES = uniqueTypes
+}
+
 type UserInfo struct {
 	Email             string `json:"email"`
 	EmailVerified     bool   `json:"email_verified"`

--- a/functions/gateway/helpers/constants.go
+++ b/functions/gateway/helpers/constants.go
@@ -111,21 +111,22 @@ var SubnavItems = map[SubnavOption]string{
 }
 
 type SitePage struct {
+	Key         string
 	Slug        string
 	Name        string
 	SubnavItems []string
 }
 
 var SitePages = map[string]SitePage{
-	"home":             {Slug: "/", Name: "Home", SubnavItems: []string{SubnavItems[NvMain], SubnavItems[NvFilters]}},
-	"about":            {Slug: "/about", Name: "About", SubnavItems: []string{SubnavItems[NvMain]}},
-	"profile":          {Slug: "/admin/profile", Name: "Profile", SubnavItems: []string{SubnavItems[NvMain]}},
-	"add-event-source": {Slug: "/admin/add-event-source", Name: "Add Event Source", SubnavItems: []string{SubnavItems[NvMain]}},
-	"settings":         {Slug: "/admin/profile/settings", Name: "Settings", SubnavItems: []string{SubnavItems[NvMain]}},
-	"map-embed":        {Slug: "/map-embed", Name: "MapEmbed", SubnavItems: []string{SubnavItems[NvMain]}},
-	"event-detail":     {Slug: "/event/{" + EVENT_ID_KEY + "}", Name: "Event Details", SubnavItems: []string{SubnavItems[NvMain], SubnavItems[NvCart]}},
-	"add-event":        {Slug: "/admin/event/new", Name: "Add Event", SubnavItems: []string{SubnavItems[NvMain]}},
-	"edit-event":       {Slug: "/admin/event/edit/{" + EVENT_ID_KEY + "}", Name: "Edit Event", SubnavItems: []string{SubnavItems[NvMain]}},
+	"home":             {Key: "home", Slug: "/", Name: "Home", SubnavItems: []string{SubnavItems[NvMain], SubnavItems[NvFilters]}},
+	"about":            {Key: "about", Slug: "/about", Name: "About", SubnavItems: []string{SubnavItems[NvMain]}},
+	"profile":          {Key: "profile", Slug: "/admin/profile", Name: "Profile", SubnavItems: []string{SubnavItems[NvMain]}},
+	"add-event-source": {Key: "add-event-source", Slug: "/admin/add-event-source", Name: "Add Event Source", SubnavItems: []string{SubnavItems[NvMain]}},
+	"settings":         {Key: "settings", Slug: "/admin/profile/settings", Name: "Settings", SubnavItems: []string{SubnavItems[NvMain]}},
+	"map-embed":        {Key: "map-embed", Slug: "/map-embed", Name: "MapEmbed", SubnavItems: []string{SubnavItems[NvMain]}},
+	"event-detail":     {Key: "event-detail", Slug: "/event/{" + EVENT_ID_KEY + "}", Name: "Event Detail", SubnavItems: []string{SubnavItems[NvMain], SubnavItems[NvCart]}},
+	"add-event":        {Key: "add-event", Slug: "/admin/event/new", Name: "Add Event", SubnavItems: []string{SubnavItems[NvMain]}},
+	"edit-event":       {Key: "edit-event", Slug: "/admin/event/edit/{" + EVENT_ID_KEY + "}", Name: "Edit Event", SubnavItems: []string{SubnavItems[NvMain]}},
 }
 
 type Subcategory struct {

--- a/functions/gateway/helpers/constants.go
+++ b/functions/gateway/helpers/constants.go
@@ -25,7 +25,7 @@ const AUTH_ROLE_CLAIMS_KEY = "urn:zitadel:iam:org:project:<project-id>:roles"
 const AUTH_METADATA_KEY = "urn:zitadel:iam:user:metadata"
 
 // NOTE: this ensures that only SLF (self) event source types are searchable by default
-var DEFAULT_SEARCHABLE_EVENT_SOURCE_TYPES = []string{"SLF"}
+var DEFAULT_SEARCHABLE_EVENT_SOURCE_TYPES = []string{"SLF", "EVS"}
 
 // SLF_EVS => Self -> Event Series
 var DEFAULT_NON_SEARCHABLE_EVENT_SOURCE_TYPES = []string{"SLF_EVS"}

--- a/functions/gateway/helpers/utils.go
+++ b/functions/gateway/helpers/utils.go
@@ -52,20 +52,20 @@ func UtcOrUnixToUnix64(t interface{}) (int64, error) {
 	}
 }
 
-func FormatDate(unixTimestamp int64) (string, error) {
-	if unixTimestamp == 0 {
-		return "", fmt.Errorf("not a valid unix timestamp: %v", unixTimestamp)
+func FormatDateLocal(t time.Time) (string, error) {
+	if t.IsZero() {
+		return "", fmt.Errorf("not a valid time: %v", t)
 	}
-	date := time.Unix(unixTimestamp, 0).UTC()
-	return date.Format("Jan 2, 2006 (Mon)"), nil
+	// Format: "Dec 24, 2024 (Tue)"
+	return t.Format("Jan 2, 2006 (Mon)"), nil
 }
 
-func FormatTime(unixTimestamp int64) (string, error) {
-	if unixTimestamp == 0 {
-		return "", fmt.Errorf("not a valid unix timestamp: %v", unixTimestamp)
+func FormatTimeLocal(t time.Time) (string, error) {
+	if t.IsZero() {
+		return "", fmt.Errorf("not a valid time: %v", t)
 	}
-	_time := time.Unix(unixTimestamp, 0).UTC()
-	return _time.Format("3:04pm"), nil
+	// Format: "7:00pm"
+	return strings.ToLower(t.Format("3:04PM")), nil
 }
 
 func TruncateStringByBytes(str string, limit int) (s string, exceededLimit bool) {
@@ -545,11 +545,9 @@ func GetLocalDateAndTime(datetime int64, timezone string) (string, string) {
 	// Convert start time to local time
 	localStartTime := time.Unix(datetime, 0).In(loc)
 
-	localUnixTime := localStartTime.Unix()
-
 	// Populate the local date and time fields
-	localStartDateStr, _ := FormatDate(localUnixTime)
-	localStartTimeStr, _ := FormatTime(localUnixTime)
+	localStartDateStr, _ := FormatDateLocal(localStartTime)
+	localStartTimeStr, _ := FormatTimeLocal(localStartTime)
 
 	return localStartTimeStr, localStartDateStr
 }

--- a/functions/gateway/helpers/utils.go
+++ b/functions/gateway/helpers/utils.go
@@ -514,17 +514,17 @@ func ArrFindFirst(needles []string, haystack []string) string {
 	return ""
 }
 
-func GetDateOrShowNone(date int64) string {
-	formattedDate, err := FormatDate(date)
-	if date == 0 || err != nil {
+func GetDateOrShowNone(datetime int64, timezone string) string {
+	_, formattedDate := GetLocalDateAndTime(datetime, timezone)
+	if formattedDate == "" {
 		return ""
 	}
 	return formattedDate
 }
 
-func GetTimeOrShowNone(time int64) string {
-	formattedTime, err := FormatTime(time)
-	if time == 0 || err != nil {
+func GetTimeOrShowNone(datetime int64, timezone string) string {
+	formattedTime, _ := GetLocalDateAndTime(datetime, timezone)
+	if formattedTime == "" {
 		return ""
 	}
 	return formattedTime

--- a/functions/gateway/helpers/utils.go
+++ b/functions/gateway/helpers/utils.go
@@ -503,9 +503,9 @@ func UpdateUserMetadataKey(userID, key, value string) error {
 	return nil
 }
 
-func ArrFindFirst(slice []string, items []string) string {
-	for _, s := range slice {
-		for _, item := range items {
+func ArrFindFirst(needles []string, haystack []string) string {
+	for _, s := range needles {
+		for _, item := range haystack {
 			if s == item {
 				return s
 			}

--- a/functions/gateway/helpers/utils_test.go
+++ b/functions/gateway/helpers/utils_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/meetnearme/api/functions/gateway/types"
 )
@@ -17,7 +18,7 @@ func init() {
 	os.Setenv("GO_ENV", GO_TEST_ENV)
 }
 
-func TestFormatDate(t *testing.T) {
+func TestFormatDateL(t *testing.T) {
 	tests := []struct {
 		name          string
 		input         string
@@ -25,18 +26,18 @@ func TestFormatDate(t *testing.T) {
 		expectedError string
 	}{
 		{"Valid date", "2099-05-01T12:00:00Z", "May 1, 2099 (Fri)", ""},
-		{"Invalid date", "invalid-date", "", "not a valid unix timestamp"},
-		{"Empty string", "", "", "not a valid unix timestamp"},
+		{"Invalid date", "invalid-date", "", "not a valid time"},
+		{"Empty string", "", "", "not a valid time"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			date, err := UtcOrUnixToUnix64(tt.input)
-			result, err := FormatDate(date)
+			date, _ := time.Parse(time.RFC3339, tt.input)
+			result, err := FormatDateLocal(date)
 			if tt.expectedError != "" && !strings.Contains(err.Error(), tt.expectedError) {
 				t.Errorf("Expected err to have: %v, got: %v", tt.expectedError, err)
 			} else if result != tt.expected {
-				t.Errorf("FormatDate(%q) = %q, want %q", tt.input, result, tt.expected)
+				t.Errorf("FormatDateL(%q) = %q, want %q", tt.input, result, tt.expected)
 			}
 		})
 	}
@@ -50,14 +51,14 @@ func TestFormatTime(t *testing.T) {
 		expectedError string
 	}{
 		{"Valid time", "2099-05-01T14:30:00Z", "2:30pm", ""},
-		{"Invalid time", "invalid-time", "", "not a valid unix timestamp"},
-		{"Empty string", "", "", "not a valid unix timestamp"},
+		{"Invalid time", "invalid-time", "", "not a valid time"},
+		{"Empty string", "", "", "not a valid time"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tm, err := UtcOrUnixToUnix64(tt.input)
-			result, err := FormatTime(tm)
+			tm, _ := time.Parse(time.RFC3339, tt.input)
+			result, err := FormatTimeLocal(tm)
 			if tt.expectedError != "" && !strings.Contains(err.Error(), tt.expectedError) {
 				t.Errorf("Expected err to have: %v, got: %v", tt.expectedError, err)
 			} else if result != tt.expected {

--- a/functions/gateway/main.go
+++ b/functions/gateway/main.go
@@ -101,7 +101,7 @@ func init() {
 		{"/api/event-rsvps/{event_id:[0-9a-fA-F-]+}/{user_id:[0-9a-fA-F-]+}", "DELETE", dynamodb_handlers.DeleteEventRsvpHandler, None}, // Delete an event RSVP
 
 		// Registrations
-		{"/api/registrations/{event_id:[0-9a-fA-F-]+}/{user_id:[0-9a-fA-F-]+}", "POST", dynamodb_handlers.CreateRegistrationHandler, None},   // Create a new event RSVP
+		{"/api/registrations/{event_id:[0-9a-fA-F-]+}/{user_id:[0-9a-fA-F-]+}", "POST", dynamodb_handlers.CreateRegistrationHandler, Check},  // Create a new event RSVP
 		{"/api/registrations/{event_id:[0-9a-fA-F-]+}/{user_id:[0-9a-fA-F-]+}", "GET", dynamodb_handlers.GetRegistrationByPkHandler, None},   // Get a registration by primary key
 		{"/api/registrations/user/{user_id:[0-9a-fA-F-]+}", "GET", dynamodb_handlers.GetRegistrationsByUserIDHandler, None},                  // Get a specific event RSVP
 		{"/api/registrations/event/{event_id:[0-9a-fA-F-]+}", "GET", dynamodb_handlers.GetRegistrationsByEventIDHandler, None},               // Get all event RSVPs
@@ -109,7 +109,7 @@ func init() {
 		{"/api/registrations/{event_id:[0-9a-fA-F-]+}/{user_id:[0-9a-fA-F-]+}", "DELETE", dynamodb_handlers.DeleteRegistrationHandler, None}, // Delete an event RSVP
 
 		// RegistrationFields
-		{"/api/registration-fields/{event_id:[0-9a-fA-F-]+}", "POST", dynamodb_handlers.CreateRegistrationFieldsHandler, None},      // Create a new
+		{"/api/registration-fields/{event_id:[0-9a-fA-F-]+}", "POST", dynamodb_handlers.CreateRegistrationFieldsHandler, Check},     // Create a new
 		{"/api/registration-fields/{event_id:[0-9a-fA-F-]+}", "GET", dynamodb_handlers.GetRegistrationFieldsByEventIDHandler, None}, // Get all
 		{"/api/registration-fields/{event_id:[0-9a-fA-F-]+}", "PUT", dynamodb_handlers.UpdateRegistrationFieldsHandler, None},       // Update an existing
 		{"/api/registration-fields/{event_id:[0-9a-fA-F-]+}", "DELETE", dynamodb_handlers.DeleteRegistrationFieldsHandler, None},    // Delete an

--- a/functions/gateway/main.go
+++ b/functions/gateway/main.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"strings"
 
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
@@ -66,12 +67,12 @@ func init() {
 		// API routes
 
 		// == START == need to expose these via permanent key for headless clients
-		{"/api/event", "POST", handlers.PostEventHandler, None},
-		{"/api/events", "POST", handlers.PostBatchEventsHandler, None},
+		{"/api/event", "POST", handlers.PostEventHandler, Require},
+		{"/api/events", "POST", handlers.PostBatchEventsHandler, Require},
 		{"/api/events", "GET", handlers.SearchEventsHandler, None},
-		{"/api/events", "PUT", handlers.BulkUpdateEventsHandler, None},
+		{"/api/events", "PUT", handlers.BulkUpdateEventsHandler, Require},
 		{"/api/events/{" + helpers.EVENT_ID_KEY + "}", "GET", handlers.GetOneEventHandler, None},
-		{"/api/events/{" + helpers.EVENT_ID_KEY + "}", "PUT", handlers.UpdateOneEventHandler, None},
+		{"/api/events/{" + helpers.EVENT_ID_KEY + "}", "PUT", handlers.UpdateOneEventHandler, Require},
 		{"/api/locations", "GET", handlers.SearchLocationsHandler, None},
 		//  == END == need to expose these via permanent key for headless clients
 		{"/api/auth/users/set-subdomain", "POST", handlers.SetUserSubdomain, Require},
@@ -82,45 +83,45 @@ func init() {
 		{"/api/user-search", "GET", handlers.SearchUsersHandler, Require},
 		{"/api/users", "GET", handlers.GetUsersHandler, Require},
 		{"/api/html/events", "GET", handlers.GetEventsPartial, None},
-		{"/api/html/seshu/session/submit", "POST", handlers.SubmitSeshuSession, None},
-		{"/api/html/seshu/session/location", "PUT", handlers.GeoThenPatchSeshuSession, None},
-		{"/api/html/seshu/session/events", "PUT", handlers.SubmitSeshuEvents, None},
+		{"/api/html/seshu/session/submit", "POST", handlers.SubmitSeshuSession, Require},
+		{"/api/html/seshu/session/location", "PUT", handlers.GeoThenPatchSeshuSession, Require},
+		{"/api/html/seshu/session/events", "PUT", handlers.SubmitSeshuEvents, Require},
 
 		// // Purchasables routes
-		{"/api/purchasables/{event_id:[0-9a-fA-F-]+}", "POST", dynamodb_handlers.CreatePurchasableHandler, None},   // Create a new purchasable
-		{"/api/purchasables/{event_id:[0-9a-fA-F-]+}", "GET", dynamodb_handlers.GetPurchasableHandler, None},       // Get all purchasables
-		{"/api/purchasables/{event_id:[0-9a-fA-F-]+}", "PUT", dynamodb_handlers.UpdatePurchasableHandler, None},    // Update an existing purchasable
-		{"/api/purchasables/{event_id:[0-9a-fA-F-]+}", "DELETE", dynamodb_handlers.DeletePurchasableHandler, None}, // Delete a purchasable
+		{"/api/purchasables/{event_id:[0-9a-fA-F-]+}", "POST", dynamodb_handlers.CreatePurchasableHandler, Require},   // Create a new purchasable
+		{"/api/purchasables/{event_id:[0-9a-fA-F-]+}", "GET", dynamodb_handlers.GetPurchasableHandler, None},          // Get all purchasables
+		{"/api/purchasables/{event_id:[0-9a-fA-F-]+}", "PUT", dynamodb_handlers.UpdatePurchasableHandler, Require},    // Update an existing purchasable
+		{"/api/purchasables/{event_id:[0-9a-fA-F-]+}", "DELETE", dynamodb_handlers.DeletePurchasableHandler, Require}, // Delete a purchasable
 
 		// // Event RSVPs routes
-		{"/api/event-rsvps/{event_id:[0-9a-fA-F-]+}/{user_id:[0-9a-fA-F-]+}", "POST", dynamodb_handlers.CreateEventRsvpHandler, None},   // Create a new event RSVP
-		{"/api/event-rsvps/{event_id:[0-9a-fA-F-]+}/{user_id:[0-9a-fA-F-]+}", "GET", dynamodb_handlers.GetEventRsvpByPkHandler, None},   // Get a specific event RSVP
-		{"/api/event-rsvps/event/{event_id:[0-9a-fA-F-]+}", "GET", dynamodb_handlers.GetEventRsvpsByEventIDHandler, None},               // Get all event RSVPs
-		{"/api/event-rsvps/user/{user_id:[0-9a-fA-F-]+}", "GET", dynamodb_handlers.GetEventRsvpsByUserIDHandler, None},                  // Get a specific event RSVP
-		{"/api/event-rsvps/{event_id:[0-9a-fA-F-]+}/{user_id:[0-9a-fA-F-]+}", "PUT", dynamodb_handlers.UpdateEventRsvpHandler, None},    // Update an existing event RSVP
-		{"/api/event-rsvps/{event_id:[0-9a-fA-F-]+}/{user_id:[0-9a-fA-F-]+}", "DELETE", dynamodb_handlers.DeleteEventRsvpHandler, None}, // Delete an event RSVP
+		{"/api/event-rsvps/{event_id:[0-9a-fA-F-]+}/{user_id:[0-9a-fA-F-]+}", "POST", dynamodb_handlers.CreateEventRsvpHandler, None},      // Create a new event RSVP
+		{"/api/event-rsvps/{event_id:[0-9a-fA-F-]+}/{user_id:[0-9a-fA-F-]+}", "GET", dynamodb_handlers.GetEventRsvpByPkHandler, Require},   // Get a specific event RSVP
+		{"/api/event-rsvps/event/{event_id:[0-9a-fA-F-]+}", "GET", dynamodb_handlers.GetEventRsvpsByEventIDHandler, Require},               // Get all event RSVPs
+		{"/api/event-rsvps/user/{user_id:[0-9a-fA-F-]+}", "GET", dynamodb_handlers.GetEventRsvpsByUserIDHandler, Require},                  // Get a specific event RSVP
+		{"/api/event-rsvps/{event_id:[0-9a-fA-F-]+}/{user_id:[0-9a-fA-F-]+}", "PUT", dynamodb_handlers.UpdateEventRsvpHandler, Require},    // Update an existing event RSVP
+		{"/api/event-rsvps/{event_id:[0-9a-fA-F-]+}/{user_id:[0-9a-fA-F-]+}", "DELETE", dynamodb_handlers.DeleteEventRsvpHandler, Require}, // Delete an event RSVP
 
 		// Registrations
-		{"/api/registrations/{event_id:[0-9a-fA-F-]+}/{user_id:[0-9a-fA-F-]+}", "POST", dynamodb_handlers.CreateRegistrationHandler, Check},  // Create a new event RSVP
-		{"/api/registrations/{event_id:[0-9a-fA-F-]+}/{user_id:[0-9a-fA-F-]+}", "GET", dynamodb_handlers.GetRegistrationByPkHandler, None},   // Get a registration by primary key
-		{"/api/registrations/user/{user_id:[0-9a-fA-F-]+}", "GET", dynamodb_handlers.GetRegistrationsByUserIDHandler, None},                  // Get a specific event RSVP
-		{"/api/registrations/event/{event_id:[0-9a-fA-F-]+}", "GET", dynamodb_handlers.GetRegistrationsByEventIDHandler, None},               // Get all event RSVPs
-		{"/api/registrations/{event_id:[0-9a-fA-F-]+}/{user_id:[0-9a-fA-F-]+}", "PUT", dynamodb_handlers.UpdateRegistrationHandler, None},    // Update an existing event RSVP
-		{"/api/registrations/{event_id:[0-9a-fA-F-]+}/{user_id:[0-9a-fA-F-]+}", "DELETE", dynamodb_handlers.DeleteRegistrationHandler, None}, // Delete an event RSVP
+		{"/api/registrations/{event_id:[0-9a-fA-F-]+}/{user_id:[0-9a-fA-F-]+}", "POST", dynamodb_handlers.CreateRegistrationHandler, Require},   // Create a new event RSVP
+		{"/api/registrations/{event_id:[0-9a-fA-F-]+}/{user_id:[0-9a-fA-F-]+}", "GET", dynamodb_handlers.GetRegistrationByPkHandler, Require},   // Get a registration by primary key
+		{"/api/registrations/user/{user_id:[0-9a-fA-F-]+}", "GET", dynamodb_handlers.GetRegistrationsByUserIDHandler, Require},                  // Get a specific event RSVP
+		{"/api/registrations/event/{event_id:[0-9a-fA-F-]+}", "GET", dynamodb_handlers.GetRegistrationsByEventIDHandler, Require},               // Get all event RSVPs
+		{"/api/registrations/{event_id:[0-9a-fA-F-]+}/{user_id:[0-9a-fA-F-]+}", "PUT", dynamodb_handlers.UpdateRegistrationHandler, Require},    // Update an existing event RSVP
+		{"/api/registrations/{event_id:[0-9a-fA-F-]+}/{user_id:[0-9a-fA-F-]+}", "DELETE", dynamodb_handlers.DeleteRegistrationHandler, Require}, // Delete an event RSVP
 
 		// RegistrationFields
-		{"/api/registration-fields/{event_id:[0-9a-fA-F-]+}", "POST", dynamodb_handlers.CreateRegistrationFieldsHandler, Check},     // Create a new
+		{"/api/registration-fields/{event_id:[0-9a-fA-F-]+}", "POST", dynamodb_handlers.CreateRegistrationFieldsHandler, Require},   // Create a new
 		{"/api/registration-fields/{event_id:[0-9a-fA-F-]+}", "GET", dynamodb_handlers.GetRegistrationFieldsByEventIDHandler, None}, // Get all
-		{"/api/registration-fields/{event_id:[0-9a-fA-F-]+}", "PUT", dynamodb_handlers.UpdateRegistrationFieldsHandler, None},       // Update an existing
-		{"/api/registration-fields/{event_id:[0-9a-fA-F-]+}", "DELETE", dynamodb_handlers.DeleteRegistrationFieldsHandler, None},    // Delete an
+		{"/api/registration-fields/{event_id:[0-9a-fA-F-]+}", "PUT", dynamodb_handlers.UpdateRegistrationFieldsHandler, Require},    // Update an existing
+		{"/api/registration-fields/{event_id:[0-9a-fA-F-]+}", "DELETE", dynamodb_handlers.DeleteRegistrationFieldsHandler, Require}, // Delete an
 
 		// Purchases
-		{"/api/purchases/{event_id:[0-9a-fA-F-]+}/{user_id:[0-9a-fA-F-]+}", "POST", dynamodb_handlers.CreatePurchaseHandler, None},                     // Create a new event RSVP
-		{"/api/purchases/{event_id:[0-9a-fA-F-]+}/{user_id:[0-9a-fA-F-]+}/{created_at:[0-9]+}", "GET", dynamodb_handlers.GetPurchaseByPkHandler, None}, // Get a specific event RSVP
-		{"/api/purchases/event/{event_id:[0-9a-fA-F-]+}", "GET", dynamodb_handlers.GetPurchasesByEventIDHandler, None},                                 // Get all event RSVPs
-		{"/api/purchases/user/{user_id:[0-9a-fA-F-]+}", "GET", dynamodb_handlers.GetPurchasesByUserIDHandler, None},                                    // Get a specific event RSVP
-		{"/api/purchases/{event_id:[0-9a-fA-F-]+}/{user_id:[0-9a-fA-F-]+}/{created_at:[0-9]+}", "PUT", dynamodb_handlers.UpdatePurchaseHandler, None},  // Update an existing event RSVP
-		{"/api/purchases/{event_id:[0-9a-fA-F-]+}/{user_id:[0-9a-fA-F-]+}", "DELETE", dynamodb_handlers.DeletePurchaseHandler, None},                   // Delete an event RSVP
+		{"/api/purchases/{event_id:[0-9a-fA-F-]+}/{user_id:[0-9a-fA-F-]+}", "POST", dynamodb_handlers.CreatePurchaseHandler, Require},                     // Create a new event RSVP
+		{"/api/purchases/{event_id:[0-9a-fA-F-]+}/{user_id:[0-9a-fA-F-]+}/{created_at:[0-9]+}", "GET", dynamodb_handlers.GetPurchaseByPkHandler, Require}, // Get a specific event RSVP
+		{"/api/purchases/event/{event_id:[0-9a-fA-F-]+}", "GET", dynamodb_handlers.GetPurchasesByEventIDHandler, Require},                                 // Get all event RSVPs
+		{"/api/purchases/user/{user_id:[0-9a-fA-F-]+}", "GET", dynamodb_handlers.GetPurchasesByUserIDHandler, Require},                                    // Get a specific event RSVP
+		{"/api/purchases/{event_id:[0-9a-fA-F-]+}/{user_id:[0-9a-fA-F-]+}/{created_at:[0-9]+}", "PUT", dynamodb_handlers.UpdatePurchaseHandler, None},     // Update an existing event RSVP
+		{"/api/purchases/{event_id:[0-9a-fA-F-]+}/{user_id:[0-9a-fA-F-]+}", "DELETE", dynamodb_handlers.DeletePurchaseHandler, None},                      // Delete an event RSVP
 
 		// Checkout Session
 		{"/api/checkout/{event_id:[0-9a-fA-F-]+}", "POST", handlers.CreateCheckoutSessionHandler, Check},
@@ -171,59 +172,72 @@ func (app *App) addRoute(route Route) {
 	switch route.Auth {
 	case Require:
 		handler = func(w http.ResponseWriter, r *http.Request) {
-			accessTokenCookie, err = r.Cookie("access_token")
-			if err != nil {
-				refreshTokenCookie, refreshTokenCookieErr = r.Cookie("refresh_token")
-				if refreshTokenCookieErr != nil {
-					http.Redirect(w, r, "/auth/login"+"?redirect="+route.Path, http.StatusFound)
+			var accessToken string
+
+			// First check Authorization header
+			authHeader := r.Header.Get("Authorization")
+			if strings.HasPrefix(authHeader, "Bearer ") {
+				accessToken = strings.TrimPrefix(authHeader, "Bearer ")
+			} else {
+				// Fall back to cookie-based auth
+				accessTokenCookie, err = r.Cookie("access_token")
+				if err != nil {
+					refreshTokenCookie, refreshTokenCookieErr = r.Cookie("refresh_token")
+					if refreshTokenCookieErr != nil {
+						http.Redirect(w, r, "/auth/login"+"?redirect="+route.Path, http.StatusFound)
+						return
+					}
+
+					tokens, refreshAccessTokenErr := services.RefreshAccessToken(refreshTokenCookie.Value)
+					if refreshAccessTokenErr != nil {
+						log.Printf("Authentication Failed: %v", err)
+						http.Error(w, "Authentication failed", http.StatusUnauthorized)
+						return
+					}
+
+					// Store the access token and refresh token securely
+					newAccessToken, ok := tokens["access_token"].(string)
+					if !ok {
+						http.Error(w, "Failed to get access token", http.StatusInternalServerError)
+						return
+					}
+
+					refreshToken, ok := tokens["refresh_token"].(string)
+					if !ok {
+						fmt.Printf("Refresh token error: %v", ok)
+						http.Error(w, "Failed to get refresh token", http.StatusInternalServerError)
+						return
+					}
+
+					// Store tokens in cookies
+					http.SetCookie(w, &http.Cookie{
+						Name:  "access_token",
+						Value: newAccessToken,
+						Path:  "/",
+					})
+
+					http.SetCookie(w, &http.Cookie{
+						Name:  "refresh_token",
+						Value: refreshToken,
+						Path:  "/",
+					})
+
+					accessToken = newAccessToken
+					http.Redirect(w, r, route.Path, http.StatusFound)
 					return
 				}
-
-				tokens, refreshAccessTokenErr := services.RefreshAccessToken(refreshTokenCookie.Value)
-				if refreshAccessTokenErr != nil {
-					log.Printf("Authentication Failed: %v", err)
-					http.Error(w, "Authentication failed", http.StatusUnauthorized)
-					return
-				}
-
-				// Store the access token and refresh token securely
-				accessToken, ok := tokens["access_token"].(string)
-				if !ok {
-					http.Error(w, "Failed to get access token", http.StatusInternalServerError)
-					return
-				}
-
-				refreshToken, ok := tokens["refresh_token"].(string)
-				if !ok {
-					fmt.Printf("Refresh token error: %v", ok)
-					http.Error(w, "Failed to get refresh token", http.StatusInternalServerError)
-					return
-				}
-
-				// Store tokens in a session or secure cookie
-				http.SetCookie(w, &http.Cookie{
-					Name:  "access_token",
-					Value: accessToken,
-					Path:  "/",
-				})
-
-				http.SetCookie(w, &http.Cookie{
-					Name:  "refresh_token",
-					Value: refreshToken,
-					Path:  "/",
-				})
-
-				var userRedirectURL string = route.Path
-				http.Redirect(w, r, userRedirectURL, http.StatusFound)
-				return
+				accessToken = accessTokenCookie.Value
 			}
 
-			accessToken := "Bearer " + accessTokenCookie.Value
-
 			// Use the Authorizer to introspect the access token
-			authCtx, err := app.AuthZ.CheckAuthorization(r.Context(), accessToken)
+			authCtx, err := app.AuthZ.CheckAuthorization(r.Context(), "Bearer "+accessToken)
 			if err != nil {
-				http.Redirect(w, r, "/auth/login"+"?redirect="+route.Path, http.StatusFound)
+				log.Printf("Authorization Failed: %v", err)
+				if strings.HasPrefix(authHeader, "Bearer ") {
+					http.Error(w, "Unauthorized", http.StatusUnauthorized)
+				} else {
+					http.Redirect(w, r, "/auth/login"+"?redirect="+route.Path, http.StatusFound)
+				}
 				return
 			}
 

--- a/functions/gateway/services/dynamodb_service/registration_service_test.go
+++ b/functions/gateway/services/dynamodb_service/registration_service_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/meetnearme/api/functions/gateway/test_helpers"
 	internal_types "github.com/meetnearme/api/functions/gateway/types"
 )
@@ -21,9 +21,11 @@ func TestInsertRegistration(t *testing.T) {
 
 	now := time.Now()
 	registration := internal_types.RegistrationInsert{
-		EventId:   "eventId",
-		UserId:    "userId",
-		Responses:  []map[string]string{{"question1": "answer1"}},
+		EventId: "eventId",
+		UserId:  "userId",
+		Responses: []map[string]interface{}{
+			{"question1": "answer1"},
+		},
 		CreatedAt: now,
 		UpdatedAt: now,
 	}
@@ -168,4 +170,3 @@ func TestDeleteRegistration(t *testing.T) {
 		t.Errorf("expected no error, got %v", err)
 	}
 }
-

--- a/functions/gateway/services/dynamodb_service/registration_service_test.go
+++ b/functions/gateway/services/dynamodb_service/registration_service_test.go
@@ -138,7 +138,7 @@ func TestUpdateRegistration(t *testing.T) {
 	service := NewRegistrationService()
 
 	updatedRegistration, err := service.UpdateRegistration(context.TODO(), mockDynamoDBClient, "eventId", "userId", internal_types.RegistrationUpdate{
-		Responses: []map[string]string{
+		Responses: []map[string]interface{}{
 			{"question1": "updatedAnswer"},
 		},
 		UpdatedAt: time.Now(),

--- a/functions/gateway/services/marqo_service.go
+++ b/functions/gateway/services/marqo_service.go
@@ -455,7 +455,7 @@ func SearchMarqoEvents(client *marqo.Client, query string, userLocation []float6
 
 	// Build eventSourceId filter using Marqo IN operator
 	if len(eventSourceIds) > 0 {
-		eventSourceIdFilter = fmt.Sprintf("eventSourceId IN (%s) AND ", strings.Join(eventSourceIds, ", "))
+		eventSourceIdFilter = fmt.Sprintf("eventSourceId IN (%s) AND ", strings.Join(eventSourceIds, ","))
 	}
 
 	// Update the filter string construction to include the new filters

--- a/functions/gateway/services/marqo_service.go
+++ b/functions/gateway/services/marqo_service.go
@@ -330,6 +330,12 @@ func ConvertEventsToDocuments(events []types.Event, hasIds bool) (documents []in
 		}
 
 		// Add optional fields only if they are not nil
+		if event.EventSourceType != "" {
+			document["eventSourceType"] = string(event.EventSourceType)
+		}
+		if event.EventSourceId != "" {
+			document["eventSourceId"] = string(event.EventSourceId)
+		}
 		if event.EndTime != 0 {
 			document["endTime"] = int64(event.EndTime)
 		}
@@ -407,7 +413,7 @@ func BulkUpsertEventToMarqo(client *marqo.Client, events []types.Event, hasIds b
 // SearchMarqoEvents searches for events based on the given query, user location, and maximum distance.
 // It returns a list of events that match the search criteria.
 // EX : SearchMarqoEvents(client, "music", []float64{37.7749, -122.4194}, 10)
-func SearchMarqoEvents(client *marqo.Client, query string, userLocation []float64, maxDistance float64, startTime, endTime int64, ownerIds []string, categories string, address string, parseDates string) (types.EventSearchResponse, error) {
+func SearchMarqoEvents(client *marqo.Client, query string, userLocation []float64, maxDistance float64, startTime, endTime int64, ownerIds []string, categories string, address string, parseDates string, eventSourceTypes []string, eventSourceIds []string) (types.EventSearchResponse, error) {
 	// Calculate the maximum and minimum latitude and longitude based on the user's location and maximum distance
 	maxLat := userLocation[0] + miToLat(maxDistance)
 	maxLong := userLocation[1] + miToLong(maxDistance, userLocation[0])
@@ -437,7 +443,35 @@ func SearchMarqoEvents(client *marqo.Client, query string, userLocation []float6
 		query = query + " {show matches for these categories(" + categories + ")}"
 	}
 
-	filter := fmt.Sprintf("%s %s startTime:[%v TO %v] AND long:[* TO %f] AND long:[%f TO *] AND lat:[* TO %f] AND lat:[%f TO *]", addressFilter, ownerFilter, startTime, endTime, maxLong, minLong, maxLat, minLat)
+	var eventSourceTypeFilter string
+	var eventSourceIdFilter string
+
+	// Build eventSourceType filter using Marqo IN operator
+	if len(eventSourceTypes) > 0 {
+		eventSourceTypeFilter = fmt.Sprintf("eventSourceType IN (%s) AND ", strings.Join(eventSourceTypes, ", "))
+	} else {
+		eventSourceTypeFilter = fmt.Sprintf("eventSourceType IN (%s) AND ", strings.Join(helpers.DEFAULT_SEARCHABLE_EVENT_SOURCE_TYPES, ", "))
+	}
+
+	// Build eventSourceId filter using Marqo IN operator
+	if len(eventSourceIds) > 0 {
+		eventSourceIdFilter = fmt.Sprintf("eventSourceId IN (%s) AND ", strings.Join(eventSourceIds, ", "))
+	}
+
+	// Update the filter string construction to include the new filters
+	filter := fmt.Sprintf("%s %s %s %s startTime:[%v TO %v] AND long:[* TO %f] AND long:[%f TO *] AND lat:[* TO %f] AND lat:[%f TO *]",
+		addressFilter,
+		ownerFilter,
+		eventSourceTypeFilter,
+		eventSourceIdFilter,
+		startTime,
+		endTime,
+		maxLong,
+		minLong,
+		maxLat,
+		minLat,
+	)
+
 	indexName := GetMarqoIndexName()
 
 	searchRequest := marqo.SearchRequest{
@@ -692,18 +726,20 @@ func NormalizeMarqoDocOrSearchRes(doc map[string]interface{}) (event *types.Even
 	startTimeInt := int64(startTimeFloat)
 
 	event = &types.Event{
-		Id:             getValue[string](doc, "_id"),
-		EventOwners:    getStringSlice(doc, "eventOwners"),
-		EventOwnerName: getValue[string](doc, "eventOwnerName"),
-		Name:           getValue[string](doc, "name"),
-		Description:    getValue[string](doc, "description"),
-		StartTime:      startTimeInt,
-		Address:        getValue[string](doc, "address"),
-		Lat:            getValue[float64](doc, "lat"),
-		Long:           getValue[float64](doc, "long"),
-		Timezone:       getValue[string](doc, "timezone"),
-		Categories:     getStringSlice(doc, "categories"),
-		Tags:           getStringSlice(doc, "tags"),
+		Id:              getValue[string](doc, "_id"),
+		EventOwners:     getStringSlice(doc, "eventOwners"),
+		EventOwnerName:  getValue[string](doc, "eventOwnerName"),
+		EventSourceId:   getValue[string](doc, "eventSourceId"),
+		EventSourceType: getValue[string](doc, "eventSourceType"),
+		Name:            getValue[string](doc, "name"),
+		Description:     getValue[string](doc, "description"),
+		StartTime:       startTimeInt,
+		Address:         getValue[string](doc, "address"),
+		Lat:             getValue[float64](doc, "lat"),
+		Long:            getValue[float64](doc, "long"),
+		Timezone:        getValue[string](doc, "timezone"),
+		Categories:      getStringSlice(doc, "categories"),
+		Tags:            getStringSlice(doc, "tags"),
 	}
 
 	// Handle optional fields
@@ -715,6 +751,16 @@ func NormalizeMarqoDocOrSearchRes(doc map[string]interface{}) (event *types.Even
 			if v := getValue[*float64](doc, "endTime"); v != nil {
 				endTime := int64(*v)
 				event.EndTime = endTime
+			}
+		}},
+		{"eventSourceType", func() {
+			if v := getValue[string](doc, "eventSourceType"); v != "" {
+				event.EventSourceType = v
+			}
+		}},
+		{"eventSourceId", func() {
+			if v := getValue[string](doc, "eventSourceId"); v != "" {
+				event.EventSourceId = v
 			}
 		}},
 		{"startingPrice", func() {

--- a/functions/gateway/services/marqo_service.go
+++ b/functions/gateway/services/marqo_service.go
@@ -423,7 +423,7 @@ func SearchMarqoEvents(client *marqo.Client, query string, userLocation []float6
 	// Search for events based on the query
 	searchMethod := "HYBRID"
 	// TODO: parameterize this
-	limit := 50
+	limit := 100
 
 	var ownerFilter string
 	if len(ownerIds) > 0 {

--- a/functions/gateway/services/marqo_service_test.go
+++ b/functions/gateway/services/marqo_service_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/meetnearme/api/functions/gateway/types"
 )
 
-func TestGetMarqoClient(t *testing.T){
+func TestGetMarqoClient(t *testing.T) {
 	os.Setenv("GO_ENV", helpers.GO_TEST_ENV)
 	defer os.Unsetenv("GO_ENV")
 
@@ -52,17 +52,15 @@ func TestGetMarqoClient(t *testing.T){
 		response := map[string]interface{}{
 			"results": []map[string]interface{}{
 				{
-					"_id":          eventId,
-					"eventOwners": []interface{}{"789"},
+					"_id":            eventId,
+					"eventOwners":    []interface{}{"789"},
 					"eventOwnerName": "Event Host Test",
-					"name":        "Test Event",
-					"description": "This is a test event",
+					"name":           "Test Event",
+					"description":    "This is a test event",
 				},
 			},
 		}
 		responseBytes, err := json.Marshal(response)
-
-
 
 		if err != nil {
 			http.Error(w, "Failed to marshal response", http.StatusInternalServerError)
@@ -131,21 +129,21 @@ func TestBulkUpsertEventToMarqo(t *testing.T) {
 
 		// Mock the response
 		response := &marqo.UpsertDocumentsResponse{
-			Errors: false,
+			Errors:    false,
 			IndexName: "mock-events-search",
 			Items: []marqo.Item{
 				{
-					ID: "123",
+					ID:     "123",
 					Result: "",
 					Status: 200,
 				},
 				{
-					ID: "456",
+					ID:     "456",
 					Result: "",
 					Status: 200,
 				},
 				{
-					ID: "789",
+					ID:     "789",
 					Result: "",
 					Status: 200,
 				},
@@ -194,37 +192,37 @@ func TestBulkUpsertEventToMarqo(t *testing.T) {
 			name: "Multiple valid events",
 			events: []types.Event{
 				{
-					EventOwners: []string{"123"},
+					EventOwners:    []string{"123"},
 					EventOwnerName: "Event Host Test Name",
-					Name:        "Test Event 1",
-					Description: "A test event 1",
-					StartTime:   startTime1,
-					Address:     "123 Test St",
-					Lat:         51.5074,
-					Long:        -0.1278,
-					Timezone:    "America/New_York",
+					Name:           "Test Event 1",
+					Description:    "A test event 1",
+					StartTime:      startTime1,
+					Address:        "123 Test St",
+					Lat:            51.5074,
+					Long:           -0.1278,
+					Timezone:       "America/New_York",
 				},
 				{
-					EventOwners: []string{"456"},
+					EventOwners:    []string{"456"},
 					EventOwnerName: "Event Host Test Name",
-					Name:        "Test Event 2",
-					Description: "A test event 2",
-					StartTime:   startTime2,
-					Address:     "456 Test Ave",
-					Lat:         40.7128,
-					Long:        -74.0060,
-					Timezone:    "America/New_York",
+					Name:           "Test Event 2",
+					Description:    "A test event 2",
+					StartTime:      startTime2,
+					Address:        "456 Test Ave",
+					Lat:            40.7128,
+					Long:           -74.0060,
+					Timezone:       "America/New_York",
 				},
 				{
-					EventOwners: []string{"789"},
+					EventOwners:    []string{"789"},
 					EventOwnerName: "Event Host Test Name",
-					Name:        "Test Event 3",
-					Description: "A test event 3",
-					StartTime:   startTime3,
-					Address:     "789 Test Blvd",
-					Lat:         34.0522,
-					Long:        -118.2437,
-					Timezone:    "America/New_York",
+					Name:           "Test Event 3",
+					Description:    "A test event 3",
+					StartTime:      startTime3,
+					Address:        "789 Test Blvd",
+					Lat:            34.0522,
+					Long:           -118.2437,
+					Timezone:       "America/New_York",
 				},
 			},
 		},
@@ -298,18 +296,18 @@ func TestSearchMarqoEvents(t *testing.T) {
 		response := map[string]interface{}{
 			"hits": []map[string]interface{}{
 				{
-					"_id":         "123",
-					"eventOwners": []interface{}{"789"},
+					"_id":            "123",
+					"eventOwners":    []interface{}{"789"},
 					"eventOwnerName": "First Event Host Test",
-					"name":        "First Test Event",
-					"description": "Description of the first event",
+					"name":           "First Test Event",
+					"description":    "Description of the first event",
 				},
 				{
-					"_id":         "456",
-					"eventOwners": []interface{}{"012"},
+					"_id":            "456",
+					"eventOwners":    []interface{}{"012"},
 					"eventOwnerName": "Second Event Host Test",
-					"name":        "Second Test Event",
-					"description": "Description of the second event",
+					"name":           "Second Test Event",
+					"description":    "Description of the second event",
 				},
 			},
 			"query": decodedQuery,
@@ -353,11 +351,11 @@ func TestSearchMarqoEvents(t *testing.T) {
 			expectedQuery:  "keywords: { test search }",
 			userLocation:   []float64{51.5074, -0.1278},
 			maxDistance:    10000,
-			startTime: 			time.Now().Unix(),
-			endTime:        time.Now().AddDate(1,0,0).Unix(),
+			startTime:      time.Now().Unix(),
+			endTime:        time.Now().AddDate(1, 0, 0).Unix(),
 			ownerIds:       []string{},
 			categories:     string(""),
-			address:				string(""),
+			address:        string(""),
 			expectedEvents: 2,
 			expectedError:  false,
 		},
@@ -367,11 +365,11 @@ func TestSearchMarqoEvents(t *testing.T) {
 			expectedQuery:  "",
 			userLocation:   []float64{51.5074, -0.1278},
 			maxDistance:    10000,
-			startTime: 			time.Now().Unix(),
-			endTime:        time.Now().AddDate(1,0,0).Unix(),
+			startTime:      time.Now().Unix(),
+			endTime:        time.Now().AddDate(1, 0, 0).Unix(),
 			ownerIds:       []string{},
 			categories:     string(""),
-			address:				string(""),
+			address:        string(""),
 			expectedEvents: 2,
 			expectedError:  false,
 		},
@@ -385,7 +383,20 @@ func TestSearchMarqoEvents(t *testing.T) {
 			}
 
 			// TODO: add meaningful test with categories
-			result, err := SearchMarqoEvents(client, tt.query, tt.userLocation, tt.maxDistance, tt.startTime, tt.endTime, tt.ownerIds, tt.categories, tt.address, "0")
+			result, err := SearchMarqoEvents(
+				client,
+				tt.query,
+				tt.userLocation,
+				tt.maxDistance,
+				tt.startTime,
+				tt.endTime,
+				tt.ownerIds,
+				tt.categories,
+				tt.address,
+				"0",
+				[]string{helpers.DEFAULT_SEARCHABLE_EVENT_SOURCE_TYPES[0]},
+				[]string{},
+			)
 
 			if tt.expectedError && err == nil {
 				t.Errorf("Expected an error, but got none")
@@ -450,12 +461,12 @@ func TestGetMarqoEventByID(t *testing.T) {
 		response := map[string]interface{}{
 			"results": []map[string]interface{}{
 				{
-					"_id":          testEventID,
-					"startTime":   testEventStartTime,
-					"eventOwners": []interface{}{testEventOwnerID},
+					"_id":            testEventID,
+					"startTime":      testEventStartTime,
+					"eventOwners":    []interface{}{testEventOwnerID},
 					"eventOwnerName": "Event Host Test",
-					"name":        testEventName,
-					"description": testEventDescription,
+					"name":           testEventName,
+					"description":    testEventDescription,
 				},
 			},
 		}
@@ -566,20 +577,20 @@ func TestBulkGetMarqoEventByID(t *testing.T) {
 		response := map[string]interface{}{
 			"results": []map[string]interface{}{
 				{
-					"_id":          testEventID1,
-					"startTime":    testEventStartTime1,
-					"eventOwners":  []interface{}{testEventOwnerID1},
+					"_id":            testEventID1,
+					"startTime":      testEventStartTime1,
+					"eventOwners":    []interface{}{testEventOwnerID1},
 					"eventOwnerName": testEventOwnerName1,
-					"name":         testEventName1,
-					"description":  testEventDescription1,
+					"name":           testEventName1,
+					"description":    testEventDescription1,
 				},
 				{
-					"_id":          testEventID2,
-					"startTime":    testEventStartTime2,
-					"eventOwners":  []interface{}{testEventOwnerID2},
+					"_id":            testEventID2,
+					"startTime":      testEventStartTime2,
+					"eventOwners":    []interface{}{testEventOwnerID2},
 					"eventOwnerName": testEventOwnerName2,
-					"name":         testEventName2,
-					"description":  testEventDescription2,
+					"name":           testEventName2,
+					"description":    testEventDescription2,
 				},
 			},
 		}

--- a/functions/gateway/templates/components/navbar.templ
+++ b/functions/gateway/templates/components/navbar.templ
@@ -407,7 +407,7 @@ templ Navbar(userInfo helpers.UserInfo, subnavTabs []string, event types.Event) 
 			function getCartRegistrationState() {
 				return {
 					registrationFields: null,
-    			registrationFieldsLoaded: false,
+					registrationFieldsLoaded: false,
 					purchasables: null,
 					purchasablesLoaded: false,
 					purchaseComplete: false,
@@ -420,6 +420,7 @@ templ Navbar(userInfo helpers.UserInfo, subnavTabs []string, event types.Event) 
 					hasPurchasable: document.querySelector('#registration-purchasables').getAttribute('data-has-purchasables') === "true",
 					eventSourceId: document.querySelector('#registration-purchasables').getAttribute('data-event-source-id'),
 					eventSourceType: document.querySelector('#registration-purchasables').getAttribute('data-event-source-type'),
+					userId: document.querySelector('#registration-purchasables').getAttribute('data-user-id'),
 					async init() {
 							const promises = [];
 							if (this.hasRegistration) {
@@ -439,7 +440,7 @@ templ Navbar(userInfo helpers.UserInfo, subnavTabs []string, event types.Event) 
 					},
 					async fetchRegistrationFields() {
 							try {
-                  const response = await fetch(`/api/registration-fields/${ this.eventSourceId && this.eventSourceType === 'EVS' ? this.eventSourceId : this.eventId}`);
+									const response = await fetch(`/api/registration-fields/${ this.eventSourceId && this.eventSourceType === 'EVS' ? this.eventSourceId : this.eventId}`);
 									const json = await response.json();
 									this.registrationFields = json?.fields;
 									this.registrationFieldsLoaded = true;
@@ -488,24 +489,38 @@ templ Navbar(userInfo helpers.UserInfo, subnavTabs []string, event types.Event) 
 									})
 									.filter(item => item !== null);
 
-				        const total = purchasedItems.reduce((sum, item) => sum + (item.cost * item.quantity), 0);
+								const total = purchasedItems.reduce((sum, item) => sum + (item.cost * item.quantity), 0);
 								console.log(`purchasedItems:`, purchasedItems)
 								// TODO: do we need the total?
 								console.log(`total`, total)
 
-								const response = await fetch(`/api/checkout/${this.eventId}`, {
-									method: 'POST',
-									headers: {
-											'Content-Type': 'application/json'
-									},
-									body: JSON.stringify({
-										status: "PENDING",
-										event_name: this.eventName,
-										purchased_items: purchasedItems,
-										total: total,
-										currency: "USD"
-									})
-								});
+								let response;
+								if (total > 0) {
+									response = await fetch(`/api/checkout/${this.eventId}`, {
+										method: 'POST',
+										headers: {
+												'Content-Type': 'application/json'
+										},
+										body: JSON.stringify({
+											status: "PENDING",
+											event_name: this.eventName,
+											purchased_items: purchasedItems,
+											total: total,
+											currency: "USD"
+										})
+									});
+								} else {
+									const regResponses = purchasedItems.flatMap(item => item.reg_responses)
+									response = await fetch(`/api/registrations/${this.eventId}/${this.userId}`, {
+										method: 'PUT',
+										headers: {
+												'Content-Type': 'application/json'
+										},
+										body: JSON.stringify({
+											responses: regResponses,
+										})
+									});
+								}
 								if (response.status === 401) {
 									this.errors['checkout'] = `You must be logged in to purchase tickets. <br /><a class="btn mt-4 btn-sm" href="/auth/login?redirect=/event/${this.eventId}">Register or Login now</a>`;
 									this.reqInFlight = false;
@@ -517,6 +532,8 @@ templ Navbar(userInfo helpers.UserInfo, subnavTabs []string, event types.Event) 
 								this.purchaseComplete = true;
 								if (json?.stripe_checkout_url) {
 										window.location.href = json.stripe_checkout_url;
+								} else if (total <= 0) {
+									window.location.href = window.location.origin + window.location.pathname + "?checkout=registered";
 								} else {
 									this.errors['checkout'] = "Unable to proceed to checkout. Please try again.";
 								}
@@ -601,8 +618,8 @@ templ Navbar(userInfo helpers.UserInfo, subnavTabs []string, event types.Event) 
 							})
 						}
 						if (Object.keys(this.errors).length === 0) {
-        			this.submitPurchase()
-    				}
+							this.submitPurchase()
+						}
 					},
 					handleCounterClick(self, direction, purchName, idx) {
 						const inputElement = self.closest('.counter-click-container').querySelector('input[type="number"]');

--- a/functions/gateway/templates/components/navbar.templ
+++ b/functions/gateway/templates/components/navbar.templ
@@ -403,7 +403,7 @@ templ Navbar(userInfo helpers.UserInfo, subnavTabs []string, event types.Event) 
 			</div>
 		</div>
 	</div>
-	<script id="registration-purchasables" data-has-registration={ fmt.Sprint(event.HasRegistrationFields) } data-has-purchasables={ fmt.Sprint(event.HasPurchasable) } data-event-id={ event.Id } data-event-name={ event.Name } data-user-id={ userInfo.Sub }>
+	<script id="registration-purchasables" data-has-registration={ fmt.Sprint(event.HasRegistrationFields) } data-has-purchasables={ fmt.Sprint(event.HasPurchasable) } data-event-id={ event.Id } data-event-source-id={ event.EventSourceId } data-event-source-type={ event.EventSourceType } data-event-name={ event.Name } data-user-id={ userInfo.Sub }>
 			function getCartRegistrationState() {
 				return {
 					registrationFields: null,
@@ -418,6 +418,8 @@ templ Navbar(userInfo helpers.UserInfo, subnavTabs []string, event types.Event) 
 					eventName: document.querySelector('#registration-purchasables').getAttribute('data-event-name'),
 					hasRegistration: document.querySelector('#registration-purchasables').getAttribute('data-has-registration') === "true",
 					hasPurchasable: document.querySelector('#registration-purchasables').getAttribute('data-has-purchasables') === "true",
+					eventSourceId: document.querySelector('#registration-purchasables').getAttribute('data-event-source-id'),
+					eventSourceType: document.querySelector('#registration-purchasables').getAttribute('data-event-source-type'),
 					async init() {
 							const promises = [];
 							if (this.hasRegistration) {
@@ -437,7 +439,7 @@ templ Navbar(userInfo helpers.UserInfo, subnavTabs []string, event types.Event) 
 					},
 					async fetchRegistrationFields() {
 							try {
-									const response = await fetch(`/api/registration-fields/${this.eventId}`);
+                  const response = await fetch(`/api/registration-fields/${ this.eventSourceId && this.eventSourceType === 'EVS' ? this.eventSourceId : this.eventId}`);
 									const json = await response.json();
 									this.registrationFields = json?.fields;
 									this.registrationFieldsLoaded = true;
@@ -527,10 +529,9 @@ templ Navbar(userInfo helpers.UserInfo, subnavTabs []string, event types.Event) 
 					},
 					async fetchPurchasables() {
 							try {
-									const response = await fetch(`/api/purchasables/${this.eventId}`);
+									const response = await fetch(`/api/purchasables/${ this.eventSourceId && this.eventSourceType === 'EVS' ? this.eventSourceId : this.eventId}`);
 									const json = await response.json();
 									this.purchasables = json?.purchasable_items;
-									console.log('purchasables', this.purchasables)
 									this.purchasablesLoaded = true;
 							} catch (error) {
 									console.error("Error fetching registration fields:", error);

--- a/functions/gateway/templates/components/navbar.templ
+++ b/functions/gateway/templates/components/navbar.templ
@@ -42,51 +42,72 @@ templ NavListItems(userInfo helpers.UserInfo) {
 
 templ PurchasableItemsList(hasRegistrationFields bool) {
 	<template x-for="(purch, index) in purchasables" :key="index">
-		<label class="form-control w-full max-w-xs">
-			<span class="label-text text-lg mt-5" x-text="purch.name"></span>
-			<span class="label-text text-lg mt-5" x-text="`\$${(purch.cost / 100)}`"></span>
-			<div>
-				<div class="relative flex items-center max-w-[8rem] mb-5 mt-3 counter-click-container">
-					<button @click="handleCounterClick($event.target, 'down', purch.name, index)" type="button" id="decrement-button" data-input-counter-decrement="quantity-input" class="bg-gray-700 hover:bg-gray-600 border-gray-600 border rounded-s-lg p-3 h-11 focus:ring-gray-700 focus:ring-2 focus:outline-none">
-						<svg class="w-3 h-3 text-white" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 18 2">
-							<path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M1 1h16"></path>
-						</svg>
-					</button>
-					<input x-model="formData[`${purch.name}_count_${index}`]" type="number" id="quantity-input" data-input-counter aria-describedby="helper-text-explanation" class="input-number-counter bg-gray-50 border-x-0 border-gray-300 h-11 text-center text-gray-900 text-sm input-bordered input-primary bg-gray-700 border-gray-600 placeholder-gray-400 text-white" placeholder="" required/>
-					<button @click="handleCounterClick($event.target, 'up', purch.name, index)" type="button" id="increment-button" data-input-counter-increment="quantity-input" class="bg-gray-700 hover:bg-gray-600 border-gray-600 border rounded-e-lg p-3 h-11 focus:ring-gray-700 focus:ring-2 focus:outline-none">
-						<svg class="w-3 h-3 text-white" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 18 18">
-							<path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 1v16M1 9h16"></path>
-						</svg>
-					</button>
-				</div>
-				// show per-purchasables item registration fields if needed
-				if hasRegistrationFields {
-					<template
-						x-if="purch.registration_fields_copy?.length"
-					>
+		<template x-if="purch.inventory > 0 && (new Date(purch.expires_on) > new Date() || !purch.expires_on)">
+			<label class="form-control w-full max-w-xs">
+				<span class="label-text text-lg mt-5" x-text="purch.name"></span>
+				<template x-if="purch.expires_on">
+					<div class="alert alert-info p-2 mt-2">
+						<span>Available until</span>
+						<strong>
+							<span
+								class="text-md"
+								x-text="new Date(purch.expires_on).toLocaleString('en-US', {
+							year: 'numeric',
+							month: 'short',
+							day: 'numeric',
+							hour: 'numeric',
+							minute: '2-digit',
+							hour12: true,
+							timeZone: eventTimezone
+						}).replace(',', ' @')"
+							></span>
+						</strong>
+					</div>
+				</template>
+				<span class="label-text text-lg mt-5" x-text="`\$${(purch.cost / 100)}`"></span>
+				<div>
+					<div class="relative flex items-center max-w-[8rem] mb-5 mt-3 counter-click-container">
+						<button @click="handleCounterClick($event.target, 'down', purch.name, index)" type="button" id="decrement-button" data-input-counter-decrement="quantity-input" class="bg-gray-700 hover:bg-gray-600 border-gray-600 border rounded-s-lg p-3 h-11 focus:ring-gray-700 focus:ring-2 focus:outline-none">
+							<svg class="w-3 h-3 text-white" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 18 2">
+								<path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M1 1h16"></path>
+							</svg>
+						</button>
+						<input x-model="formData[`${purch.name}_count_${index}`]" type="number" id="quantity-input" data-input-counter aria-describedby="helper-text-explanation" class="input-number-counter bg-gray-50 border-x-0 border-gray-300 h-11 text-center text-gray-900 text-sm input-bordered input-primary bg-gray-700 border-gray-600 placeholder-gray-400 text-white" placeholder="" required/>
+						<button @click="handleCounterClick($event.target, 'up', purch.name, index)" type="button" id="increment-button" data-input-counter-increment="quantity-input" class="bg-gray-700 hover:bg-gray-600 border-gray-600 border rounded-e-lg p-3 h-11 focus:ring-gray-700 focus:ring-2 focus:outline-none">
+							<svg class="w-3 h-3 text-white" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 18 18">
+								<path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 1v16M1 9h16"></path>
+							</svg>
+						</button>
+					</div>
+					// show per-purchasables item registration fields if needed
+					if hasRegistrationFields {
 						<template
-							x-for="(field, idx) in purch.registration_fields_copy"
-							:key="field.name"
+							x-if="purch.registration_fields_copy?.length"
 						>
-							<div class="flex-none">
-								<label class="form-control w-full max-w-xs">
-									<template x-if="parseInt(formData[`${purch.name}_count_${index}`]) > 0 && field.type !== 'checkbox' ">
-										<div class="label">
-											<span class="label-text" x-text="field.description"></span>
-										</div>
-									</template>
-									<template x-for="i in parseInt(formData[`${purch.name}_count_${index}`] || 0)" :key="i">
-										<div class="my-2" x-data="{ _index: `purch_${eventId}_${purch.name}_field_${field.name}_count_${i}` }">
-											@RegistrationFieldsByType(true)
-										</div>
-									</template>
-								</label>
-							</div>
+							<template
+								x-for="(field, idx) in purch.registration_fields_copy"
+								:key="field.name"
+							>
+								<div class="flex-none">
+									<label class="form-control w-full max-w-xs">
+										<template x-if="parseInt(formData[`${purch.name}_count_${index}`]) > 0 && field.type !== 'checkbox' ">
+											<div class="label">
+												<span class="label-text" x-text="field.description"></span>
+											</div>
+										</template>
+										<template x-for="i in parseInt(formData[`${purch.name}_count_${index}`] || 0)" :key="i">
+											<div class="my-2" x-data="{ _index: `purch_${eventId}_${purch.name}_field_${field.name}_count_${i}` }">
+												@RegistrationFieldsByType(true)
+											</div>
+										</template>
+									</label>
+								</div>
+							</template>
 						</template>
-					</template>
-				}
-			</div>
-		</label>
+					}
+				</div>
+			</label>
+		</template>
 	</template>
 }
 
@@ -403,7 +424,7 @@ templ Navbar(userInfo helpers.UserInfo, subnavTabs []string, event types.Event) 
 			</div>
 		</div>
 	</div>
-	<script id="registration-purchasables" data-has-registration={ fmt.Sprint(event.HasRegistrationFields) } data-has-purchasables={ fmt.Sprint(event.HasPurchasable) } data-event-id={ event.Id } data-event-source-id={ event.EventSourceId } data-event-source-type={ event.EventSourceType } data-event-name={ event.Name } data-user-id={ userInfo.Sub }>
+	<script id="registration-purchasables" data-has-registration={ fmt.Sprint(event.HasRegistrationFields) } data-has-purchasables={ fmt.Sprint(event.HasPurchasable) } data-event-id={ event.Id } data-event-source-id={ event.EventSourceId } data-event-source-type={ event.EventSourceType } data-event-name={ event.Name } data-event-timezone={ event.Timezone } data-user-id={ userInfo.Sub }>
 			function getCartRegistrationState() {
 				return {
 					registrationFields: null,
@@ -416,6 +437,7 @@ templ Navbar(userInfo helpers.UserInfo, subnavTabs []string, event types.Event) 
 					errors: {},
 					eventId: document.querySelector('#registration-purchasables').getAttribute('data-event-id'),
 					eventName: document.querySelector('#registration-purchasables').getAttribute('data-event-name'),
+					eventTimezone: document.querySelector('#registration-purchasables').getAttribute('data-event-timezone'),
 					hasRegistration: document.querySelector('#registration-purchasables').getAttribute('data-has-registration') === "true",
 					hasPurchasable: document.querySelector('#registration-purchasables').getAttribute('data-has-purchasables') === "true",
 					eventSourceId: document.querySelector('#registration-purchasables').getAttribute('data-event-source-id'),
@@ -431,6 +453,7 @@ templ Navbar(userInfo helpers.UserInfo, subnavTabs []string, event types.Event) 
 							}
 							await Promise.all(promises);
 							this.checkAndMoveRegistrationFields();
+              console.log('this.purchasables', this.purchasables)
 					},
 					checkAndMoveRegistrationFields() {
 							if (this.hasRegistration && this.hasPurchasable &&
@@ -535,7 +558,11 @@ templ Navbar(userInfo helpers.UserInfo, subnavTabs []string, event types.Event) 
 								} else if (total <= 0) {
 									window.location.href = window.location.origin + window.location.pathname + "?checkout=registered";
 								} else {
-									this.errors['checkout'] = "Unable to proceed to checkout. Please try again.";
+                  if (json?.error?.message) {
+                    this.errors['checkout'] = json.error.message;
+                  } else {
+                    this.errors['checkout'] = "Unable to proceed to checkout. Please try again.";
+                  }
 								}
 							} catch (error) {
 									console.error("Error submitting checkout:", error);

--- a/functions/gateway/templates/components/navbar.templ
+++ b/functions/gateway/templates/components/navbar.templ
@@ -43,10 +43,10 @@ templ NavListItems(userInfo helpers.UserInfo) {
 templ PurchasableItemsList(hasRegistrationFields bool) {
 	<template x-for="(purch, index) in purchasables" :key="index">
 		<template x-if="purch.inventory > 0 && (new Date(purch.expires_on) > new Date() || !purch.expires_on)">
-			<label class="form-control w-full max-w-xs">
+			<label class="form-control w-full bg-base-200 card mb-5 p-2 px-4">
 				<span class="label-text text-lg mt-5" x-text="purch.name"></span>
 				<template x-if="purch.expires_on">
-					<div class="alert alert-info p-2 mt-2">
+					<div class="alert alert-info p-2 mt-2 w-fit">
 						<span>Available until</span>
 						<strong>
 							<span
@@ -89,7 +89,7 @@ templ PurchasableItemsList(hasRegistrationFields bool) {
 								:key="field.name"
 							>
 								<div class="flex-none">
-									<label class="form-control w-full max-w-xs">
+									<label class="form-control w-full">
 										<template x-if="parseInt(formData[`${purch.name}_count_${index}`]) > 0 && field.type !== 'checkbox' ">
 											<div class="label">
 												<span class="label-text" x-text="field.description"></span>
@@ -177,7 +177,7 @@ templ RegistrationFieldsByType(nestedInPurchasable bool) {
 			:type="field.type"
 			:placeholder="field.placeholder"
 			:required="field.required"
-			class="select w-full max-w-xs select-bordered border-opacity-100"
+			class="select w-full select-bordered border-opacity-100"
 		>
 			<template x-if="!field.placeholder && field.required">
 				<option disabled selected x-text=" 'Select One' "></option>
@@ -352,7 +352,7 @@ templ Navbar(userInfo helpers.UserInfo, subnavTabs []string, event types.Event) 
 								</div>
 							</template>
 							<template x-for="(field, index) in registrationFields" :key="index">
-								<label class="form-control w-full max-w-xs" x-data="{ idx: '' }">
+								<label class="form-control w-full" x-data="{ idx: '' }">
 									<template x-if="field?.type !== 'checkbox' ">
 										<div class="label">
 											<span class="label-text" x-text="field.description"></span>

--- a/functions/gateway/templates/pages/event_details.templ
+++ b/functions/gateway/templates/pages/event_details.templ
@@ -77,6 +77,11 @@ templ EventDetailsPage(event types.Event, checkoutParamVal string, canEdit bool)
 					<br/>
 					<br/>
 				}
+				if checkoutParamVal == "registered" {
+					@partials.SuccessBannerHTML("Thanks for your interest, can't wait to see you at the event!")
+					<br/>
+					<br/>
+				}
 				@IconLeftSection("Host", event.EventOwnerName, "community", `/?owners=`+event.EventOwners[0], false, event)
 				<br/>
 				@IconLeftSection("Venue", event.Address, "location", "/?address="+event.Address, true, event)

--- a/functions/gateway/templates/pages/event_details.templ
+++ b/functions/gateway/templates/pages/event_details.templ
@@ -71,12 +71,12 @@ templ EventDetailsPage(event types.Event, checkoutParamVal string, canEdit bool)
 				<br/>
 				@IconLeftSection("Venue", event.Address, "location", "/?address="+event.Address, true, event)
 				<br/>
-				if helpers.GetDateOrShowNone(event.StartTime) != "" {
-					@IconLeftSection("Date", helpers.GetDateOrShowNone(event.StartTime), "calendar", "", false, event)
+				if helpers.GetDateOrShowNone(event.StartTime, event.Timezone) != "" {
+					@IconLeftSection("Date", helpers.GetDateOrShowNone(event.StartTime, event.Timezone), "calendar")
 				}
 				<br/>
-				if helpers.GetTimeOrShowNone(event.StartTime) != "" {
-					@IconLeftSection("Time", helpers.GetTimeOrShowNone(event.StartTime), "clock", "", false, event)
+				if helpers.GetTimeOrShowNone(event.StartTime, event.Timezone) != "" {
+					@IconLeftSection("Time", helpers.GetTimeOrShowNone(event.StartTime, event.Timezone), "clock")
 				}
 				<br/>
 				if event.StartingPrice > 0 {

--- a/functions/gateway/templates/pages/event_details.templ
+++ b/functions/gateway/templates/pages/event_details.templ
@@ -72,11 +72,11 @@ templ EventDetailsPage(event types.Event, checkoutParamVal string, canEdit bool)
 				@IconLeftSection("Venue", event.Address, "location", "/?address="+event.Address, true, event)
 				<br/>
 				if helpers.GetDateOrShowNone(event.StartTime, event.Timezone) != "" {
-					@IconLeftSection("Date", helpers.GetDateOrShowNone(event.StartTime, event.Timezone), "calendar")
+					@IconLeftSection("Date", helpers.GetDateOrShowNone(event.StartTime, event.Timezone), "calendar", "", false, event)
 				}
 				<br/>
 				if helpers.GetTimeOrShowNone(event.StartTime, event.Timezone) != "" {
-					@IconLeftSection("Time", helpers.GetTimeOrShowNone(event.StartTime, event.Timezone), "clock")
+					@IconLeftSection("Time", helpers.GetTimeOrShowNone(event.StartTime, event.Timezone), "clock", "", false, event)
 				}
 				<br/>
 				if event.StartingPrice > 0 {

--- a/functions/gateway/templates/pages/event_details.templ
+++ b/functions/gateway/templates/pages/event_details.templ
@@ -60,6 +60,16 @@ templ EventDetailsPage(event types.Event, checkoutParamVal string, canEdit bool)
 				<div class="alert alert-success">You are an editor for this event. <a class="btn btn-sm" href={ templ.URL("/admin/event/edit/" + event.Id) }>Edit Event</a></div>
 			}
 			<h2 class="text-3xl mt-2">{ event.Name }</h2>
+			if event.EventSourceType == "SLF_EVS" {
+				<h3 class="text-xl mt-2">Event Series</h3>
+				<div
+					hx-get={ "/api/html/events?list_mode=DATES_ONLY&end_time=2099-10-18T10:00:00Z&radius=5000&event_source_ids=" + event.Id }
+					hx-trigger="load"
+					hx-swap="outerHTML"
+				>
+					<div class="mt-2"><span class="loading loading-spinner loading-md text-primary"></span></div>
+				</div>
+			}
 			<br/>
 			<p>
 				if checkoutParamVal == "success" {
@@ -71,14 +81,16 @@ templ EventDetailsPage(event types.Event, checkoutParamVal string, canEdit bool)
 				<br/>
 				@IconLeftSection("Venue", event.Address, "location", "/?address="+event.Address, true, event)
 				<br/>
-				if helpers.GetDateOrShowNone(event.StartTime, event.Timezone) != "" {
-					@IconLeftSection("Date", helpers.GetDateOrShowNone(event.StartTime, event.Timezone), "calendar", "", false, event)
+				if event.EventSourceType != "SLF_EVS" {
+					if helpers.GetDateOrShowNone(event.StartTime, event.Timezone) != "" {
+						@IconLeftSection("Date", helpers.GetDateOrShowNone(event.StartTime, event.Timezone), "calendar", "", false, event)
+					}
+					<br/>
+					if helpers.GetTimeOrShowNone(event.StartTime, event.Timezone) != "" {
+						@IconLeftSection("Time", helpers.GetTimeOrShowNone(event.StartTime, event.Timezone), "clock", "", false, event)
+					}
+					<br/>
 				}
-				<br/>
-				if helpers.GetTimeOrShowNone(event.StartTime, event.Timezone) != "" {
-					@IconLeftSection("Time", helpers.GetTimeOrShowNone(event.StartTime, event.Timezone), "clock", "", false, event)
-				}
-				<br/>
 				if event.StartingPrice > 0 {
 					// TODO: handle basecurrency
 					@IconLeftSection("Price", "$"+fmt.Sprint(event.StartingPrice/100), "price", "", false, event)

--- a/functions/gateway/templates/pages/event_details_templ_test.go
+++ b/functions/gateway/templates/pages/event_details_templ_test.go
@@ -26,15 +26,16 @@ func TestEventDetailsPage(t *testing.T) {
 		{
 			name: "Valid event",
 			event: types.Event{
-				Id:             "123",
-				Name:           "Test Event",
-				Description:    "This is a test event",
-				Address:        "123 Test St",
-				StartTime:      validEventStartTime,
-				EventOwners:    []string{"abc-uuid"},
-				EventOwnerName: "Brians Pub",
-				Lat:            38.896305,
-				Long:           -77.023289,
+				Id:              "123",
+				Name:            "Test Event",
+				Description:     "This is a test event",
+				Address:         "123 Test St",
+				StartTime:       validEventStartTime,
+				EventOwners:     []string{"abc-uuid"},
+				EventOwnerName:  "Brians Pub",
+				EventSourceType: "SLF",
+				Lat:             38.896305,
+				Long:            -77.023289,
 			},
 			checkoutParamVal: "",
 			expected: []string{
@@ -49,17 +50,45 @@ func TestEventDetailsPage(t *testing.T) {
 			canEdit: false,
 		},
 		{
+			name: "Valid event",
+			event: types.Event{
+				Id:              "123",
+				Name:            "Karaoke Nationals",
+				Description:     "This is a test event",
+				Address:         "123 Test St",
+				StartTime:       validEventStartTime,
+				EventOwners:     []string{"abc-uuid"},
+				EventOwnerName:  "Brians Pub",
+				EventSourceType: "SLF",
+				Lat:             38.896305,
+				Long:            -77.023289,
+			},
+			checkoutParamVal: "",
+			expected: []string{
+				"Karaoke Nationals",
+				"This is a test event",
+				"123 Test St",
+				"May 1, 2099",
+				"12:00pm",
+				"abc-uuid",
+				"Brians Pub",
+				"<title>Meet Near Me - Karaoke Nationals</title>",
+			},
+			canEdit: false,
+		},
+		{
 			name: "Valid event, editor role sees edit button",
 			event: types.Event{
-				Id:             "123",
-				Name:           "Test Event",
-				Description:    "This is a test event",
-				Address:        "123 Test St",
-				StartTime:      validEventStartTime,
-				EventOwners:    []string{"abc-uuid"},
-				EventOwnerName: "Brians Pub",
-				Lat:            38.896305,
-				Long:           -77.023289,
+				Id:              "123",
+				Name:            "Test Event",
+				Description:     "This is a test event",
+				Address:         "123 Test St",
+				StartTime:       validEventStartTime,
+				EventOwners:     []string{"abc-uuid"},
+				EventOwnerName:  "Brians Pub",
+				EventSourceType: "SLF",
+				Lat:             38.896305,
+				Long:            -77.023289,
 			},
 			checkoutParamVal: "",
 			expected: []string{
@@ -89,7 +118,7 @@ func TestEventDetailsPage(t *testing.T) {
 			component := EventDetailsPage(tt.event, tt.checkoutParamVal, tt.canEdit)
 
 			// Wrap the component with Layout
-			layoutTemplate := Layout(helpers.SitePages["events"], helpers.UserInfo{}, component, types.Event{})
+			layoutTemplate := Layout(helpers.SitePages["event-detail"], helpers.UserInfo{}, component, tt.event)
 
 			// Render the component to a string
 			var buf bytes.Buffer

--- a/functions/gateway/templates/pages/home.templ
+++ b/functions/gateway/templates/pages/home.templ
@@ -5,38 +5,85 @@ import (
 	"github.com/meetnearme/api/functions/gateway/helpers"
 	"github.com/meetnearme/api/functions/gateway/types"
 	"log"
+	"strconv"
 )
 
-templ EventsInner(events []types.Event) {
-	if (len(events) < 1) {
-		<p class="text-md md:text-lg text-center mt-5">
-			No events found, try changing your filters like location, date, and time, or
-			<br/>
-			<br/>
-			<a class="btn btn-primary btn-small" href="/?radius=500">Expand Your Search</a>
-		</p>
-	} else {
-		for _, ev := range events {
-			<div class="flex w-full relative pb-24 md:pb-4">
-				<a data-umami-event={ "event-list-clk" } data-umami-event-event-id={ ev.Id } class="flex w-full" href={ templ.URL("/event/" + ev.Id) }>
-					<img
-						loading="lazy"
-						src={ helpers.GetImgUrlFromHash(ev) }
-						alt=""
-						class="object-cover w-full aspect-[4/3] md:aspect-[16/9] opacity-50 md:opacity-30 md:hover:opacity-75 transition-all"
-					/>
-				</a>
-				<div class="flex flex-col justify-between w-full p-4 md:p-12 bg-gradient-to-t from-black/70 from-80% to-transparent absolute bottom-0 left-0">
-					<div class="mb-2">
-						<h2 class="text-2xl md:text-3xl">{ ev.Name }</h2>
-						<p class="text-sm md:text-base">{ helpers.GetDateOrShowNone(ev.StartTime, ev.Timezone) } | { helpers.GetTimeOrShowNone(ev.StartTime, ev.Timezone) } &commat; { ev.Address }</p>
-					</div>
-					<br/>
-					<a data-umami-event={ "event-list-clk" } data-umami-event-event-id={ ev.Id } href={ templ.URL("/event/" + ev.Id) } class="btn btn-primary btn-block mb-2 md:mb-3">
-						LEARN MORE
-						&rarr;
+script navigateToSlideHandler(index int) {
+    const currentIndex = parseInt(document.getElementById('current-slide-index').value);
+    const newIndex = currentIndex + index;
+    const totalSlides = document.querySelectorAll('.carousel-item').length;
+
+    // Only proceed if newIndex is within bounds (0 to totalSlides-1)
+    if (newIndex >= 0 && newIndex < totalSlides) {
+        const slide = document.getElementById(`slide-${newIndex}`);
+        if (slide) {
+            slide.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'start' });
+            document.getElementById('current-slide-index').value = newIndex;
+        }
+    }
+}
+
+templ EventsInner(events []types.Event, mode string) {
+	if mode == "DETAILED" {
+		if (len(events) < 1) {
+			<p class="text-md md:text-lg text-center mt-5">
+				No events found, try changing your filters like location, date, and time, or
+				<br/>
+				<br/>
+				<a class="btn btn-primary btn-small" href="/?radius=500">Expand Your Search</a>
+			</p>
+		} else {
+			for _, ev := range events {
+				<div class="flex w-full relative pb-24 md:pb-4">
+					<a data-umami-event={ "event-list-clk" } data-umami-event-event-id={ ev.Id } class="flex w-full" href={ templ.URL("/event/" + ev.Id) }>
+						<img
+							loading="lazy"
+							src={ helpers.GetImgUrlFromHash(ev) }
+							alt=""
+							class="object-cover w-full aspect-[4/3] md:aspect-[16/9] opacity-50 md:opacity-30 md:hover:opacity-75 transition-all"
+						/>
 					</a>
+					<div class="flex flex-col justify-between w-full p-4 md:p-12 bg-gradient-to-t from-black/70 from-80% to-transparent absolute bottom-0 left-0">
+						<div class="mb-2">
+							<h2 class="text-2xl md:text-3xl">{ ev.Name }</h2>
+							<p class="text-sm md:text-base">{ helpers.GetDateOrShowNone(ev.StartTime, ev.Timezone) } | { helpers.GetTimeOrShowNone(ev.StartTime, ev.Timezone) } &commat; { ev.Address }</p>
+						</div>
+						<br/>
+						<a data-umami-event={ "event-list-clk" } data-umami-event-event-id={ ev.Id } href={ templ.URL("/event/" + ev.Id) } class="btn btn-primary btn-block mb-2 md:mb-3">
+							LEARN MORE
+							&rarr;
+						</a>
+					</div>
 				</div>
+			}
+		}
+	}
+	if mode == "DATES_ONLY" {
+		if (len(events) < 1) {
+			<p class="text-md md:text-lg text-center mt-5">
+				This event series has no events yet.
+			</p>
+		} else {
+			<div class="carousel-container relative w-full">
+				<div class="carousel rounded-box max-w-full relative mb-4">
+					<input type="hidden" id="current-slide-index" value="0"/> <!-- Hidden input to track current slide -->
+					for idx, ev := range events {
+						<div id={ "slide-" + strconv.Itoa(idx) } class="carousel-item bg-base-200 flex-shrink-0 w-48 snap-start mr-4 last:mr-0 whitespace-nowrap">
+							<a href={ templ.URL("/event/" + ev.Id) } class="block p-4 rounded-lg">
+								<div class="text-lg font-semibold">{ helpers.GetDateOrShowNone(ev.StartTime, ev.Timezone) }</div>
+								<div class="text-md">{ helpers.GetTimeOrShowNone(ev.StartTime, ev.Timezone) }</div>
+							</a>
+						</div>
+					}
+				</div>
+				<button
+					class="btn btn-circle carousel-control-left"
+					onClick={ navigateToSlideHandler(-1) }
+				>❮</button>
+				<button
+					class="btn btn-circle carousel-control-right"
+					onClick={ navigateToSlideHandler(1) }
+				>❯</button>
 			</div>
 		}
 	}
@@ -292,7 +339,7 @@ templ HomePage(events []types.Event, cfLocation helpers.CdnLocation, latStr, lon
 				<span class="loading loading-spinner loading-lg text-primary"></span>
 			</div>
 			<div id="events-container-inner">
-				@EventsInner(events)
+				@EventsInner(events, "")
 			</div>
 		</main>
 	</div>

--- a/functions/gateway/templates/pages/home.templ
+++ b/functions/gateway/templates/pages/home.templ
@@ -19,6 +19,16 @@ script navigateToSlideHandler(index int) {
         if (slide) {
             slide.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'start' });
             document.getElementById('current-slide-index').value = newIndex;
+            if (newIndex == 0) {
+                document.getElementsByClassName('carousel-control-left')[0].classList.add('hidden');
+            } else {
+                document.getElementsByClassName('carousel-control-left')[0].classList.remove('hidden');
+            }
+            if (newIndex == totalSlides - 1) {
+                document.getElementsByClassName('carousel-control-right')[0].classList.add('hidden');
+            } else {
+                document.getElementsByClassName('carousel-control-right')[0].classList.remove('hidden');
+            }
         }
     }
 }
@@ -77,7 +87,7 @@ templ EventsInner(events []types.Event, mode string) {
 					}
 				</div>
 				<button
-					class="btn btn-circle carousel-control-left"
+					class="btn btn-circle carousel-control-left hidden"
 					onClick={ navigateToSlideHandler(-1) }
 				>❮</button>
 				<button

--- a/functions/gateway/templates/pages/home.templ
+++ b/functions/gateway/templates/pages/home.templ
@@ -34,7 +34,7 @@ script navigateToSlideHandler(index int) {
 }
 
 templ EventsInner(events []types.Event, mode string) {
-	if mode == "DETAILED" {
+	if mode == "DETAILED" || mode == "" {
 		if (len(events) < 1) {
 			<p class="text-md md:text-lg text-center mt-5">
 				No events found, try changing your filters like location, date, and time, or

--- a/functions/gateway/templates/pages/home.templ
+++ b/functions/gateway/templates/pages/home.templ
@@ -29,7 +29,7 @@ templ EventsInner(events []types.Event) {
 				<div class="flex flex-col justify-between w-full p-4 md:p-12 bg-gradient-to-t from-black/70 from-80% to-transparent absolute bottom-0 left-0">
 					<div class="mb-2">
 						<h2 class="text-2xl md:text-3xl">{ ev.Name }</h2>
-						<p class="text-sm md:text-base">{ helpers.GetDateOrShowNone(ev.StartTime) } | { helpers.GetTimeOrShowNone(ev.StartTime) } &commat; { ev.Address }</p>
+						<p class="text-sm md:text-base">{ helpers.GetDateOrShowNone(ev.StartTime, ev.Timezone) } | { helpers.GetTimeOrShowNone(ev.StartTime, ev.Timezone) } &commat; { ev.Address }</p>
 					</div>
 					<br/>
 					<a data-umami-event={ "event-list-clk" } data-umami-event-event-id={ ev.Id } href={ templ.URL("/event/" + ev.Id) } class="btn btn-primary btn-block mb-2 md:mb-3">

--- a/functions/gateway/templates/pages/home_templ_test.go
+++ b/functions/gateway/templates/pages/home_templ_test.go
@@ -59,6 +59,7 @@ func TestHomePage(t *testing.T) {
 	for _, element := range expectedElements {
 		if !strings.Contains(renderedContent, element) {
 			t.Errorf("Expected rendered content to contain '%s', but it didn't", element)
+			t.Errorf("rendered content \n'%s'", renderedContent)
 		}
 	}
 }

--- a/functions/gateway/templates/pages/layout.templ
+++ b/functions/gateway/templates/pages/layout.templ
@@ -78,7 +78,7 @@ templ Layout(sitePage helpers.SitePage, userInfo helpers.UserInfo, pageContent t
 
 			document.addEventListener('click', (event) => {
 				const target = event.target.closest('a');
-				if !target.getAttribute('href').startsWith('#') {
+				if (!target?.getAttribute?.('href')?.startsWith('#')) {
 					return;
 				}
 				if (target && target.href && !target.target && !event.ctrlKey && !event.metaKey) {

--- a/functions/gateway/templates/pages/layout.templ
+++ b/functions/gateway/templates/pages/layout.templ
@@ -78,6 +78,9 @@ templ Layout(sitePage helpers.SitePage, userInfo helpers.UserInfo, pageContent t
 
 			document.addEventListener('click', (event) => {
 				const target = event.target.closest('a');
+				if !target.getAttribute('href').startsWith('#') {
+					return;
+				}
 				if (target && target.href && !target.target && !event.ctrlKey && !event.metaKey) {
 					showLoadingIndicator();
 				}

--- a/functions/gateway/templates/pages/layout.templ
+++ b/functions/gateway/templates/pages/layout.templ
@@ -11,7 +11,11 @@ templ Layout(sitePage helpers.SitePage, userInfo helpers.UserInfo, pageContent t
 	<!DOCTYPE html>
 	<html data-theme="cyberpunk">
 		<head>
-			<title>Meet Near Me - { sitePage.Name }</title>
+			if event.Id != "" && sitePage.Key == "event-detail" {
+				<title>Meet Near Me - { event.Name }</title>
+			} else {
+				<title>Meet Near Me - { sitePage.Name }</title>
+			}
 			<link rel="icon" href={ templ.EscapeString(os.Getenv("STATIC_BASE_URL") + "/assets/logo.svg") }/>
 			<link rel="preconnect" href="https://fonts.googleapis.com"/>
 			<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>

--- a/functions/gateway/transport/http_test.go
+++ b/functions/gateway/transport/http_test.go
@@ -138,7 +138,7 @@ func TestSendServerRes(t *testing.T) {
 				t.Errorf("handler returned wrong status code: got %v want %v", status, tt.expectedStatus)
 			}
 
-			if rr.Body.String() != tt.expectedBody {
+			if !strings.Contains(rr.Body.String(), tt.expectedBody) {
 				t.Errorf("handler returned unexpected body: got %v want %v", rr.Body.String(), tt.expectedBody)
 			}
 		})

--- a/functions/gateway/types/events.go
+++ b/functions/gateway/types/events.go
@@ -1,30 +1,32 @@
 package types
 
 type Event struct {
-	Id          	string `json:"id,omitempty"`
-	EventOwners 	[]string `json:"eventOwners" validate:"required,min=1"`
-	EventOwnerName string `json:"eventOwnerName" validate:"required"`
-	Name        	string `json:"name" validate:"required"`
-	Description 	string `json:"description" validate:"required"`
-	StartTime   	int64 `json:"startTime" validate:"required"`
-	EndTime     	int64 `json:"endTime,omitempty"`
-	Address     	string `json:"address" validate:"required"`
-	Lat    				float64 `json:"lat" validate:"required"`
-	Long    			float64 `json:"long" validate:"required"`
-	StartingPrice int32 `json:"startingPrice,omitempty"`
-	Currency 			string `json:"currency,omitempty"`
-	PayeeId  			string `json:"payeeId,omitempty"`
-	HasRegistrationFields bool `json:"hasRegistrationFields,omitempty"`
-	HasPurchasable bool  `json:"hasPurchasable,omitempty"`
-	ImageUrl      string `json:"imageUrl,omitempty"`
-	Timezone      string `json:"timezone" validate:"required"`
-	Categories    []string `json:"categories,omitempty"`
-	Tags    			[]string `json:"tags,omitempty"`
-	CreatedAt     int64 `json:"createdAt,omitempty"`
-	UpdatedAt     int64 `json:"updatedAt,omitempty"`
-	UpdatedBy     string `json:"updatedBy,omitempty"`
-	RefUrl 				string `json:"refUrl,omitempty"`
-	HideCrossPromo bool   `json:"hideCrossPromo,omitempty"`
+	Id                    string   `json:"id,omitempty"`
+	EventOwners           []string `json:"eventOwners" validate:"required,min=1"`
+	EventOwnerName        string   `json:"eventOwnerName" validate:"required"`
+	EventSourceType       string   `json:"eventSourceType" validate:"required"`
+	Name                  string   `json:"name" validate:"required"`
+	Description           string   `json:"description" validate:"required"`
+	StartTime             int64    `json:"startTime" validate:"required"`
+	EndTime               int64    `json:"endTime,omitempty"`
+	Address               string   `json:"address" validate:"required"`
+	Lat                   float64  `json:"lat" validate:"required"`
+	Long                  float64  `json:"long" validate:"required"`
+	EventSourceId         string   `json:"eventSourceId"`
+	StartingPrice         int32    `json:"startingPrice,omitempty"`
+	Currency              string   `json:"currency,omitempty"`
+	PayeeId               string   `json:"payeeId,omitempty"`
+	HasRegistrationFields bool     `json:"hasRegistrationFields,omitempty"`
+	HasPurchasable        bool     `json:"hasPurchasable,omitempty"`
+	ImageUrl              string   `json:"imageUrl,omitempty"`
+	Timezone              string   `json:"timezone" validate:"required"`
+	Categories            []string `json:"categories,omitempty"`
+	Tags                  []string `json:"tags,omitempty"`
+	CreatedAt             int64    `json:"createdAt,omitempty"`
+	UpdatedAt             int64    `json:"updatedAt,omitempty"`
+	UpdatedBy             string   `json:"updatedBy,omitempty"`
+	RefUrl                string   `json:"refUrl,omitempty"`
+	HideCrossPromo        bool     `json:"hideCrossPromo,omitempty"`
 
 	// New fields for UI use only
 	LocalizedStartDate string `json:"localStartDate,omitempty"`
@@ -32,7 +34,7 @@ type Event struct {
 }
 
 type EventSearchResponse struct {
-	Events			[]Event `json:"events"`
-	Filter 			string 	`json:"filter,omitempty"`
-	Query				string	`json:"query,omitempty"`
+	Events []Event `json:"events"`
+	Filter string  `json:"filter,omitempty"`
+	Query  string  `json:"query,omitempty"`
 }

--- a/functions/gateway/types/purchasables.go
+++ b/functions/gateway/types/purchasables.go
@@ -7,82 +7,84 @@ import (
 
 // PurchasablesInsert represents the data required to insert a new user
 type PurchasableItemInsert struct {
-		PurchasableIndex					int `json:"purchasable_index" dynamodbav:"purchasableIndex"`
-    Name          string `json:"name" validate:"required" dynamodbav:"name"`
-    ItemType         string `json:"item_type" validate:"required" dynamodbav:"itemType"` // Validate as email
-    Cost		  float64 `json:"cost" validate:"required" dynamodbav:"cost"`
-	Inventory int32 `json:"inventory" validate:"required" dynamodbav:"inventory"`
-	StartingQuantity int32	`json:"starting_quantity" validate:"required" dynamodbav:"startingQuantity"`
-    Currency         string `json:"currency" validate:"required" dynamodbav:"currency"`
-	ChargeRecurrenceInterval string `json:"charge_recurrence_interval" validate:"required" dynamodbav:"chargeRecurrenceInterval"`
-	ChargeRecurrenceIntervalCount int32 `json:"charge_recurrence_interval_count" validate:"required" dynamodbav:"chargeRecurrenceIntervalCount"`
-	ChargeRecurrenceEndDate string `json:"charge_recurrence_end_date" validate:"required" dynamodbav:"chargeRecurrenceEndDate"`
-	DonationRatio float64 `json:"donation_ratio" validate:"required" dynamodbav:"donationRatio"`
-	RegistrationFields []string `json:"registration_fields" dynamodbav:"registrationFields"`
-    CreatedAt     string `json:"created_at" dynamodbav:"createdAt"` // Adjust based on your date format
-    UpdatedAt     string `json:"updated_at" dynamodbav:"updatedAt"` // Adjust based on your date format
+	PurchasableIndex              int        `json:"purchasable_index" dynamodbav:"purchasableIndex"`
+	Name                          string     `json:"name" validate:"required" dynamodbav:"name"`
+	ItemType                      string     `json:"item_type" validate:"required" dynamodbav:"itemType"` // Validate as email
+	Cost                          float64    `json:"cost" validate:"required" dynamodbav:"cost"`
+	Inventory                     int32      `json:"inventory" validate:"required" dynamodbav:"inventory"`
+	StartingQuantity              int32      `json:"starting_quantity" validate:"required" dynamodbav:"startingQuantity"`
+	Currency                      string     `json:"currency" validate:"required" dynamodbav:"currency"`
+	ChargeRecurrenceInterval      string     `json:"charge_recurrence_interval" validate:"required" dynamodbav:"chargeRecurrenceInterval"`
+	ChargeRecurrenceIntervalCount int32      `json:"charge_recurrence_interval_count" validate:"required" dynamodbav:"chargeRecurrenceIntervalCount"`
+	ChargeRecurrenceEndDate       time.Time  `json:"charge_recurrence_end_date" validate:"required" dynamodbav:"chargeRecurrenceEndDate"`
+	DonationRatio                 float64    `json:"donation_ratio" validate:"required" dynamodbav:"donationRatio"`
+	RegistrationFields            []string   `json:"registration_fields" dynamodbav:"registrationFields"`
+	ExpiresOn                     *time.Time `json:"expires_on,omitempty" dynamodbav:"expiresOn,omitempty"`
+	CreatedAt                     time.Time  `json:"created_at" dynamodbav:"createdAt"` // Adjust based on your date format
+	UpdatedAt                     time.Time  `json:"updated_at" dynamodbav:"updatedAt"` // Adjust based on your date format
 }
 
 // PurchasableInventoryUpdate represents the data required to update a purchasable item's inventory
 type PurchasableInventoryUpdate struct {
-	Name     string
-	Quantity int32
-	PurchasableIndex    int
+	Name             string
+	Quantity         int32
+	PurchasableIndex int
 }
-
 
 // Purchasables represents a user in the system
 type PurchasableItem struct {
-    Name          string `json:"name" dynamodbav:"name"`
-    ItemType         string `json:"item_type" dynamodbav:"itemType"` // Validate as email
-    Cost		  float64 `json:"cost" dynamodbav:"cost"`
-	Inventory int32 `json:"inventory" dynamodbav:"inventory"`
-	StartingQuantity int32	`json:"starting_quantity" dynamodbav:"startingQuantity"`
-    Currency         string `json:"currency" dynamodbav:"currency"`
-	ChargeRecurrenceInterval string `json:"charge_recurrence_interval" dynamodbav:"chargeRecurrenceInterval"`
-	ChargeRecurrenceIntervalCount int32 `json:"charge_recurrence_interval_count" dynamodbav:"chargeRecurrenceIntervalCount"`
-	ChargeRecurrenceEndDate time.Time `json:"charge_recurrence_end_date" dynamodbav:"chargeRecurrenceEndDate"`
-    DonationRatio float64 `json:"donation_ratio" dynamodbav:"donationRatio"`
-		RegistrationFields []string `json:"registration_fields" dynamodbav:"registrationFields"`
-    CreatedAt     time.Time `json:"created_at" dynamodbav:"createdAt"` // Adjust based on your date format
-    UpdatedAt     time.Time `json:"updated_at" dynamodbav:"updatedAt"` // Adjust based on your date format
+	Name                          string     `json:"name" dynamodbav:"name"`
+	ItemType                      string     `json:"item_type" dynamodbav:"itemType"` // Validate as email
+	Cost                          float64    `json:"cost" dynamodbav:"cost"`
+	Inventory                     int32      `json:"inventory" dynamodbav:"inventory"`
+	StartingQuantity              int32      `json:"starting_quantity" dynamodbav:"startingQuantity"`
+	Currency                      string     `json:"currency" dynamodbav:"currency"`
+	ChargeRecurrenceInterval      string     `json:"charge_recurrence_interval" dynamodbav:"chargeRecurrenceInterval"`
+	ChargeRecurrenceIntervalCount int32      `json:"charge_recurrence_interval_count" dynamodbav:"chargeRecurrenceIntervalCount"`
+	ChargeRecurrenceEndDate       time.Time  `json:"charge_recurrence_end_date" dynamodbav:"chargeRecurrenceEndDate"`
+	DonationRatio                 float64    `json:"donation_ratio" dynamodbav:"donationRatio"`
+	RegistrationFields            []string   `json:"registration_fields" dynamodbav:"registrationFields"`
+	ExpiresOn                     *time.Time `json:"expires_on,omitempty" dynamodbav:"expiresOn,omitempty"`
+	CreatedAt                     time.Time  `json:"created_at" dynamodbav:"createdAt"` // Adjust based on your date format
+	UpdatedAt                     time.Time  `json:"updated_at" dynamodbav:"updatedAt"` // Adjust based on your date format
 }
 
 // PurchasablesUpdate represents the data required to update a user
 type PurchasableItemUpdate struct {
-	Name          string `json:"name" dynamodbav:"name"`
-	ItemType         string `json:"item_type" dynamodbav:"itemType"` // Validate as email
-    Cost		  float64 `json:"cost" dynamodbav:"cost"`
-	Inventory int32 `json:"inventory" dynamodbav:"inventory"`
-	StartingQuantity int32	`json:"starting_quantity" dynamodbav:"startingQuantity"`
-    Currency         string `json:"currency" dynamodbav:"currency"`
-	ChargeRecurrenceInterval string `json:"charge_recurrence_interval" dynamodbav:"chargeRecurrenceInterval"`
-	ChargeRecurrenceIntervalCount int32 `json:"charge_recurrence_interval_count" dynamodbav:"chargeRecurrenceIntervalCount"`
-	ChargeRecurrenceEndDate string `json:"charge_recurrence_end_date" dynamodbav:"chargeRecurrenceEndDate"`
-	RegistrationFields []string `json:"registration_fields" dynamodbav:"registrationFields"`
-    DonationRatio float64 `json:"donation_ratio" dynamodbav:"donationRatio"`
-    UpdatedAt     time.Time `json:"updated_at" dynamodbav:"updatedAt"` // Adjust based on your date format
+	Name                          string     `json:"name" dynamodbav:"name"`
+	ItemType                      string     `json:"item_type" dynamodbav:"itemType"` // Validate as email
+	Cost                          float64    `json:"cost" dynamodbav:"cost"`
+	Inventory                     int32      `json:"inventory" dynamodbav:"inventory"`
+	StartingQuantity              int32      `json:"starting_quantity" dynamodbav:"startingQuantity"`
+	Currency                      string     `json:"currency" dynamodbav:"currency"`
+	ChargeRecurrenceInterval      string     `json:"charge_recurrence_interval" dynamodbav:"chargeRecurrenceInterval"`
+	ChargeRecurrenceIntervalCount int32      `json:"charge_recurrence_interval_count" dynamodbav:"chargeRecurrenceIntervalCount"`
+	ChargeRecurrenceEndDate       time.Time  `json:"charge_recurrence_end_date" dynamodbav:"chargeRecurrenceEndDate"`
+	RegistrationFields            []string   `json:"registration_fields" dynamodbav:"registrationFields"`
+	DonationRatio                 float64    `json:"donation_ratio" dynamodbav:"donationRatio"`
+	ExpiresOn                     *time.Time `json:"expires_on,omitempty" dynamodbav:"expiresOn,omitempty"`
+	UpdatedAt                     time.Time  `json:"updated_at" dynamodbav:"updatedAt"` // Adjust based on your date format
 }
 
 type PurchasableInsert struct {
-	EventId string `json:"event_id" validate:"required" dynamodbav:"eventId"`
+	EventId          string                  `json:"event_id" validate:"required" dynamodbav:"eventId"`
 	PurchasableItems []PurchasableItemInsert `json:"purchasable_items" validate:"required" dynamodbav:"purchasableItems"`
-    CreatedAt     time.Time `json:"created_at" dynamodbav:"createdAt"` // Adjust based on your date format
-    UpdatedAt     time.Time `json:"updated_at" dynamodbav:"updatedAt"` // Adjust based on your date format
+	CreatedAt        time.Time               `json:"created_at" dynamodbav:"createdAt"` // Adjust based on your date format
+	UpdatedAt        time.Time               `json:"updated_at" dynamodbav:"updatedAt"` // Adjust based on your date format
 }
 
 type Purchasable struct {
-	EventId string `json:"event_id" dynamodbav:"eventId"`
+	EventId          string                  `json:"event_id" dynamodbav:"eventId"`
 	PurchasableItems []PurchasableItemInsert `json:"purchasable_items"  dynamodbav:"purchasableItems"`
-    CreatedAt     time.Time `json:"created_at" dynamodbav:"createdAt"` // Adjust based on your date format
-    UpdatedAt     time.Time `json:"updated_at" dynamodbav:"updatedAt"` // Adjust based on your date format
+	CreatedAt        time.Time               `json:"created_at" dynamodbav:"createdAt"` // Adjust based on your date format
+	UpdatedAt        time.Time               `json:"updated_at" dynamodbav:"updatedAt"` // Adjust based on your date format
 }
 
 type PurchasableUpdate struct {
-	EventId string `json:"event_id" validastringte:"required" dynamodbav:"eventId"`
+	EventId          string                  `json:"event_id" validastringte:"required" dynamodbav:"eventId"`
 	PurchasableItems []PurchasableItemInsert `json:"purchasable_items" dynamodbav:"purchasableItems"`
-    CreatedAt     time.Time `json:"created_at" dynamodbav:"createdAt"` // Adjust based on your date format
-    UpdatedAt     time.Time `json:"updated_at" dynamodbav:"updatedAt"` // Adjust based on your date format
+	CreatedAt        time.Time               `json:"created_at" dynamodbav:"createdAt"` // Adjust based on your date format
+	UpdatedAt        time.Time               `json:"updated_at" dynamodbav:"updatedAt"` // Adjust based on your date format
 }
 
 // PurchasablesServiceInterface defines the methods for user-related operations using the RDSDataAPI
@@ -93,6 +95,3 @@ type PurchasableServiceInterface interface {
 	UpdatePurchasableInventory(ctx context.Context, dynamodbClient DynamoDBAPI, eventId string, updates []PurchasableInventoryUpdate, purchasableMap map[string]PurchasableItemInsert) error
 	DeletePurchasable(ctx context.Context, dynamodbClient DynamoDBAPI, eventId string) error
 }
-
-
-

--- a/functions/gateway/types/purchases.go
+++ b/functions/gateway/types/purchases.go
@@ -2,65 +2,22 @@ package types
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
 	"time"
 )
 
-// FlexibleValue can be a string, int32, or bool
-type FlexibleValue struct {
-	value interface{}
-}
-
-// attach behavior the guarantees Unmarshaling JSON works correctly
-func (fv *FlexibleValue) UnmarshalJSON(data []byte) error {
-	// Try string
-	var s string
-	if err := json.Unmarshal(data, &s); err == nil {
-		fv.value = s
-		return nil
-	}
-
-	// Try bool
-	var b bool
-	if err := json.Unmarshal(data, &b); err == nil {
-		fv.value = b
-		return nil
-	}
-
-	// Try int32
-	var i int32
-	if err := json.Unmarshal(data, &i); err == nil {
-		fv.value = i
-		return nil
-	}
-
-	return fmt.Errorf("unable to unmarshal value")
-}
-
-// Handle Marshal default behavior
-func (fv FlexibleValue) MarshalJSON() ([]byte, error) {
-	return json.Marshal(fv.value)
-}
-
-// Add a method that hadles for calling Value on struct
-func (fv FlexibleValue) Value() interface{} {
-	return fv.value
-}
-
 // Purchase represents a purchase in the system
 type PurchasedItem struct {
-	Name                          string                     `json:"name" dynamodbav:"name"`
-	PurchasableIndex              int                        `json:"purchasable_index" dyamodbav:"purchasableIndex"`
-	ItemType                      string                     `json:"item_type" dynamodbav:"itemType"` // Validate as email
-	Cost                          float64                    `json:"cost" dynamodbav:"cost"`
-	Quantity                      int32                      `json:"quantity" dynamodbav:"quantity"`
-	Currency                      string                     `json:"currency" dynamodbav:"currency"`
-	ChargeRecurrenceInterval      string                     `json:"charge_recurrence_interval" dynamodbav:"chargeRecurrenceInterval"`
-	ChargeRecurrenceIntervalCount int                        `json:"charge_recurrence_interval_count" dynamodbav:"chargeRecurrenceIntervalCount"`
-	ChargeRecurrenceEndDate       time.Time                  `json:"charge_recurrence_end_date" dynamodbav:"chargeRecurrenceEndDate"`
-	DonationRatio                 float64                    `json:"donation_ratio" dynamodbav:"donationRatio"`
-	RegResponses                  []map[string]FlexibleValue `json:"reg_responses" dynamodbav:"regResponses"`
+	Name                          string                   `json:"name" dynamodbav:"name"`
+	PurchasableIndex              int                      `json:"purchasable_index" dyamodbav:"purchasableIndex"`
+	ItemType                      string                   `json:"item_type" dynamodbav:"itemType"` // Validate as email
+	Cost                          float64                  `json:"cost" dynamodbav:"cost"`
+	Quantity                      int32                    `json:"quantity" dynamodbav:"quantity"`
+	Currency                      string                   `json:"currency" dynamodbav:"currency"`
+	ChargeRecurrenceInterval      string                   `json:"charge_recurrence_interval" dynamodbav:"chargeRecurrenceInterval"`
+	ChargeRecurrenceIntervalCount int                      `json:"charge_recurrence_interval_count" dynamodbav:"chargeRecurrenceIntervalCount"`
+	ChargeRecurrenceEndDate       time.Time                `json:"charge_recurrence_end_date" dynamodbav:"chargeRecurrenceEndDate"`
+	DonationRatio                 float64                  `json:"donation_ratio" dynamodbav:"donationRatio"`
+	RegResponses                  []map[string]interface{} `json:"reg_responses" dynamodbav:"regResponses"`
 }
 
 // PurchaseInsert represents the data required to insert a new purchase

--- a/functions/gateway/types/registrations.go
+++ b/functions/gateway/types/registrations.go
@@ -7,29 +7,28 @@ import (
 
 // RegistrationsInsert represents the data required to insert a new user
 type RegistrationInsert struct {
-	EventId       string `json:"event_id" validate:"required" dynamodbav:"eventId"` // UUID format validation
-	UserId		  string `json:"user_id" validate:"required" dynamodbav:"userId"`
-	Responses  []map[string]string      `json:"responses" dynamodbav:"responses"`
-	CreatedAt     time.Time `json:"created_at" dynamodbav:"createdAt"` // Adjust based on your date format
-	UpdatedAt     time.Time `json:"updated_at" dynamodbav:"updatedAt"` // Adjust based on your date format
+	EventId   string                   `json:"event_id" validate:"required" dynamodbav:"eventId"` // UUID format validation
+	UserId    string                   `json:"user_id" validate:"required" dynamodbav:"userId"`
+	Responses []map[string]interface{} `json:"responses" dynamodbav:"responses"`
+	CreatedAt time.Time                `json:"created_at" dynamodbav:"createdAt"` // Adjust based on your date format
+	UpdatedAt time.Time                `json:"updated_at" dynamodbav:"updatedAt"` // Adjust based on your date format
 }
-
 
 // Registrations represents a user in the system
 type Registration struct {
-	EventId       string `json:"event_id" validate:"required" dynamodbav:"eventId` // UUID format validation
-	UserId		  string `json:"user_id" validate:"required" dynamodbav:"userId"`
-	Responses  []map[string]string      `json:"responses" dynamodbav:"responses"`
-	CreatedAt     time.Time `json:"created_at" dynamodbav:"createdAt"` // Adjust based on your date format
-	UpdatedAt     time.Time `json:"updated_at" dynamodbav:"updatedAt"` // Adjust based on your date format
+	EventId   string                   `json:"event_id" validate:"required" dynamodbav:"eventId` // UUID format validation
+	UserId    string                   `json:"user_id" validate:"required" dynamodbav:"userId"`
+	Responses []map[string]interface{} `json:"responses" dynamodbav:"responses"`
+	CreatedAt time.Time                `json:"created_at" dynamodbav:"createdAt"` // Adjust based on your date format
+	UpdatedAt time.Time                `json:"updated_at" dynamodbav:"updatedAt"` // Adjust based on your date format
 }
 
 // RegistrationsUpdate represents the data required to update a user
 type RegistrationUpdate struct {
-	EventId       string `json:"event_id" validate:"required" dynamodbav:"eventId` // UUID format validation
-	UserId		  string `json:"user_id" validate:"required" dynamodbav:"userId"`
-	Responses  []map[string]string      `json:"responses" dynamodbav:"responses"`
-	UpdatedAt     time.Time `json:"updated_at" dynamodbav:"updatedAt"` // Adjust based on your date format
+	EventId   string                   `json:"event_id" validate:"required" dynamodbav:"eventId` // UUID format validation
+	UserId    string                   `json:"user_id" validate:"required" dynamodbav:"userId"`
+	Responses []map[string]interface{} `json:"responses" dynamodbav:"responses"`
+	UpdatedAt time.Time                `json:"updated_at" dynamodbav:"updatedAt"` // Adjust based on your date format
 }
 
 // RegistrationsServiceInterface defines the methods for user-related operations using the RDSDataAPI
@@ -41,7 +40,3 @@ type RegistrationServiceInterface interface {
 	UpdateRegistration(ctx context.Context, dynamoClient DynamoDBAPI, eventId, userId string, registration RegistrationUpdate) (*Registration, error)
 	DeleteRegistration(ctx context.Context, dynamoClient DynamoDBAPI, eventId, userId string) error
 }
-
-
-
-

--- a/internal/database/marqo/migration/main.go
+++ b/internal/database/marqo/migration/main.go
@@ -76,7 +76,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	timestamp := time.Now().UTC().Format("20060102150405")
+	timestamp := time.Now().UTC().Format("2006-01-02-1504")
 	targetIndex := fmt.Sprintf("%s-events-%s", *env, timestamp)
 
 	fmt.Printf("Starting migration from %s to %s\n", sourceIndex, targetIndex)
@@ -128,7 +128,7 @@ func (c *MarqoClient) GetCurrentIndex(envPrefix string) (string, error) {
 			}
 
 			timestamp := parts[len(parts)-2]
-			indexTime, err := time.ParseInLocation("20060102150405", timestamp, time.UTC)
+			indexTime, err := time.ParseInLocation("2006-01-02-1504", timestamp, time.UTC)
 			if err != nil {
 				continue
 			}

--- a/internal/database/marqo/migration/migrate.go
+++ b/internal/database/marqo/migration/migrate.go
@@ -7,32 +7,31 @@ import (
 	"strings"
 )
 
-
 func LoadSchema(path string) (map[string]interface{}, error) {
-    data, err := os.ReadFile(path)
-    if err != nil {
-        return nil, fmt.Errorf("failed to read schema file: %w", err)
-    }
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read schema file: %w", err)
+	}
 
-    var schema map[string]interface{}
-    if err := json.Unmarshal(data, &schema); err != nil {
-        return nil, fmt.Errorf("failed to parse schema JSON: %w", err)
-    }
+	var schema map[string]interface{}
+	if err := json.Unmarshal(data, &schema); err != nil {
+		return nil, fmt.Errorf("failed to parse schema JSON: %w", err)
+	}
 
-    return schema, nil
+	return schema, nil
 }
 
 type Migrator struct {
-    sourceClient  *MarqoClient
-    targetClient  *MarqoClient
-    batchSize     int
-    transformers  []TransformFunc
-	schema map[string]interface{}
+	sourceClient *MarqoClient
+	targetClient *MarqoClient
+	batchSize    int
+	transformers []TransformFunc
+	schema       map[string]interface{}
 }
 
 func NewMigrator(sourceURL, targetURL, apiKey string, batchSize int, transformerNames []string, schema map[string]interface{}) (*Migrator, error) {
-    // Validate and collect requested transformers
-    transformers := make([]TransformFunc, 0)
+	// Validate and collect requested transformers
+	transformers := make([]TransformFunc, 0)
 	if len(transformerNames) > 0 {
 		for _, name := range transformerNames {
 			transformer, exists := TransformerRegistry[name]
@@ -43,13 +42,13 @@ func NewMigrator(sourceURL, targetURL, apiKey string, batchSize int, transformer
 		}
 	}
 
-    return &Migrator{
-        sourceClient:  NewMarqoClient(sourceURL, apiKey),
-        targetClient:  NewMarqoClient(targetURL, apiKey),
-        batchSize:     batchSize,
-        transformers:  transformers,
-		schema: schema,
-    }, nil
+	return &Migrator{
+		sourceClient: NewMarqoClient(sourceURL, apiKey),
+		targetClient: NewMarqoClient(targetURL, apiKey),
+		batchSize:    batchSize,
+		transformers: transformers,
+		schema:       schema,
+	}, nil
 }
 
 func getAllowedFields(schema map[string]interface{}) map[string]bool {
@@ -70,9 +69,8 @@ func removeProtectedFields(doc map[string]interface{}, allowedFields map[string]
 	// Create a new map for the cleaned document
 	cleaned := make(map[string]interface{})
 
-	// Copy all fields except protected ones (those starting with _)
 	for key, value := range doc {
-		if !strings.HasPrefix(key, "_") && allowedFields[key] {
+		if key == "_id" || (!strings.HasPrefix(key, "_") && allowedFields[key]) {
 			cleaned[key] = value
 		}
 	}
@@ -81,26 +79,53 @@ func removeProtectedFields(doc map[string]interface{}, allowedFields map[string]
 }
 
 func (m *Migrator) applyTransformers(doc map[string]interface{}) (map[string]interface{}, error) {
+	// Log original document
+	eventName, _ := doc["name"].(string)
+	eventID, _ := doc["id"].(string)
+	originalJSON, _ := json.MarshalIndent(doc, "", "  ")
+	fmt.Printf("\n=== Pre-Transform Event ===\nID: %s\nName: %s\nDocument:\n%s\n",
+		eventID, eventName, string(originalJSON))
+
 	allowedFields := getAllowedFields(m.schema)
-    result := removeProtectedFields(doc, allowedFields)
+	result := removeProtectedFields(doc, allowedFields)
 
-    var err error
-    for _, transformer := range m.transformers {
-        result, err = transformer(result)
-        if err != nil {
-            return nil, fmt.Errorf("transformer failed: %w", err)
-        }
-    }
+	var err error
+	for _, transformer := range m.transformers {
+		result, err = transformer(result)
+		if err != nil {
+			return nil, fmt.Errorf("transformer failed: %w", err)
+		}
+	}
 
-    return result, nil
+	// Log transformed document
+	transformedJSON, _ := json.MarshalIndent(result, "", "  ")
+	fmt.Printf("\n=== Post-Transform Event ===\nID: %s\nName: %s\nDocument:\n%s\n",
+		eventID, eventName, string(transformedJSON))
+
+	return result, nil
 }
 
+// func (m *Migrator) applyTransformers(doc map[string]interface{}) (map[string]interface{}, error) {
+// 	allowedFields := getAllowedFields(m.schema)
+//     result := removeProtectedFields(doc, allowedFields)
+
+//     var err error
+//     for _, transformer := range m.transformers {
+//         result, err = transformer(result)
+//         if err != nil {
+//             return nil, fmt.Errorf("transformer failed: %w", err)
+//         }
+//     }
+
+//     return result, nil
+// }
+
 func (m *Migrator) MigrateEvents(sourceIndex, targetIndex string, schema map[string]interface{}) error {
-    // Create the new index
+	// Create the new index
 	endpoint, err := m.targetClient.CreateStructuredIndex(targetIndex, schema)
-    if err != nil {
-        return fmt.Errorf("failed to create target index: %w", err)
-    }
+	if err != nil {
+		return fmt.Errorf("failed to create target index: %w", err)
+	}
 
 	// Update target client with new endpoint
 	m.targetClient = NewMarqoClient(endpoint, m.targetClient.apiKey)
@@ -108,7 +133,7 @@ func (m *Migrator) MigrateEvents(sourceIndex, targetIndex string, schema map[str
 
 	type batchResult struct {
 		count int
-		err error
+		err   error
 	}
 
 	workers := 4
@@ -140,20 +165,20 @@ func (m *Migrator) MigrateEvents(sourceIndex, targetIndex string, schema map[str
 		}()
 	}
 
-    offset := 0
-    totalMigrated := 0
+	offset := 0
+	totalMigrated := 0
 	activeBatches := 0
 
-    for {
-        // Fetch batch of documents from source
-        docs, err := m.sourceClient.Search(sourceIndex, "*", offset, m.batchSize)
-        if err != nil {
-            return fmt.Errorf("failed to fetch documents at offset %d: %w", offset, err)
-        }
+	for {
+		// Fetch batch of documents from source
+		docs, err := m.sourceClient.Search(sourceIndex, "*", offset, m.batchSize)
+		if err != nil {
+			return fmt.Errorf("failed to fetch documents at offset %d: %w", offset, err)
+		}
 
-        if len(docs) == 0 {
-            break
-        }
+		if len(docs) == 0 {
+			break
+		}
 
 		// Send batch to worker
 		batchChan <- docs
@@ -170,7 +195,7 @@ func (m *Migrator) MigrateEvents(sourceIndex, targetIndex string, schema map[str
 			activeBatches--
 			fmt.Printf("Migrated and transformed %d documents\n", totalMigrated)
 		}
-    }
+	}
 
 	// close batch channel and wait for remaining results
 	close(batchChan)
@@ -185,6 +210,6 @@ func (m *Migrator) MigrateEvents(sourceIndex, targetIndex string, schema map[str
 		fmt.Printf("Migrated and transformed %d documents\n", totalMigrated)
 	}
 
-    fmt.Printf("Migration completed. Total documents migrated and transformed: %d\n", totalMigrated)
-    return nil
+	fmt.Printf("Migration completed. Total documents migrated and transformed: %d\n", totalMigrated)
+	return nil
 }

--- a/internal/database/marqo/migration/schema.json
+++ b/internal/database/marqo/migration/schema.json
@@ -1,7 +1,7 @@
 {
   "type": "structured",
   "vectorNumericType": "float",
-  "model": "hf/bge-large-en-v1.5",
+  "model": "Marqo/dunzhang-stella_en_400M_v5",
   "normalizeEmbeddings": true,
   "textPreprocessing": {
     "splitOverlap": 0,

--- a/internal/database/marqo/migration/transformers.go
+++ b/internal/database/marqo/migration/transformers.go
@@ -57,7 +57,7 @@ var TransformerRegistry = map[string]TransformFunc{
 
 		return doc, nil
 	},
-	"timestamp_correction": func(doc map[string]interface{}) (map[string]interface{}, error) {
+	"timestamp_correction_2024_12_01": func(doc map[string]interface{}) (map[string]interface{}, error) {
 		startTime, ok := doc["startTime"].(float64)
 		if !ok {
 			return doc, nil

--- a/internal/database/marqo/migration/transformers.go
+++ b/internal/database/marqo/migration/transformers.go
@@ -11,21 +11,21 @@ type TransformFunc func(map[string]interface{}) (map[string]interface{}, error)
 
 type TimestampInfo struct {
 	OriginalTimestamp int64
-	UTCTime string
-	LocalTime string
-	Timezone string
+	UTCTime           string
+	LocalTime         string
+	Timezone          string
 }
 
 // TransformerRegistry holds all available transformers
 var TransformerRegistry = map[string]TransformFunc{
 	"name_transformer": func(doc map[string]interface{}) (map[string]interface{}, error) {
-        // Check if the "name" field exists and is a string
-        if name, ok := doc["name"].(string); ok {
-            // Modify the "name" field
-            doc["name"] = name + " - transformed"
-        }
-        return doc, nil
-    },
+		// Check if the "name" field exists and is a string
+		if name, ok := doc["name"].(string); ok {
+			// Modify the "name" field
+			doc["name"] = name + " - transformed"
+		}
+		return doc, nil
+	},
 	"timestamp_diagnostic": func(doc map[string]interface{}) (map[string]interface{}, error) {
 		startTime, ok := doc["startTime"].(float64)
 		if !ok {
@@ -47,9 +47,9 @@ var TransformerRegistry = map[string]TransformFunc{
 
 		info := TimestampInfo{
 			OriginalTimestamp: int64(startTime),
-			UTCTime: utcTime.Format(time.RFC3339),
-			LocalTime: localTime.Format(time.RFC3339),
-			Timezone: timezone,
+			UTCTime:           utcTime.Format(time.RFC3339),
+			LocalTime:         localTime.Format(time.RFC3339),
+			Timezone:          timezone,
 		}
 
 		infoBytes, _ := json.MarshalIndent(info, "", " ")
@@ -118,15 +118,23 @@ var TransformerRegistry = map[string]TransformFunc{
 
 		return doc, nil
 	},
-    // "tensor_weights": func(doc map[string]interface{}) (map[string]interface{}, error) {
-    //     // Implement the actual tensor weights transformation
-    //     if _, ok := doc["name"].(string); ok {
-    //         doc["_tensor_weights"] = map[string]float64{
-    //             "name": 0.3,
-    //             "description": 0.5,
-    //             "address": 0.2,
-    //         }
-    //     }
-    //     return doc, nil
-    // },
+	"add_missing_ev_type_2024_12_01": func(doc map[string]interface{}) (map[string]interface{}, error) {
+		// ⛔️ WARNING: This transformer patches a missing field with ONE value, running it on post-migrated
+		// data with be destructive!
+		if _, ok := doc["name"].(string); ok {
+			doc["eventSourceType"] = "SLF"
+		}
+		return doc, nil
+	},
+	// "tensor_weights": func(doc map[string]interface{}) (map[string]interface{}, error) {
+	//     // Implement the actual tensor weights transformation
+	//     if _, ok := doc["name"].(string); ok {
+	//         doc["_tensor_weights"] = map[string]float64{
+	//             "name": 0.3,
+	//             "description": 0.5,
+	//             "address": 0.2,
+	//         }
+	//     }
+	//     return doc, nil
+	// },
 }

--- a/scripts/go_test_filtered.sh
+++ b/scripts/go_test_filtered.sh
@@ -10,7 +10,7 @@ if [[ "$1" == "-v" ]]; then
 fi
 
 # Find all directories excluding node_modules
-DIRS=$(find . -type d -not -path "./node_modules*")
+DIRS=$(find ./functions -type d -not -path "./node_modules*")
 
 # Create a temporary coverage file
 COVERAGE_FILE=$(mktemp)

--- a/static/assets/global.css
+++ b/static/assets/global.css
@@ -28,6 +28,15 @@
   }
 }
 
+@layer components {
+  .carousel-control-left {
+    @apply no-animation absolute left-0 mr-8 -m-1 top-1/2 -translate-y-1/2 -translate-x-full;
+  }
+  .carousel-control-right {
+    @apply no-animation absolute right-0 ml-8 -m-1 top-1/2 -translate-y-1/2 translate-x-full;
+  }
+}
+
 body {
   padding-top: 5rem;
 }
@@ -216,6 +225,14 @@ body:has(.bottom-drawer) {
   /* TODO: FIX THIS! use tailwind variables */
   background: white;
   padding: 20px;
+}
+
+.btn.carousel-control-left:active:hover, .btn.carousel-control-left:active:focus {
+  transform: translate(-100%, -50%)
+}
+
+.btn.carousel-control-right:active:hover, .btn.carousel-control-right:active:focus {
+  transform: translate(100%, -50%)
 }
 
 .btn.btn-bold-outline {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,8 @@
 /** @type {import('tailwindcss').Config} */
 
 export default {
+  mode: 'jit',
+  purge: ['**/*.templ'],
   content: ['**/*.templ'],
   theme: {
     fontSize: {


### PR DESCRIPTION
This wraps up the user-facing aspect of event series. Fixes / changes include:

- [x] Modify default query to include both `SLF` and `EVS` `eventSourceType` (`SLF_EVS` -> Event Series parent can be shared as a URL for marketing but doesn't appear in search listings
- [x] Implement lazy-loading of all "child" events from Event Series parent
- [x] Fix handling of `$0` / FREE events to POST to `/api/registrations` 
- [x] Fix `FlexibleValue` struct type that was broken and just use `[]map[string]interface{}` instead for registration response on purchasables and registrations 
- [x] Implement time-bound purchasables with expiration time and server-side security to prevent client-side spoofing
- [x] Fix longstanding timezone offset error (wasn't visible to users, but was wrong in the DB) (Fixes #198)
- [x] Implement initial version of `Authorization: Bearer <access_token>` handling for headless clients (Fixes #202)
- [x] Pursuant to auth fixes, lock down most routes to protect from bots / malicious attacks