### PR TITLE
[feature] add "fallback" behavior for Event Attendees for Stripe PENDING sessions to help debug failed payments

### DIFF
--- a/functions/gateway/templates/pages/event_attendees.templ
+++ b/functions/gateway/templates/pages/event_attendees.templ
@@ -96,10 +96,14 @@ templ EventAttendeesPage(pageObj helpers.SitePage, event types.Event, isEditor b
 											</td>
 											<td x-text="`\$${(purchase.total / 100).toFixed(2)}`"></td>
 											<td x-text="new Date(purchase.created_at * 1000).toLocaleString()"></td>
-											<td></td>
-											<template x-if="purchase.stripe_transaction_id">
-												<a class="btn btn-sm btn-primary mt-2" target="_blank" :href=" 'https://dashboard.stripe.com/payments/' + purchase.stripe_transaction_id ">View on Stripe</a>
-											</template>
+											<td>
+												<template x-if="purchase.stripe_transaction_id">
+													<a class="btn btn-sm btn-primary mt-2" target="_blank" :href=" 'https://dashboard.stripe.com/payments/' + purchase.stripe_transaction_id ">View on Stripe</a>
+												</template>
+												<template x-if="!purchase.stripe_transaction_id && purchase.stripe_session_id">
+													<a class="btn btn-sm btn-primary mt-2" target="_blank" :href=" 'https://dashboard.stripe.com/workbench/logs?object=' + purchase.stripe_session_id + '&filtered=true' ">View Incomplete on Stripe</a>
+												</template>
+											</td>
 										</tr>
 									</template>
 								</tbody>


### PR DESCRIPTION
Point to checkout sessions in logs for debugging `PENDING` transactions or those that are not `SETTLED`

An example URL for the debugging fallback behavior
`https://dashboard.stripe.com/workbench/logs?object=cs_live_a1QaKStj0a4BGlQhvXkR2kDqf4fVx1uW3E8bQOKfTqapI13M6iEWdlKrD5&filtered=true`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced display of Stripe transaction links in the Event Attendees page, showing relevant links based on available transaction data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->