### PR TITLE
[fix] failing geolocation field in production

### DIFF
--- a/functions/gateway/services/geo_service.go
+++ b/functions/gateway/services/geo_service.go
@@ -20,7 +20,7 @@ func (s *RealGeoService) GetGeo(location string, baseUrl string) (lat string, lo
 	if baseUrl == "" {
 		return "", "", "", fmt.Errorf("base URL is empty")
 	}
-	htmlString, err := GetHTMLFromURL(baseUrl+"/map-embed?address="+location, 0, false, "#mapDiv div div")
+	htmlString, err := GetHTMLFromURL(baseUrl+"/map-embed?address="+location, 0, true, "#mapDiv")
 	if err != nil {
 		return "", "", "", err
 	}


### PR DESCRIPTION
fix scraping bee dom path `#mapDiv div div` has issues with string escaping and `js_render` needs to be set to true