### PR TITLE
Pre-launch bugfix festival 🎉 

### DIFF
--- a/functions/gateway/handlers/data_handlers.go
+++ b/functions/gateway/handlers/data_handlers.go
@@ -528,11 +528,14 @@ func GetUsersHandler(w http.ResponseWriter, r *http.Request) http.HandlerFunc {
 				activeRequests++
 				go func(id string) {
 					membersString, err := helpers.GetOtherUserMetaByID(id, "members")
-					if err != nil {
-						metaChan <- userMetaResult{id: id, members: []string{}, err: err}
+					if throwOnMissing && err != nil {
+						metaChan <- userMetaResult{id: id, members: nil, err: err}
 						return
 					}
-					members := strings.Split(membersString, ",")
+					members := []string{}
+					if membersString != "" {
+						members = strings.Split(membersString, ",")
+					}
 					metaChan <- userMetaResult{id: id, members: members, err: nil}
 				}(id)
 			}

--- a/functions/gateway/handlers/data_handlers_test.go
+++ b/functions/gateway/handlers/data_handlers_test.go
@@ -1436,7 +1436,14 @@ func TestGetUsersHandler(t *testing.T) {
 			pathParts := strings.Split(r.URL.Path, "/")
 			id := pathParts[len(pathParts)-3] // Assuming ID is second-to-last part
 			if id == "tm_b8de1f5b-d377-458e-a47e-96123afcc6f3" {
-				http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				// Return an empty or invalid metadata structure to trigger the error
+				json.NewEncoder(w).Encode(map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"value": "", // This will cause GetBase64ValueFromMap to return empty string
+					},
+				})
 				return
 			}
 
