### PR TITLE
leaderboard score summing + community pages

### DIFF
--- a/functions/gateway/handlers/data_handlers_test.go
+++ b/functions/gateway/handlers/data_handlers_test.go
@@ -1431,6 +1431,15 @@ func TestGetUsersHandler(t *testing.T) {
 		if strings.Contains(r.URL.Path, "/meta") {
 			// Handle meta requests
 			w.Header().Set("Content-Type", "application/json")
+
+			// Extract the ID from the URL path
+			pathParts := strings.Split(r.URL.Path, "/")
+			id := pathParts[len(pathParts)-3] // Assuming ID is second-to-last part
+			if id == "tm_b8de1f5b-d377-458e-a47e-96123afcc6f3" {
+				http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+				return
+			}
+
 			response := map[string]interface{}{
 				"metadata": map[string]interface{}{
 					"value": base64.StdEncoding.EncodeToString([]byte("user1,user2")),
@@ -1674,6 +1683,12 @@ func TestGetUsersHandler(t *testing.T) {
 			queryParams:    "?ids=nonexistent",
 			expectedStatus: http.StatusBadRequest,
 			expectedBody:   `Invalid ID length: nonexistent. Must be exactly 18 characters`,
+		},
+		{
+			name:           "GetOtherUserMetaByID fails on missing user meta with throw=1",
+			queryParams:    "?ids=tm_b8de1f5b-d377-458e-a47e-96123afcc6f3&throw=1",
+			expectedStatus: http.StatusInternalServerError,
+			expectedBody:   "Failed to get user meta",
 		},
 	}
 

--- a/functions/gateway/handlers/dynamodb_handlers/competition_round_handlers.go
+++ b/functions/gateway/handlers/dynamodb_handlers/competition_round_handlers.go
@@ -62,11 +62,10 @@ func (h *CompetitionRoundHandler) PutCompetitionRounds(w http.ResponseWriter, r 
 		return
 	}
 
-	log.Printf("Handler: Successfully created competition rounds")
 	response, err := json.Marshal(res)
 	if err != nil {
 		log.Printf("Handler ERROR: Failed to marshal response: %v", err)
-		transport.SendServerRes(w, []byte("Error marshaling JSON"), http.StatusInternalServerError, err)
+		transport.SendServerRes(w, []byte("Error marshaling JSON >> 70"), http.StatusInternalServerError, err)
 		return
 	}
 
@@ -208,7 +207,7 @@ func GetCompetitionRoundsScoreSums(w http.ResponseWriter, r *http.Request) http.
 		service := dynamodb_service.NewCompetitionRoundService()
 		competitionRounds, err := service.GetCompetitionRounds(r.Context(), db, competitionId)
 		if err != nil {
-			transport.SendServerRes(w, []byte("Failed to check for purchase: "+err.Error()), http.StatusInternalServerError, err)
+			transport.SendServerRes(w, []byte("Failed to retrieve competition rounds for score sum: "+err.Error()), http.StatusInternalServerError, err)
 			return
 		}
 

--- a/functions/gateway/handlers/dynamodb_handlers/competition_round_handlers.go
+++ b/functions/gateway/handlers/dynamodb_handlers/competition_round_handlers.go
@@ -195,6 +195,50 @@ func (h *CompetitionRoundHandler) DeleteCompetitionRound(w http.ResponseWriter, 
 	transport.SendServerRes(w, []byte("CompetitionRound successfully deleted"), http.StatusOK, nil)
 }
 
+func GetCompetitionRoundsScoreSums(w http.ResponseWriter, r *http.Request) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		vars := mux.Vars(r)
+		competitionId := vars["competitionId"]
+		if competitionId == "" {
+			transport.SendServerRes(w, []byte("Missing competition ID"), http.StatusBadRequest, nil)
+			return
+		}
+
+		db := transport.GetDB()
+		service := dynamodb_service.NewCompetitionRoundService()
+		competitionRounds, err := service.GetCompetitionRounds(r.Context(), db, competitionId)
+		if err != nil {
+			transport.SendServerRes(w, []byte("Failed to check for purchase: "+err.Error()), http.StatusInternalServerError, err)
+			return
+		}
+
+		var scoreSums = map[string]float64{}
+		for _, round := range *competitionRounds {
+			competitorA := round.CompetitorA
+			competitorB := round.CompetitorB
+			if _, ok := scoreSums[competitorA]; ok {
+				scoreSums[competitorA] += round.CompetitorAScore
+			} else {
+				scoreSums[competitorA] = round.CompetitorAScore
+			}
+
+			if _, ok := scoreSums[competitorB]; ok {
+				scoreSums[competitorB] += round.CompetitorBScore
+			} else {
+				scoreSums[competitorB] = round.CompetitorBScore
+			}
+		}
+
+		jsonResponse, err := json.Marshal(scoreSums)
+		if err != nil {
+			transport.SendServerRes(w, []byte("Error marshaling JSON"), http.StatusInternalServerError, err)
+			return
+		}
+
+		transport.SendServerRes(w, jsonResponse, http.StatusOK, nil)
+	}
+}
+
 func PutCompetitionRoundsHandler(w http.ResponseWriter, r *http.Request) http.HandlerFunc {
 	log.Print("Hit round handler wrapper")
 	eventCompetitionRoundService := dynamodb_service.NewCompetitionRoundService()

--- a/functions/gateway/handlers/page_handlers.go
+++ b/functions/gateway/handlers/page_handlers.go
@@ -649,9 +649,9 @@ func GetAddOrEditCompetitionPage(w http.ResponseWriter, r *http.Request) http.Ha
 		competitionConfig = competitionConfigResponse.CompetitionConfig
 		users = competitionConfigResponse.Owners
 	}
-	log.Printf("649 >>> competitionConfig: %+v", competitionConfig)
+
 	competitionPage := pages.AddOrEditCompetitionPage(pageObj, competitionConfig, users)
-	layoutTemplate := pages.Layout(pageObj, userInfo, competitionPage, internal_types.Event{}, []string{"https://cdn.jsdelivr.net/npm/@alpinejs/focus@3.x.x/dist/cdn.min.js", "https://cdn.jsdelivr.net/npm/@alpinejs/sort@3.x.x/dist/cdn.min.js"})
+	layoutTemplate := pages.Layout(pageObj, userInfo, competitionPage, internal_types.Event{}, []string{"https://cdn.jsdelivr.net/npm/@alpinejs/focus@3.x.x/dist/cdn.min.js"})
 
 	var buf bytes.Buffer
 	err := layoutTemplate.Render(ctx, &buf)

--- a/functions/gateway/helpers/constants.go
+++ b/functions/gateway/helpers/constants.go
@@ -62,9 +62,9 @@ const COMP_UNASSIGNED_ROUND_EVENT_ID = "fake-event-id-123"
 const COMP_TEAM_ID_PREFIX = "tm_"
 
 // NOTE: these are the default searchable event source types that show up in the home event list view
-var DEFAULT_SEARCHABLE_EVENT_SOURCE_TYPES = []string{ES_SINGLE_EVENT, ES_EVENT_SERIES}
+var DEFAULT_SEARCHABLE_EVENT_SOURCE_TYPES = []string{ES_SERIES_PARENT, ES_SINGLE_EVENT}
 
-var DEFAULT_NON_SEARCHABLE_EVENT_SOURCE_TYPES = []string{ES_SERIES_PARENT}
+var DEFAULT_NON_SEARCHABLE_EVENT_SOURCE_TYPES = []string{ES_EVENT_SERIES}
 
 var ALL_EVENT_SOURCE_TYPES []string
 

--- a/functions/gateway/main.go
+++ b/functions/gateway/main.go
@@ -128,14 +128,13 @@ func init() {
 		{"/api/competition-config/{" + helpers.COMPETITIONS_ID_KEY + "}", "DELETE", dynamodb_handlers.DeleteCompetitionConfigHandler, Require},
 
 		// Competition Round
-		{"/api/competition-round/{" + helpers.COMPETITIONS_ID_KEY + "}", "PUT", dynamodb_handlers.PutCompetitionRoundsHandler, Require},                // creation or update
-		{"/api/competition-round/competition/{" + helpers.COMPETITIONS_ID_KEY + "}", "GET", dynamodb_handlers.GetAllCompetitionRoundsHandler, Require}, // Gets all rounds for a competition using begins_with
-		// below event can find all rounds associated with an event, and using 000_000 we can find all unassociated rounds
+		{"/api/competition-round/{" + helpers.COMPETITIONS_ID_KEY + "}", "PUT", dynamodb_handlers.PutCompetitionRoundsHandler, Require}, // creation or update
+		{"/api/competition-round/competition-sum/{" + helpers.COMPETITIONS_ID_KEY + "}", "GET", dynamodb_handlers.GetCompetitionRoundsScoreSums, Require},
+		{"/api/competition-round/competition/{" + helpers.COMPETITIONS_ID_KEY + "}", "GET", dynamodb_handlers.GetAllCompetitionRoundsHandler, Require},                                // Gets all rounds for a competition using begins_with
 		{"/api/competition-round/event/{" + helpers.EVENT_ID_KEY + "}", "GET", dynamodb_handlers.GetCompetitionRoundsByEventIdHandler, Require},                                       // This gets a single round item by the event id it is associated with
 		{"/api/competition-round/{" + helpers.COMPETITIONS_ID_KEY + "}/{" + helpers.ROUND_NUMBER_KEY + "}", "GET", dynamodb_handlers.GetCompetitionRoundByPrimaryKeyHandler, Require}, // This gets a single round item by its own id
 		{"/api/competition-round/{" + helpers.COMPETITIONS_ID_KEY + "}/{" + helpers.ROUND_NUMBER_KEY + "}", "DELETE", dynamodb_handlers.DeleteCompetitionRoundHandler, Require},
 		// summing, ending point for leader board needed here
-		{"/api/competition-round/competition-sum/" + helpers.COMPETITIONS_ID_KEY + "}", "GET", dynamodb_handlers.GetCompetitionRoundsScoreSums, Require},
 
 		// Competition Waiting Room
 		{"/api/waiting-room/{" + helpers.COMPETITIONS_ID_KEY + "}", "PUT", dynamodb_handlers.PutCompetitionWaitingRoomParticipantHandler, Require},

--- a/functions/gateway/main.go
+++ b/functions/gateway/main.go
@@ -135,6 +135,7 @@ func init() {
 		{"/api/competition-round/{" + helpers.COMPETITIONS_ID_KEY + "}/{" + helpers.ROUND_NUMBER_KEY + "}", "GET", dynamodb_handlers.GetCompetitionRoundByPrimaryKeyHandler, Require}, // This gets a single round item by its own id
 		{"/api/competition-round/{" + helpers.COMPETITIONS_ID_KEY + "}/{" + helpers.ROUND_NUMBER_KEY + "}", "DELETE", dynamodb_handlers.DeleteCompetitionRoundHandler, Require},
 		// summing, ending point for leader board needed here
+		{"/api/competition-round/competition-sum/" + helpers.COMPETITIONS_ID_KEY + "}", "GET", dynamodb_handlers.GetCompetitionRoundsScoreSums, Require},
 
 		// Competition Waiting Room
 		{"/api/waiting-room/{" + helpers.COMPETITIONS_ID_KEY + "}", "PUT", dynamodb_handlers.PutCompetitionWaitingRoomParticipantHandler, Require},

--- a/functions/gateway/services/marqo_service.go
+++ b/functions/gateway/services/marqo_service.go
@@ -681,7 +681,6 @@ func BulkGetMarqoEventByID(client *marqo.Client, docIds []string, parseDates str
 		log.Printf("Failed to get documents: %v", err)
 		return nil, err
 	}
-	log.Printf(">>> 684 res.Results: %+v", res.Results)
 	// Check if no documents were found
 	if len(res.Results) == 1 && res.Results[0]["_found"] == false {
 		log.Printf("No documents found for the given IDs, %v", docIds)

--- a/functions/gateway/templates/pages/competition_add_edit.templ
+++ b/functions/gateway/templates/pages/competition_add_edit.templ
@@ -128,7 +128,7 @@ templ AddOrEditCompetitionPage(pageObj helpers.SitePage, competition types.Compe
 					</template>
 				</div>
 				@components.UsersSelect([]types.UserSearchResultDangerous{}, "", "competitors", "Competitors", "competitors", false)
-				<template x-if="formData.competitors.length > 0 && usersDataLoaded">
+				<template x-if="formData?.competitors?.length > 0 && usersDataLoaded">
 					<template x-for="(competitor, idx) in competitors">
 						<div class="flex items-center gap-4 my-4 pl-4">
 							<span x-text="idx + 1 + '. ' + competitor.displayName"></span>
@@ -140,7 +140,7 @@ templ AddOrEditCompetitionPage(pageObj helpers.SitePage, competition types.Compe
 						<span>Loading competitors... <span class="loading loading-spinner loading-md text-primary"></span></span>
 					</div>
 				</template>
-				<template x-if="formData.competitors.length === 0 && usersDataLoaded">
+				<template x-if="formData?.competitors?.length === 0 && usersDataLoaded">
 					<div class="flex items-center gap-4 my-4 pl-4">No competitors yet</div>
 				</template>
 				<div class="divider"></div>
@@ -157,17 +157,17 @@ templ AddOrEditCompetitionPage(pageObj helpers.SitePage, competition types.Compe
 						</div>
 					</template>
 					<template x-if="teams.length > 0 && usersDataLoaded">
-						<ul x-sort="($item, $position) => handleTeamOrder($item, $position)" class="list-none p-0 grid grid-cols-1 md:grid-cols-2 gap-4 relative">
+						<ul class="list-none p-0 grid grid-cols-1 md:grid-cols-2 gap-4 relative">
 							<template x-for="(team, index) in teams" :key="team.value + '-' + index">
-								<li x-sort:item="team.value" class="card bg-base-100 shadow-md p-4">
+								<li class="card bg-base-100 shadow-md p-4">
 									<div class="flex items-center gap-2 mb-4">
-										<span x-sort:handle class="cursor-move">
-											<svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-												<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8h16M4 16h16"></path>
-											</svg>
-										</span>
+										// <span class="cursor-move">
+										// 	<svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+										// 		<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8h16M4 16h16"></path>
+										// 	</svg>
+										// </span>
 										<button
-											@click="removeTeam(team.value)"
+											@click="removeTeam(team)"
 											class="btn btn-ghost btn-circle btn-sm ml-auto"
 											:disabled="saveReqInFlight"
 										>
@@ -250,13 +250,13 @@ templ AddOrEditCompetitionPage(pageObj helpers.SitePage, competition types.Compe
 						</template>
 						<template x-if="teams.length > 1 || formData.rounds.length > 0">
 							<template x-for="(round, index) in formData.rounds" :key="index">
-								<li x-sort:item="round.roundNumber" class="card bg-base-100 shadow-md p-4 mb-4">
+								<li class="card bg-base-100 shadow-md p-4 mb-4">
 									<div class="flex items-center gap-2 mb-4">
-										<span x-sort:handle class="cursor-move">
-											<svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-												<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8h16M4 16h16"></path>
-											</svg>
-										</span>
+										// <span class="cursor-move">
+										// 	<svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+										// 		<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8h16M4 16h16"></path>
+										// 	</svg>
+										// </span>
 										<button
 											@click="removeRound(index)"
 											class="btn btn-ghost btn-circle btn-sm ml-auto"
@@ -303,16 +303,16 @@ templ AddOrEditCompetitionPage(pageObj helpers.SitePage, competition types.Compe
 											</template>
 										</select>
 									</div>
-                  <label class="form-control w-full max-w-xs">
-                    <div class="label">Round Description</div>
-                    <input
-                      class="input input-bordered w-full"
-                      id="round"
-                      type="text"
-                      placeholder="Enter Round description"
-                      x-model.fill="formData.description"
-                    />
-                  </label>
+									<label class="form-control w-full max-w-xs">
+										<div class="label">Round Description</div>
+										<input
+											class="input input-bordered w-full"
+											id="round"
+											type="text"
+											placeholder="Enter Round description"
+											x-model.fill="formData.description"
+										/>
+									</label>
 									<div class="divider"></div>
 									<div class="form-control mb-4">
 										<label class="cursor-pointer">
@@ -417,6 +417,7 @@ templ AddOrEditCompetitionPage(pageObj helpers.SitePage, competition types.Compe
 					// Set initial options to current owners
 					this.allOptions = this.owners;
 
+					if (this.formData?.competitors?.length > 0) {
 						try {
 							// Run both fetch requests in parallel
 							const [roundsResponse, usersResponse] = await Promise.all([
@@ -473,7 +474,10 @@ templ AddOrEditCompetitionPage(pageObj helpers.SitePage, competition types.Compe
 							this.usersDataLoaded = true
 							this.roundsDataLoaded = true
 						}
-
+					} else {
+						this.usersDataLoaded = true
+						this.roundsDataLoaded = true
+					}
 					})();
 
 				},
@@ -531,7 +535,7 @@ templ AddOrEditCompetitionPage(pageObj helpers.SitePage, competition types.Compe
 					this.waitingRoom = this.waitingRoom.filter(competitor => competitor.userId !== userId);
 				},
 				removeTeam(team) {
-					this.teams = this.teams.filter(_team => _team.name !== team.name);
+					this.teams = this.teams.filter(_team => _team.id !== team.id);
 				},
 				addTeam(teamName) {
 					this.teams.push({
@@ -656,23 +660,30 @@ templ AddOrEditCompetitionPage(pageObj helpers.SitePage, competition types.Compe
 									}))
 								};
 							}),
-							rounds: this.formData.rounds?.map?.(round => ({
-								...round,
-								...(this.formData.id ? { competitionId: this.formData.id } : {}),
-								// NOTE: we aren't using this yet
-								isPending: false,
-								competitorAScore: parseFloat(round.competitorAScore) ?? 0,
-								competitorBScore: parseFloat(round.competitorBScore) ?? 0,
-								// isPending
-								// isVotingOpen
-								// status
-								// eventId
-								// competitorA
-								// competitorB
-								// competitorAScore
-								// competitorBScore
-                // description
-							}))
+							rounds: this.formData?.rounds?.map?.(round => {
+								const _round  = JSON.parse(JSON.stringify(round))
+								delete _round.competitorADisplayName
+								delete _round.competitorBDisplayName
+								return {
+									..._round,
+									...(this.formData.id ? { competitionId: this.formData.id } : {}),
+									// NOTE: we aren't using this yet
+									isPending: false,
+									competitorAScore: parseFloat(_round?.competitorAScore) ?? 0,
+									competitorBScore: parseFloat(_round?.competitorBScore) ?? 0,
+									// competitorAScore: 0,
+									// competitorBScore: 0,
+									// isPending
+									// isVotingOpen
+									// status
+									// eventId
+									// competitorA
+									// competitorB
+									// competitorAScore
+									// competitorBScore
+									// description
+									}
+							})
 						};
 						const response = await fetch('/api/competition-config', {
 							method: 'PUT',

--- a/functions/gateway/templates/pages/competition_add_edit.templ
+++ b/functions/gateway/templates/pages/competition_add_edit.templ
@@ -303,16 +303,16 @@ templ AddOrEditCompetitionPage(pageObj helpers.SitePage, competition types.Compe
 											</template>
 										</select>
 									</div>
-									<label class="form-control w-full max-w-xs">
-										<div class="label">Round Description</div>
-										<input
-											class="input input-bordered w-full"
-											id="round"
-											type="text"
-											placeholder="Enter description"
-											x-model.fill="round.description"
-										/>
-									</label>
+                  <label class="form-control w-full max-w-xs">
+                    <div class="label">Round Description</div>
+                    <input
+                      class="input input-bordered w-full"
+                      id="round"
+                      type="text"
+                      placeholder="Enter Round description"
+                      x-model.fill="formData.description"
+                    />
+                  </label>
 									<div class="divider"></div>
 									<div class="form-control mb-4">
 										<label class="cursor-pointer">
@@ -671,7 +671,7 @@ templ AddOrEditCompetitionPage(pageObj helpers.SitePage, competition types.Compe
 								// competitorB
 								// competitorAScore
 								// competitorBScore
-								// description
+                // description
 							}))
 						};
 						const response = await fetch('/api/competition-config', {

--- a/functions/gateway/templates/pages/event_add_edit.templ
+++ b/functions/gateway/templates/pages/event_add_edit.templ
@@ -402,8 +402,17 @@ templ AddOrEditEventPage(pageObj helpers.SitePage, event types.Event, isEditor b
 									<template x-if="child.competitionConfigId">
 										<div class="form-control">
 											<label class="label">Competition Config</label>
+											<a class="link link-primary" :href="'/admin/competition/' + child.competitionConfigId + '/edit' ">
+												View Competition Config
+											</a>
 											<input disabled type="hidden" name="competitionConfigId" x-model.fill="child.competitionConfigId"/>
-											<template x-if="child?.competitionRounds?.length > 0">
+											<template x-if="child?.competitionConfigId && !competitionRoundsLoaded">
+												<div class="flex justify-between items-center">
+													<div>Loading competition rounds...</div>
+													<span class="loading loading-spinner loading-sm"></span>
+												</div>
+											</template>
+											<template x-if="child?.competitionConfigId && competitionRoundsLoaded">
 												<template x-for="(competitionRound, index) in child.competitionRounds">
 													<div class="flex justify-between items-center">
 														<div x-text=" (index + 1) + '. ' + competitionRound.roundName"></div>
@@ -986,7 +995,7 @@ templ AddOrEditEventPage(pageObj helpers.SitePage, event types.Event, isEditor b
 										competitionIdsToFetch.forEach(competitionId => {
 											promises.push(fetch(`/api/competition-round/competition/${competitionId}`))
 										})
-
+										this.competitionRoundsLoaded = false
 										const roundResponses = await Promise.all(promises)
 										const roundData = await Promise.all(roundResponses.map(r => r.json()))
 										// Flatten the array of round data arrays
@@ -1017,6 +1026,8 @@ templ AddOrEditEventPage(pageObj helpers.SitePage, event types.Event, isEditor b
 												}
 										});
 
+
+										this.competitionRoundsLoaded = true
 										this.$nextTick(() => {
 											// Dispatch event to trigger event child height recalculation
 											window.dispatchEvent(new CustomEvent('child-content-changed'));
@@ -1055,6 +1066,7 @@ templ AddOrEditEventPage(pageObj helpers.SitePage, event types.Event, isEditor b
 					competitionModalCompetitionSelection: null,
 					competitionModalRounds: [],
 					competitionModalRoundsLoading: false,
+					competitionRoundsLoaded: false,
 					competitionModalRoundSelections: [],
 					eventDetailUrl: document.querySelector('#add-edit-event').getAttribute('data-event-detail-url') ?? null,
 					eventChildrenLoaded: false,
@@ -1173,19 +1185,20 @@ templ AddOrEditEventPage(pageObj helpers.SitePage, event types.Event, isEditor b
 						})
 					},
 					transformEventToPayload(event) {
-						const eventFiltered = Object.fromEntries(
-							Object.entries(event)
+						const _event = JSON.parse(JSON.stringify(event))
+						const _eventFiltered = Object.fromEntries(
+							Object.entries(_event)
 								// eslint-disable-next-line no-unused-vars
 								.filter(([_, value]) => value !== '')
 						)
-						if (!event.hasPurchasable) {
-							delete eventFiltered.startingPrice
-							delete eventFiltered.currency
-							delete eventFiltered.payeeId
+						if (!_event.hasPurchasable) {
+							delete _eventFiltered.startingPrice
+							delete _eventFiltered.currency
+							delete _eventFiltered.payeeId
 						}
 
 						return {
-							...eventFiltered,
+							..._eventFiltered,
 							startTime: this.formData.event.startTime ? this.formData.event.startTime + this.timeZuluSuffix : null,
 							endTime: this.formData.event.endTime ? this.formData.event.endTime + this.timeZuluSuffix : null,
 							lat: parseFloat(this.formData.event.lat),
@@ -1480,17 +1493,18 @@ templ AddOrEditEventPage(pageObj helpers.SitePage, event types.Event, isEditor b
 						competitionRound.isRemoving = true;
 
 						try {
-								let roundUpdate = {
-									...competitionRound,
+								const _competitionRound = JSON.parse(JSON.stringify(competitionRound))
+								let _roundUpdate = {
+									..._competitionRound,
 									eventId: this.roundEmptyEventId
 								}
-								delete roundUpdate.isRemoving
+								delete _roundUpdate.isRemoving
 								const response = await fetch(`/api/competition-round/${competitionRound.competitionId}`, {
 										method: 'PUT',
 										headers: {
 												'Content-Type': 'application/json',
 										},
-										body: JSON.stringify([roundUpdate]),
+										body: JSON.stringify([_roundUpdate]),
 								});
 
 								if (!response.ok) {
@@ -1526,18 +1540,18 @@ templ AddOrEditEventPage(pageObj helpers.SitePage, event types.Event, isEditor b
 
 					async handlePublishClick() {
 						this.saveReqInFlight = true
-						const parentEvent = this.transformEventToPayload(this.formData.event)
+						const _parentEvent = JSON.parse(JSON.stringify(this.transformEventToPayload(this.formData.event)))
 						this.purchasables = this.purchasables.map(p => ({
 							...p,
 							currency: this.formData.event.currency,
 						}))
 						// NOTE: never set the eventSourceId on the parent event, it IS the parent
-						delete parentEvent.eventSourceId
-						delete parentEvent.competitionRounds
+						delete _parentEvent.eventSourceId
+						delete _parentEvent.competitionRounds
 
 						let payload = {
 							events: [{
-								...parentEvent,
+								..._parentEvent,
 							}],
 							purchasableUpdate: {
 								event_id: this.formData.event.id,
@@ -1561,15 +1575,17 @@ templ AddOrEditEventPage(pageObj helpers.SitePage, event types.Event, isEditor b
 								// body size limit constraints. The API will
 								// always take the parent event's description
 								// and seed it to each child event
-								delete parentEvent.description
-								delete child.description
+								const _childEvent = JSON.parse(JSON.stringify(child))
 
-								delete child.competitionRounds
+								delete _parentEvent.description
+								delete _childEvent.description
+
+								delete _childEvent.competitionRounds
 								// NOTE: never override the child event's id with the parent id
-								delete parentEvent.id
+								delete _parentEvent.id
 								payload.events.push({
-									...parentEvent,
-									...child,
+									..._parentEvent,
+									..._childEvent,
 									eventSourceId: this.formData.event.id,
 									startTime: child.startTime ? child.startTime + this.timeZuluSuffix : null,
 									endTime: child.endTime ? child.endTime + this.timeZuluSuffix : null,

--- a/functions/gateway/templates/pages/event_add_edit.templ
+++ b/functions/gateway/templates/pages/event_add_edit.templ
@@ -341,7 +341,7 @@ templ AddOrEditEventPage(pageObj helpers.SitePage, event types.Event, isEditor b
 					<div>
 						if event.EventSourceType == helpers.ES_SERIES_PARENT {
 							<div
-								hx-get={ "/api/html/event-series-form/" + event.Id + "?&event_source_ids=" + event.Id }
+								hx-get={ "/api/html/event-series-form/" + event.Id + "?&event_source_ids=" + event.Id + "&event_source_types=" + helpers.ES_EVENT_SERIES }
 								hx-trigger="load"
 								hx-swap="outerHTML"
 								@htmx:after-request="setEventChildrenLoaded()"

--- a/functions/gateway/templates/pages/event_details.templ
+++ b/functions/gateway/templates/pages/event_details.templ
@@ -386,7 +386,7 @@ templ EventDetailsPage(event types.Event, userInfo helpers.UserInfo, canEdit boo
 						});
 
 						const data = await response.json();
-						if (response.status !== 200) {
+						if (response.status > 400) {
 							throw new Error(data.message || 'Vote submission failed')
 						}
 					} catch (e) {

--- a/functions/gateway/templates/pages/event_details.templ
+++ b/functions/gateway/templates/pages/event_details.templ
@@ -6,6 +6,7 @@ import (
 	"github.com/meetnearme/api/functions/gateway/types"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 )
 
@@ -23,12 +24,16 @@ templ IconLeftSection(labelText, labelValue, icon string, urlString string, sect
 					<strong>{ labelText }:</strong>
 					// TODO: rewrite this after migrating to `event.EventOwners` array (required marqo db migration)
 					{{ eventOwnersArr := strings.Split(event.EventOwnerName, helpers.EventOwnerNameDelimiter) }}
-					for idx, owner := range event.EventOwners {
-						if idx > 0 {
-							,&nbsp;
+					// Fallback: if no delimiter was found, use the entire EventOwnerName
+					if len(eventOwnersArr) == 1 && len(event.EventOwners) > 0 {
+						<a class="link link-primary" href={ templ.URL(os.Getenv("APEX_URL") + "/user/" + event.EventOwners[0]) }>{ event.EventOwnerName }</a>
+					} else {
+						for idx, owner := range event.EventOwners {
+							if idx > 0 {
+								,&nbsp;
+							}
+							<a class="link link-primary" href={ templ.URL(os.Getenv("APEX_URL") + "/user/" + owner) }>{ eventOwnersArr[idx] }</a>
 						}
-						<a class="link link-primary" href={ templ.URL(os.Getenv("APEX_URL") + "/user/" + owner) }>{ eventOwnersArr[idx] }</a>
-						// <a class="link link-primary" href={ templ.URL("https://" + owner + "." + os.Getenv("APEX_URL")) }>{ eventOwnersArr[idx] }</a>
 					}
 				} else if urlString != "" {
 					<strong>{ labelText }:</strong> <a class="link link-primary" href={ templ.URL(urlString) }>{ labelValue }</a>
@@ -114,7 +119,7 @@ templ EventDetailsPage(event types.Event, userInfo helpers.UserInfo, canEdit boo
 			if event.EventSourceType == helpers.ES_SERIES_PARENT {
 				<h3 class="text-xl mt-2">Event Series</h3>
 				<div
-					hx-get={ "/api/html/events?list_mode=" + helpers.EV_MODE_CAROUSEL + "&radius=500000&end_time=2099-10-18T10:00:00Z&event_source_ids=" + event.Id }
+					hx-get={ "/api/html/events?list_mode=" + helpers.EV_MODE_CAROUSEL + "&radius=" + strconv.Itoa(helpers.DEFAULT_MAX_RADIUS) + "&end_time=2099-10-18T10:00:00Z&event_source_ids=" + event.Id + "&event_source_types=" + helpers.ES_EVENT_SERIES }
 					hx-trigger="load"
 					hx-swap="outerHTML"
 				>
@@ -123,7 +128,9 @@ templ EventDetailsPage(event types.Event, userInfo helpers.UserInfo, canEdit boo
 			}
 			<br/>
 			<p>
-				@IconLeftSection("Host", event.EventOwnerName, "community", `/?owners=`+event.EventOwners[0], "OWNER_NAME", event)
+				if event.EventOwnerName != "" {
+					@IconLeftSection("Host", event.EventOwnerName, "community", `/?owners=`+event.EventOwners[0], "OWNER_NAME", event)
+				}
 				<br/>
 				@IconLeftSection("Venue", event.Address, "location", "/?address="+event.Address, "VENUE", event)
 				<br/>
@@ -145,7 +152,7 @@ templ EventDetailsPage(event types.Event, userInfo helpers.UserInfo, canEdit boo
 					<div class="divider my-3"></div>
 					<h3 class="text-xl mt-2 mb-2">All Events in this Series</h3>
 					<div
-						hx-get={ "/api/html/events?list_mode=" + helpers.EV_MODE_CAROUSEL + "&radius=500000&end_time=2099-10-18T10:00:00Z&event_source_ids=" + event.EventSourceId }
+						hx-get={ "/api/html/events?list_mode=" + helpers.EV_MODE_CAROUSEL + "&radius=500000&end_time=2099-10-18T10:00:00Z&event_source_ids=" + event.EventSourceId + "&event_source_types=" + helpers.ES_EVENT_SERIES }
 						hx-trigger="load"
 						hx-swap="outerHTML"
 					>

--- a/functions/gateway/templates/pages/home.templ
+++ b/functions/gateway/templates/pages/home.templ
@@ -183,6 +183,7 @@ func GetPageUserID(pageUser *types.UserSearchResult) string {
 }
 
 templ HomePage(events []types.Event, pageUser *types.UserSearchResult, cfLocation helpers.CdnLocation, latStr, lonStr, origLat, origLong string) {
+	// we assume this is "home" and not a community / user profile page
 	if pageUser == nil {
 		<div class="header-hero bg-[#00ffzz]">
 			<h1 class="text-xl md:text-4xl text-center mb-5">
@@ -197,7 +198,9 @@ templ HomePage(events []types.Event, pageUser *types.UserSearchResult, cfLocatio
 			<h1 class="text-5xl alt-title font-bold text-center uppercase">{ pageUser.DisplayName }</h1>
 			if pageUser.Metadata != nil && pageUser.Metadata[helpers.META_ABOUT_KEY] != "" {
 				<h2 class="text-3xl font-bold uppercase my-10">About</h2>
-				<p class="whitespace-pre-wrap">{ pageUser.Metadata[helpers.META_ABOUT_KEY] }</p>
+				<div class="prose prose-invert max-w-none">
+					@templ.Raw(pageUser.Metadata[helpers.META_ABOUT_KEY])
+				</div>
 			}
 		</div>
 	}

--- a/functions/gateway/templates/pages/home_templ_test.go
+++ b/functions/gateway/templates/pages/home_templ_test.go
@@ -78,7 +78,7 @@ func TestHomePage(t *testing.T) {
 				"Test Event 2",
 				"New York, US",
 				"data-page-user-id=\"1234567890\"",
-				"Welcome to Brian&#39;s Pub",
+				"Welcome to Brian's Pub",
 				"Brian&#39;s Pub</h1>",
 			},
 		},

--- a/functions/gateway/templates/pages/layout.templ
+++ b/functions/gateway/templates/pages/layout.templ
@@ -23,7 +23,7 @@ templ Layout(sitePage helpers.SitePage, userInfo helpers.UserInfo, pageContent t
 			<link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400&family=Ubuntu+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Anton&family=Unbounded:wght@900&display=swap" rel="stylesheet"/>
 			// 🚨 WARNING 🚨 This filename is automatically updated by PostCSS
 			// ✅ DO commit it to version control whenever you see it change
-			<link rel="stylesheet" href={ templ.EscapeString(os.Getenv("STATIC_BASE_URL") + "/assets/styles.76094cea.css") }/>
+			<link rel="stylesheet" href={ templ.EscapeString(os.Getenv("STATIC_BASE_URL") + "/assets/styles.035ee10e.css") }/>
 			<meta name="viewport" content="width=device-width, initial-scale=1"/>
 			<script src="https://unpkg.com/htmx.org@1.9.12"></script>
 			<script src="https://unpkg.com/htmx.org@1.9.12/dist/ext/json-enc.js"></script>

--- a/functions/gateway/templates/pages/layout.templ
+++ b/functions/gateway/templates/pages/layout.templ
@@ -23,7 +23,7 @@ templ Layout(sitePage helpers.SitePage, userInfo helpers.UserInfo, pageContent t
 			<link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400&family=Ubuntu+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Anton&family=Unbounded:wght@900&display=swap" rel="stylesheet"/>
 			// 🚨 WARNING 🚨 This filename is automatically updated by PostCSS
 			// ✅ DO commit it to version control whenever you see it change
-			<link rel="stylesheet" href={ templ.EscapeString(os.Getenv("STATIC_BASE_URL") + "/assets/styles.035ee10e.css") }/>
+			<link rel="stylesheet" href={ templ.EscapeString(os.Getenv("STATIC_BASE_URL") + "/assets/styles.fcf069c1.css") }/>
 			<meta name="viewport" content="width=device-width, initial-scale=1"/>
 			<script src="https://unpkg.com/htmx.org@1.9.12"></script>
 			<script src="https://unpkg.com/htmx.org@1.9.12/dist/ext/json-enc.js"></script>

--- a/functions/gateway/types/competitions.go
+++ b/functions/gateway/types/competitions.go
@@ -116,7 +116,7 @@ type CompetitionRound struct {
 
 type CompetitionRoundUpdate struct {
 	// TODO: clean these up for iterative saving in incomplete state
-	CompetitionId    string  `json:"competitionId" dynamodbav:"competitionId"`
+	CompetitionId    string  `json:"competitionId" dynamodbav:"competitionId" validate:"required"`
 	RoundNumber      int64   `json:"roundNumber" dynamodbav:"roundNumber" validate:"required"`
 	EventId          string  `json:"eventId,omitempty" dynamodbav:"eventId"`
 	RoundName        string  `json:"roundName" dynamodbav:"roundName" validate:"required"`

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -101,6 +101,18 @@ export default {
           borderBottomRightRadius: 'inherit',
           borderBottomLeftRadius: 'inherit',
         },
+        '.carousel-control-left': {
+          display: 'none',
+          '@screen md': {
+            display: 'block',
+          },
+        },
+        '.carousel-control-right': {
+          display: 'none',
+          '@screen md': {
+            display: 'block',
+          },
+        },
       });
     },
   ],


### PR DESCRIPTION
Also includes

* Bugfixes for event + competition admin pages that would cause teams to not be created, competitions / events to lose data after saving
* Remove sortable on `competitions` admin for better mobile experience
* Move to show `event series` by default on home / community pages
* fix carousel nav layout bug on mobile
* enable HTML / richtext for links on community / user pages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new API endpoint to view competition round score summaries.
  - Added a direct link to access competition settings from event management.
  - Enabled responsive carousel navigation controls on medium and larger screens.

- **Bug Fixes**
  - Improved error handling for data retrieval and vote submission, reducing unexpected interruptions.
  - Refined data fetching and validation in competition and event pages for smoother user interactions.

- **Refactor & Style**
  - Streamlined competition management workflows with enhanced team removal and round handling.
  - Updated page layouts to provide a cleaner design and improved metadata presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->