### PR TITLE
[fix] PostCSS watcher fix - guard against infinite loop triggered from changes to `layout.templ`

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -4,6 +4,7 @@ import fs from 'fs';
 import path from 'path';
 
 let previousHash = '';
+let previousTemplateHash = '';
 
 export default {
   plugins: [
@@ -26,6 +27,9 @@ export default {
           const templatePath = 'functions/gateway/templates/pages/layout.templ';
           const template = fs.readFileSync(templatePath, 'utf8');
 
+          // Hash the template content to detect changes
+          const templateHash = crypto.createHash('md5').update(template).digest('hex').slice(0, 8);
+
           // Extract current hash from filename in template
           const hashMatch = template.match(/styles\.(.*?)\.css/);
           const currentHash = hashMatch ? hashMatch[1] : null;
@@ -33,11 +37,14 @@ export default {
           // Check if we need to update based on:
           // 1. Hash differences
           // 2. Missing hashed CSS file
+          // 3. Template content hasn't changed
           const currentHashedFile = currentHash ? `${baseStylesPath}.${currentHash}.css` : null;
-          const needsUpdate = newHash !== currentHash && newHash !== previousHash ||
-                             (currentHash && !fs.existsSync(currentHashedFile));
+          const needsUpdate = (newHash !== currentHash && newHash !== previousHash ||
+                             (currentHash && !fs.existsSync(currentHashedFile))) &&
+                             templateHash !== previousTemplateHash;
 
           if (needsUpdate) {
+            previousTemplateHash = templateHash;  // Store the new template hash
             const pattern = /styles\..*?\.css/;
             const updatedTemplate = template.replace(pattern, `styles.${newHash}.css`);
             fs.writeFileSync(templatePath, updatedTemplate);


### PR DESCRIPTION
Store the hashed value of `layout.templ`'s content to guard against infinite loop in PostCSS watcher