@@ -1478,6 +1485,24 @@ func TestGetUsersHandler(t *testing.T) {
 
 			switch {
 			case len(userIds) == 1 && strings.HasPrefix(userIds[0], "tm_"):
+				// Check if this is the error test case
+				if userIds[0] == "tm_b8de1f5b-d377-458e-a47e-96123afcc6f3" {
+					// Return a successful user search response
+					json.NewEncoder(w).Encode(map[string]interface{}{
+						"result": []map[string]interface{}{
+							{
+								"userId": userIds[0],
+								"human": map[string]interface{}{
+									"profile": map[string]interface{}{
+										"displayName": "Test User",
+									},
+								},
+							},
+						},
+					})
+					return
+				}
+
 				response.Result = []struct {
 					UserID             string `json:"userId"`
 					Username           string `json:"username"`

--- a/functions/gateway/main.go
+++ b/functions/gateway/main.go
@@ -122,6 +122,7 @@ func init() {
 		// Competition Config
 		{"/api/competition-config", "PUT", dynamodb_handlers.UpdateCompetitionConfigHandler, Require},
 		{"/api/competition-config/owner", "GET", dynamodb_handlers.GetCompetitionConfigsByPrimaryOwnerHandler, Require},
+		{"/api/competition-config/owner/{" + helpers.USER_ID_KEY + "}", "GET", dynamodb_handlers.GetCompetitionConfigsByPrimaryOwnerHandler, Require},
 		{"/api/competition-config/{" + helpers.COMPETITIONS_ID_KEY + "}", "GET", dynamodb_handlers.GetCompetitionConfigByIdHandler, Require},
 		// verify below is correct with brian, was not accessing userId from context
 		{"/api/competition-config/{" + helpers.COMPETITIONS_ID_KEY + "}", "PUT", dynamodb_handlers.UpdateCompetitionConfigHandler, Require},

--- a/functions/gateway/services/dynamodb_service/purchases_service.go
+++ b/functions/gateway/services/dynamodb_service/purchases_service.go
@@ -291,8 +291,6 @@ func (s *PurchaseService) HasPurchaseForEvent(ctx context.Context, dynamodbClien
 		return false, fmt.Errorf("query failed: %w", err)
 	}
 
-	log.Printf("result: %+v", result)
-
 	var purchases []internal_types.Purchase
 	err = attributevalue.UnmarshalListOfMaps(result.Items, &purchases)
 	if err != nil {

--- a/functions/gateway/templates/pages/competition_add_edit.templ
+++ b/functions/gateway/templates/pages/competition_add_edit.templ
@@ -85,6 +85,24 @@ templ AddOrEditCompetitionPage(pageObj helpers.SitePage, competition types.Compe
 				// Replace the owners section with the new component
 				@components.UsersSelect(users, competition.PrimaryOwner, "owners", "Additional Admins", "admins", true)
 				<div class="divider"></div>
+				<div class="form-control">
+					<label class="label">Start Time</label>
+					<input
+						type="datetime-local"
+						x-model.fill="formData.startTime"
+						class="input input-bordered"
+						:disabled="saveReqInFlight"
+					/>
+					<div class="form-control">
+						<label class="label">End Time</label>
+						<input
+							type="datetime-local"
+							x-model.fill="formData.endTime"
+							class="input input-bordered"
+							:disabled="saveReqInFlight"
+						/>
+					</div>
+				</div>
 			</div>
 		</div>
 		<h2 class="card-title sticky sticky-under-top-nav subheader bg-base-100 z-40 py-2">Competitors</h2>
@@ -396,7 +414,7 @@ templ AddOrEditCompetitionPage(pageObj helpers.SitePage, competition types.Compe
 			</div>
 		</template>
 	</div>
-	<script id="add-edit-competition" data-competition-name={ competition.Name } data-competition-module-type={ competition.ModuleType } data-competition-scoring-method={ competition.ScoringMethod } data-competition-id={ competition.Id } data-competition-auxilary-owners={ string(helpers.ToJSON(competition.AuxilaryOwners)) } data-competition-primary-owner={ competition.PrimaryOwner } data-competition-owners={ string(helpers.ToJSON(users)) } data-competition-detail-url={ strings.Replace(strings.Replace(helpers.SitePages["competition-detail"].Slug, helpers.COMPETITIONS_ID_KEY, "", 1), "{trailingslash:\\/?}", "", 1) } data-competition-empty-team-name={ helpers.COMP_EMPTY_TEAM_NAME } data-round-empty-event-id={ helpers.COMP_UNASSIGNED_ROUND_EVENT_ID } data-team-id-prefix={ helpers.COMP_TEAM_ID_PREFIX } competition-competitors={ string(helpers.ToJSON(competition.Competitors)) }>
+	<script id="add-edit-competition" data-competition-name={ competition.Name } data-competition-module-type={ competition.ModuleType } data-competition-scoring-method={ competition.ScoringMethod } data-competition-id={ competition.Id } data-competition-auxilary-owners={ string(helpers.ToJSON(competition.AuxilaryOwners)) } data-competition-primary-owner={ competition.PrimaryOwner } data-competition-owners={ string(helpers.ToJSON(users)) } data-competition-detail-url={ strings.Replace(strings.Replace(helpers.SitePages["competition-detail"].Slug, helpers.COMPETITIONS_ID_KEY, "", 1), "{trailingslash:\\/?}", "", 1) } data-competition-empty-team-name={ helpers.COMP_EMPTY_TEAM_NAME } data-round-empty-event-id={ helpers.COMP_UNASSIGNED_ROUND_EVENT_ID } data-team-id-prefix={ helpers.COMP_TEAM_ID_PREFIX } competition-competitors={ string(helpers.ToJSON(competition.Competitors)) } data-competition-start-time={ helpers.GetDatetimePickerFormatted(competition.StartTime, nil) } data-competition-end-time={ helpers.GetDatetimePickerFormatted(competition.EndTime, nil) }>
 		function getEditCompetitionState() {
 			return {
 				init() {
@@ -416,7 +434,7 @@ templ AddOrEditCompetitionPage(pageObj helpers.SitePage, competition types.Compe
 
 					// Set initial options to current owners
 					this.allOptions = this.owners;
-
+console.log('this.formData.competitors', this.formData.competitors)
 					if (this.formData?.competitors?.length > 0) {
 						try {
 							// Run both fetch requests in parallel
@@ -443,6 +461,9 @@ templ AddOrEditCompetitionPage(pageObj helpers.SitePage, competition types.Compe
 									...round
 								}
 							})
+
+              console.log('usersData', usersData)
+
 
 							this.teams = usersData
 								.filter(user => user.userId.startsWith('tm_'))
@@ -480,6 +501,8 @@ templ AddOrEditCompetitionPage(pageObj helpers.SitePage, competition types.Compe
 					}
 					})();
 
+          console.log("temp", document.querySelector('#add-edit-competition').getAttribute('data-competition-start-time'))
+
 				},
 				usersDataLoaded: false,
 				roundsDataLoaded: false,
@@ -496,6 +519,20 @@ templ AddOrEditCompetitionPage(pageObj helpers.SitePage, competition types.Compe
 					primaryOwner: document.querySelector('#add-edit-competition').getAttribute('data-competition-primary-owner'),
 					competitors: JSON.parse(document.querySelector('#add-edit-competition').getAttribute('competition-competitors')),
 					rounds: [],
+          startTime: document.querySelector('#add-edit-competition').getAttribute('data-competition-start-time') === '1970-01-01T00:00' ? (() => {
+						const now = new Date();
+						// Convert to local ISO string and trim off seconds/milliseconds
+						return new Date(now.getTime() - (now.getTimezoneOffset() * 60000))
+							.toISOString()
+							.slice(0, 16);
+					})() : document.querySelector('#add-edit-competition').getAttribute('data-competition-start-time'),
+          endTime: document.querySelector('#add-edit-competition').getAttribute('data-competition-end-time') === '1970-01-01T00:00' ? (() => {
+						const now = new Date();
+						// Convert to local ISO string and trim off seconds/milliseconds
+						return new Date(now.getTime() - (now.getTimezoneOffset() * 60000))
+							.toISOString()
+							.slice(0, 16);
+					})() : document.querySelector('#add-edit-competition').getAttribute('data-competition-end-time'),
 				},
 				saveReqInFlight: false,
 				// tallyVotesReqInFlight: false,
@@ -644,11 +681,14 @@ templ AddOrEditCompetitionPage(pageObj helpers.SitePage, competition types.Compe
 							})
 							return ids
 						})
+            console.log('this.formData.startTime', this.formData.startTime)
 						const competitionData = {
 							...this.formData,
 							// eslint-disable-next-line no-unused-vars
 							auxilaryOwners: Object.entries(this.owners).map(([key, val]) => val.value),
 							competitors,
+              startTime: this.formData.startTime ? Math.floor(new Date(this.formData.startTime).getTime() / 1000) : 0,
+              endTime: this.formData.endTime ? Math.floor(new Date(this.formData.endTime).getTime() / 1000) : 0,
 							teams: this.teams?.map?.(team => {
 								// Create a new object without mutating the original
 								const { label, ...restTeam } = team;

--- a/functions/gateway/templates/pages/competition_add_edit.templ
+++ b/functions/gateway/templates/pages/competition_add_edit.templ
@@ -86,7 +86,7 @@ templ AddOrEditCompetitionPage(pageObj helpers.SitePage, competition types.Compe
 				@components.UsersSelect(users, competition.PrimaryOwner, "owners", "Additional Admins", "admins", true)
 				<div class="divider"></div>
 				<div class="form-control">
-					<label class="label">Start Time</label>
+					<label class="label">Start Time (of First Event)</label>
 					<input
 						type="datetime-local"
 						x-model.fill="formData.startTime"
@@ -94,7 +94,7 @@ templ AddOrEditCompetitionPage(pageObj helpers.SitePage, competition types.Compe
 						:disabled="saveReqInFlight"
 					/>
 					<div class="form-control">
-						<label class="label">End Time</label>
+						<label class="label">End Time (of Last Event)</label>
 						<input
 							type="datetime-local"
 							x-model.fill="formData.endTime"
@@ -434,7 +434,6 @@ templ AddOrEditCompetitionPage(pageObj helpers.SitePage, competition types.Compe
 
 					// Set initial options to current owners
 					this.allOptions = this.owners;
-console.log('this.formData.competitors', this.formData.competitors)
 					if (this.formData?.competitors?.length > 0) {
 						try {
 							// Run both fetch requests in parallel
@@ -461,9 +460,6 @@ console.log('this.formData.competitors', this.formData.competitors)
 									...round
 								}
 							})
-
-              console.log('usersData', usersData)
-
 
 							this.teams = usersData
 								.filter(user => user.userId.startsWith('tm_'))
@@ -500,9 +496,6 @@ console.log('this.formData.competitors', this.formData.competitors)
 						this.roundsDataLoaded = true
 					}
 					})();
-
-          console.log("temp", document.querySelector('#add-edit-competition').getAttribute('data-competition-start-time'))
-
 				},
 				usersDataLoaded: false,
 				roundsDataLoaded: false,
@@ -519,14 +512,14 @@ console.log('this.formData.competitors', this.formData.competitors)
 					primaryOwner: document.querySelector('#add-edit-competition').getAttribute('data-competition-primary-owner'),
 					competitors: JSON.parse(document.querySelector('#add-edit-competition').getAttribute('competition-competitors')),
 					rounds: [],
-          startTime: document.querySelector('#add-edit-competition').getAttribute('data-competition-start-time') === '1970-01-01T00:00' ? (() => {
+					startTime: document.querySelector('#add-edit-competition').getAttribute('data-competition-start-time') === '1970-01-01T00:00' ? (() => {
 						const now = new Date();
 						// Convert to local ISO string and trim off seconds/milliseconds
 						return new Date(now.getTime() - (now.getTimezoneOffset() * 60000))
 							.toISOString()
 							.slice(0, 16);
 					})() : document.querySelector('#add-edit-competition').getAttribute('data-competition-start-time'),
-          endTime: document.querySelector('#add-edit-competition').getAttribute('data-competition-end-time') === '1970-01-01T00:00' ? (() => {
+					endTime: document.querySelector('#add-edit-competition').getAttribute('data-competition-end-time') === '1970-01-01T00:00' ? (() => {
 						const now = new Date();
 						// Convert to local ISO string and trim off seconds/milliseconds
 						return new Date(now.getTime() - (now.getTimezoneOffset() * 60000))
@@ -681,14 +674,29 @@ console.log('this.formData.competitors', this.formData.competitors)
 							})
 							return ids
 						})
-            console.log('this.formData.startTime', this.formData.startTime)
+						const formatDateTime = (dateTimeStr) => {
+							if (!dateTimeStr) return 0;
+							// Add seconds if they're missing
+							const formattedStr = dateTimeStr.includes(':') ?
+								(dateTimeStr.match(/:/g).length === 1 ? `${dateTimeStr}:00` : dateTimeStr) :
+								`${dateTimeStr}:00:00`;
+							return Math.floor(new Date(formattedStr).getTime() / 1000);
+						};
+
+						// Add this new function to convert Unix timestamp back to datetime-local format
+						const formatUnixToDateTimeLocal = (unixTimestamp) => {
+							if (!unixTimestamp) return '';
+							const date = new Date(unixTimestamp * 1000); // Multiply by 1000 to convert seconds to milliseconds
+							return date.toISOString().slice(0, 16); // Get yyyy-MM-ddThh:mm format
+						};
+
 						const competitionData = {
 							...this.formData,
 							// eslint-disable-next-line no-unused-vars
 							auxilaryOwners: Object.entries(this.owners).map(([key, val]) => val.value),
 							competitors,
-              startTime: this.formData.startTime ? Math.floor(new Date(this.formData.startTime).getTime() / 1000) : 0,
-              endTime: this.formData.endTime ? Math.floor(new Date(this.formData.endTime).getTime() / 1000) : 0,
+							startTime: formatDateTime(this.formData.startTime),
+							endTime: formatDateTime(this.formData.endTime),
 							teams: this.teams?.map?.(team => {
 								// Create a new object without mutating the original
 								const { label, ...restTeam } = team;
@@ -746,7 +754,9 @@ console.log('this.formData.competitors', this.formData.competitors)
 								window.history.pushState({ path: newUrl }, '', newUrl);
 							}
 							this.formData = {
-								...json
+								...json,
+								startTime: formatUnixToDateTimeLocal(json.startTime),
+								endTime: formatUnixToDateTimeLocal(json.endTime)
 							}
 						} else {
 							throw new Error(`Failed to update competition ${ json?.error?.message ? ": " + json.error.message : ''}`)

--- a/functions/gateway/templates/pages/event_add_edit.templ
+++ b/functions/gateway/templates/pages/event_add_edit.templ
@@ -267,7 +267,7 @@ templ AddOrEditEventPage(pageObj helpers.SitePage, event types.Event, isEditor b
 					type="datetime-local"
 					x-model.fill={ "formData.event.startTime" }
 					if (event.StartTime > 0) {
-						value={ helpers.GetDatetimePickerFormatted(event.StartTime, event.Timezone) }
+						value={ helpers.GetDatetimePickerFormatted(event.StartTime, &event.Timezone) }
 					}
 					:disabled="saveReqInFlight"
 				/>
@@ -279,7 +279,7 @@ templ AddOrEditEventPage(pageObj helpers.SitePage, event types.Event, isEditor b
 					type="datetime-local"
 					x-model.fill={ "formData.event.endTime" }
 					if (event.EndTime > 0) {
-						value={ helpers.GetDatetimePickerFormatted(event.EndTime, event.Timezone) }
+						value={ helpers.GetDatetimePickerFormatted(event.EndTime, &event.Timezone) }
 					}
 					:disabled="saveReqInFlight"
 				/>

--- a/functions/gateway/templates/pages/home.templ
+++ b/functions/gateway/templates/pages/home.templ
@@ -203,6 +203,11 @@ templ HomePage(events []types.Event, pageUser *types.UserSearchResult, cfLocatio
 				</div>
 			}
 		</div>
+		<template x-if="competitions?.length">
+			<template x-for="competition in competitions">
+				<div x-text="JSON.stringify(competition)"></div>
+			</template>
+		</template>
 	}
 	<div class="min-h-screen">
 		if pageUser == nil {
@@ -533,7 +538,7 @@ templ HomePage(events []types.Event, pageUser *types.UserSearchResult, cfLocatio
 
 		function getHomeState() {
 			return {
-				init() {
+				async init() {
 					this.updateParamsFromUrl(false);
 
 					// enhance history.pushState with a listener and call it on every
@@ -559,7 +564,18 @@ templ HomePage(events []types.Event, pageUser *types.UserSearchResult, cfLocatio
 					window.addEventListener('popstate', () => {
 						this.updateParamsFromUrl();
 					});
+
+          console.log('this.pageUserId', this.pageUserId)
+          await fetch(`/api/competition-config/owner/${this.pageUserId}`).then(res => {
+            return res.json()
+          }).then(json => {
+            console.log(json)
+            this.competitions = json
+          });
+
 				},
+        competitions: [],
+        pageUserId: document.querySelector('#alpine-state').getAttribute('data-page-user-id'),
 				start_time: null,
 				end_time: null,
 				q: null,

--- a/functions/gateway/templates/pages/home.templ
+++ b/functions/gateway/templates/pages/home.templ
@@ -194,7 +194,7 @@ templ HomePage(events []types.Event, pageUser *types.UserSearchResult, cfLocatio
 			</h1>
 		</div>
 	} else {
-		<div class="space-y-10">
+		<div class="space-y-10" x-data="getCompetitionsState()">
 			<h1 class="text-5xl alt-title font-bold text-center uppercase">{ pageUser.DisplayName }</h1>
 			if pageUser.Metadata != nil && pageUser.Metadata[helpers.META_ABOUT_KEY] != "" {
 				<h2 class="text-3xl font-bold uppercase my-10">About</h2>
@@ -202,12 +202,40 @@ templ HomePage(events []types.Event, pageUser *types.UserSearchResult, cfLocatio
 					@templ.Raw(pageUser.Metadata[helpers.META_ABOUT_KEY])
 				</div>
 			}
-		</div>
-		<template x-if="competitions?.length">
-			<template x-for="competition in competitions">
-				<div x-text="JSON.stringify(competition)"></div>
+			<template x-if="competitions?.length">
+				<div>
+					<h2 class="text-3xl font-bold uppercase my-10">Competitions</h2>
+					<template x-for="competition in competitions">
+						<div>
+							<div x-text="competition.name"></div>
+							<h3 x-text="competition.name" class="text-2xl font-bold my-10"></h3>
+							<h4 class="text-xl font-bold my-2 uppercase">Rounds</h4>
+							<template x-if="rounds && rounds[competition.id]">
+								<template x-for="round in rounds[competition.id]">
+									<template x-if="round.eventId !== fakeEventId">
+										<a class="link link-primary" :href="`/event/${round.eventId}`"><div x-text="round.roundName"></div></a>
+									</template>
+									<template x-if="round.eventId === fakeEventId">
+										<div x-text="round.roundName"></div>
+									</template>
+								</template>
+							</template>
+							<template x-if="leaderboards && leaderboards[competition.id]">
+								<div>
+									<h3 class="text-xl font-bold my-2 uppercase">Leaderboard</h3>
+									<template x-for="[teamId, score] in Object.entries(leaderboards[competition.id])">
+										<div class="flex justify-between border-b border-gray-700">
+											<div x-text="users.find(user => user.userId === teamId)?.displayName"></div>
+											<div x-text="'Score: ' + score"></div>
+										</div>
+									</template>
+								</div>
+							</template>
+						</div>
+					</template>
+				</div>
 			</template>
-		</template>
+		</div>
 	}
 	<div class="min-h-screen">
 		if pageUser == nil {
@@ -461,7 +489,7 @@ templ HomePage(events []types.Event, pageUser *types.UserSearchResult, cfLocatio
 			}
 		</main>
 	</div>
-	<script id="alpine-state" data-cities-default-list={ GetCitiesAsJsonStr() } data-city-label-initial={ GetCityCountryFromLocation(cfLocation, latStr, lonStr, origLat, origLong) } data-page-user-id={ GetPageUserID(pageUser) }>
+	<script id="alpine-state" data-cities-default-list={ GetCitiesAsJsonStr() } data-city-label-initial={ GetCityCountryFromLocation(cfLocation, latStr, lonStr, origLat, origLong) } data-page-user-id={ GetPageUserID(pageUser) } data-fake-event-id={ helpers.COMP_UNASSIGNED_ROUND_EVENT_ID }>
 		// NOTE: this is used by htmx to get the data-attributes
 		// eslint-disable-next-line no-unused-vars
 		function sendParmsFromQs() {
@@ -564,18 +592,8 @@ templ HomePage(events []types.Event, pageUser *types.UserSearchResult, cfLocatio
 					window.addEventListener('popstate', () => {
 						this.updateParamsFromUrl();
 					});
-
-          console.log('this.pageUserId', this.pageUserId)
-          await fetch(`/api/competition-config/owner/${this.pageUserId}`).then(res => {
-            return res.json()
-          }).then(json => {
-            console.log(json)
-            this.competitions = json
-          });
-
 				},
-        competitions: [],
-        pageUserId: document.querySelector('#alpine-state').getAttribute('data-page-user-id'),
+				pageUserId: document.querySelector('#alpine-state').getAttribute('data-page-user-id'),
 				start_time: null,
 				end_time: null,
 				q: null,
@@ -662,6 +680,88 @@ templ HomePage(events []types.Event, pageUser *types.UserSearchResult, cfLocatio
 						this.hasEvents = false;
 					}
 				},
+			}
+		}
+
+		function getCompetitionsState() {
+			return {
+				async init() {
+					await fetch(`/api/competition-config/owner/${this.pageUserId}`).then(res => {
+						return res.json()
+					}).then(json => {
+						const _competitions = json.filter(competition => {
+							return competition.endTime > new Date().getTime() / 1000
+						})
+						this.competitions = _competitions
+					});
+
+					// Create an array of promises for fetching competition rounds and leaderboards
+					const fetchPromises = this.competitions.flatMap(competition => [
+						// Fetch rounds
+						fetch(`/api/competition-round/competition/${competition.id}`)
+							.then(response => response.json())
+							.catch(error => {
+								// eslint-disable-next-line no-console
+								console.error(`Error fetching rounds for competition ${competition.id}:`, error);
+								return null;
+							}),
+						// Fetch leaderboard
+						fetch(`/api/competition-round/competition-sum/${competition.id}`)
+							.then(response => response.json())
+							.catch(error => {
+								// eslint-disable-next-line no-console
+								console.error(`Error fetching leaderboard for competition ${competition.id}:`, error);
+								return null;
+							})
+					]);
+
+					// Wait for all requests to complete
+					try {
+						const results = await Promise.all(fetchPromises);
+						// Process results in pairs (rounds and leaderboard for each competition)
+						this.rounds = {};
+						this.leaderboards = {};
+						for (let i = 0; i < results.length; i += 2) {
+							const roundsArray = results[i];
+							const leaderboardData = results[i + 1];
+							if (roundsArray && roundsArray.length > 0) {
+								this.rounds[roundsArray[0].competitionId] = roundsArray;
+							}
+							if (leaderboardData) {
+								// Sort the entries by score in descending order
+								const sortedEntries = Object.entries(leaderboardData)
+									.sort(([, scoreA], [, scoreB]) => scoreB - scoreA);
+
+								// Convert back to object while maintaining sorted order
+								this.leaderboards[this.competitions[i / 2].id] = Object.fromEntries(sortedEntries);
+							}
+						}
+					} catch (error) {
+						// eslint-disable-next-line no-console
+						console.error('Error fetching competition data:', error);
+					}
+
+					try {
+						const userIds = Object.values(this.leaderboards)
+							.flatMap(leaderboard => Object.keys(leaderboard))
+							.join(',');
+
+						const users = await fetch(`/api/users?ids=${userIds}`).then(res => {
+							return res.json()
+						})
+
+						this.users = users
+					} catch (error) {
+						// eslint-disable-next-line no-console
+						console.error('Error fetching users:', error);
+					}
+				},
+				competitions: [],
+				rounds: {},
+				leaderboards: {},
+				users: [],
+				pageUserId: document.querySelector('#alpine-state').getAttribute('data-page-user-id'),
+				fakeEventId: document.querySelector('#alpine-state').getAttribute('data-fake-event-id'),
 			}
 		}
 	</script>

--- a/functions/gateway/templates/pages/home.templ
+++ b/functions/gateway/templates/pages/home.templ
@@ -207,7 +207,6 @@ templ HomePage(events []types.Event, pageUser *types.UserSearchResult, cfLocatio
 					<h2 class="text-3xl font-bold uppercase my-10">Competitions</h2>
 					<template x-for="competition in competitions">
 						<div>
-							<div x-text="competition.name"></div>
 							<h3 x-text="competition.name" class="text-2xl font-bold my-10"></h3>
 							<h4 class="text-xl font-bold my-2 uppercase">Rounds</h4>
 							<template x-if="rounds && rounds[competition.id]">

--- a/functions/gateway/templates/pages/home_templ_test.go
+++ b/functions/gateway/templates/pages/home_templ_test.go
@@ -78,7 +78,7 @@ func TestHomePage(t *testing.T) {
 				"Test Event 2",
 				"New York, US",
 				"data-page-user-id=\"1234567890\"",
-				"Welcome to Brian&#39;s Pub",
+				"Welcome to Brian's Pub",
 				"Brian&#39;s Pub</h1>",
 			},
 		},

--- a/functions/gateway/templates/pages/layout.templ
+++ b/functions/gateway/templates/pages/layout.templ
@@ -23,7 +23,7 @@ templ Layout(sitePage helpers.SitePage, userInfo helpers.UserInfo, pageContent t
 			<link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400&family=Ubuntu+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Anton&family=Unbounded:wght@900&display=swap" rel="stylesheet"/>
 			// 🚨 WARNING 🚨 This filename is automatically updated by PostCSS
 			// ✅ DO commit it to version control whenever you see it change
-			<link rel="stylesheet" href={ templ.EscapeString(os.Getenv("STATIC_BASE_URL") + "/assets/styles.fcf069c1.css") }/>
+			<link rel="stylesheet" href={ templ.EscapeString(os.Getenv("STATIC_BASE_URL") + "/assets/styles.bbff2a1d.css") }/>
 			<meta name="viewport" content="width=device-width, initial-scale=1"/>
 			<script src="https://unpkg.com/htmx.org@1.9.12"></script>
 			<script src="https://unpkg.com/htmx.org@1.9.12/dist/ext/json-enc.js"></script>

--- a/functions/gateway/templates/pages/layout.templ
+++ b/functions/gateway/templates/pages/layout.templ
@@ -23,7 +23,7 @@ templ Layout(sitePage helpers.SitePage, userInfo helpers.UserInfo, pageContent t
 			<link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400&family=Ubuntu+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Anton&family=Unbounded:wght@900&display=swap" rel="stylesheet"/>
 			// 🚨 WARNING 🚨 This filename is automatically updated by PostCSS
 			// ✅ DO commit it to version control whenever you see it change
-			<link rel="stylesheet" href={ templ.EscapeString(os.Getenv("STATIC_BASE_URL") + "/assets/styles.035ee10e.css") }/>
+			<link rel="stylesheet" href={ templ.EscapeString(os.Getenv("STATIC_BASE_URL") + "/assets/styles.fcf069c1.css") }/>
 			<meta name="viewport" content="width=device-width, initial-scale=1"/>
 			<script src="https://unpkg.com/htmx.org@1.9.12"></script>
 			<script src="https://unpkg.com/htmx.org@1.9.12/dist/ext/json-enc.js"></script>

--- a/functions/gateway/templates/pages/profile.templ
+++ b/functions/gateway/templates/pages/profile.templ
@@ -178,7 +178,7 @@ templ ProfilePage(userInfo helpers.UserInfo, roleClaims []helpers.RoleClaim, int
 					<textarea
 						name="about"
 						class="textarea textarea-bordered w-full"
-						maxlength="500"
+						maxlength="750"
 						id="about"
 						placeholder="Personal bio or organization description on your profile"
 					>

--- a/functions/gateway/templates/partials/events_admin_children.templ
+++ b/functions/gateway/templates/partials/events_admin_children.templ
@@ -132,7 +132,7 @@ templ EventAdminChildren(eventParent types.Event, eventChildren []types.Event) {
 								name={ string("event_" + strconv.Itoa(idx) + "_" + string(child.FieldName)) }
 								x-model.fill={ "formData.eventChildren[" + strconv.Itoa(idx) + "]." + camelCaseFieldName }
 								if (child.ChildValue != "" && child.ChildValue.(int64) != 0) {
-									value={ helpers.GetDatetimePickerFormatted(child.ChildValue.(int64), eventParent.Timezone) }
+									value={ helpers.GetDatetimePickerFormatted(child.ChildValue.(int64), &eventParent.Timezone) }
 								}
 							/>
 						}

--- a/functions/gateway/types/competitions.go
+++ b/functions/gateway/types/competitions.go
@@ -9,8 +9,8 @@ import (
 // CompetitionConfigInterface defines the methods for competition-related operations
 type CompetitionConfigServiceInterface interface {
 	GetCompetitionConfigById(ctx context.Context, dynamodbClient DynamoDBAPI, id string) (CompetitionConfigResponse, error)
-	GetCompetitionConfigsByPrimaryOwner(ctx context.Context, dynamodbClient DynamoDBAPI, primaryOwner string) (*[]CompetitionConfig, error)
-	UpdateCompetitionConfig(ctx context.Context, dynamodbClient DynamoDBAPI, id string, competitionConfig CompetitionConfigUpdate) (*CompetitionConfig, error)
+	GetCompetitionConfigsByPrimaryOwner(ctx context.Context, dynamodbClient DynamoDBAPI, primaryOwner string, isSelf bool) (*[]CompetitionConfig, error)
+	UpdateCompetitionConfig(ctx context.Context, dynamodbClient DynamoDBAPI, id string, competitionConfig CompetitionConfigUpdate, isNew bool) (*CompetitionConfig, error)
 	DeleteCompetitionConfig(ctx context.Context, dynamodbClient DynamoDBAPI, id string) error
 }
 
@@ -53,6 +53,8 @@ type CompetitionConfig struct {
 	Status        string             `json:"status" dynamodbav:"status" validate:"required,oneof=DRAFT ACTIVE COMPLETE"`
 	CreatedAt     int64              `json:"createdAt" dynamodbav:"createdAt"`
 	UpdatedAt     int64              `json:"updatedAt" dynamodbav:"updatedAt"`
+	StartTime     int64              `json:"startTime" dynamodbav:"startTime"`
+	EndTime       int64              `json:"endTime" dynamodbav:"endTime"`
 }
 
 type CompetitionConfigResponse struct {
@@ -92,6 +94,8 @@ type CompetitionConfigUpdate struct {
 	// TODO: these should be enums for re-use on the client
 	Status    string `json:"status,omitempty" dynamodbav:"status" validate:"omitempty,oneof=DRAFT ACTIVE COMPLETE"`
 	UpdatedAt int64  `json:"updatedAt" dynamodbav:"updatedAt"`
+	StartTime int64  `json:"startTime" dynamodbav:"startTime"`
+	EndTime   int64  `json:"endTime" dynamodbav:"endTime"`
 }
 
 // CompetitionRound types following the same pattern

--- a/stacks/StorageStack.ts
+++ b/stacks/StorageStack.ts
@@ -137,12 +137,15 @@ export function StorageStack({ stack }: StackContext) {
       competitors: 'string', // JSON string array of competitor IDs
       status: 'string', // DRAFT, ACTIVE, COMPLETE
       createdAt: 'number',
-      updatedAt: 'number'
+      updatedAt: 'number',
+      startTime: 'number',
+      endTime: 'number',
     },
     primaryIndex: { partitionKey: 'id' },
     globalIndexes: {
       primaryOwner:{ partitionKey: 'primaryOwner', sortKey: 'id' },
-    },
+      endTime:{ partitionKey: 'primaryOwner', sortKey: 'endTime' },
+    }
   });
 
   // This table needs the concept of sub rounds


### PR DESCRIPTION
* Add leaderboard / rounds to community pages
* Fix competition edit permissions issue where admins couldn't create
* Increase max length for community / user page "About" (`500` chars => `750` chars)
* Add new route /api/competition-config/owner/{ user Id}` to fetch standings on community pages
* Add new CompetitionConfig GSI for `endDate` sorting by competitions that have a future end date
* initial pass (still broken) at timepickers in competition admin + wire up types
* Fix bug in team user creation in zitadel
* Fix silent nil pointer error when loading user / community page if there is no user data  (was being swallowed by goroutine concurrency channel)
* Modify `helpers.GetDatetimePickerFormatted` to return unix time when timezone is optionally omitted
* Fix broken unit test for `TestGetUsersHandler`

![image](https://github.com/user-attachments/assets/48e5674b-0e16-45aa-8f65-af4006039f5f)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Competition management pages now include new start and end time fields for scheduling.
  - Home page now dynamically retrieves and displays competition information.
  - Added functionality for retrieving competition configurations based on the primary owner's user ID.

- **Enhancements**
  - Profile pages support longer bios with an increased character limit.
  - Updated styling provides a refreshed visual experience.
  - Improved error handling and metadata processing for user and competition configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->