### PR TITLE
[fix] Rounds data cross-pollution `event admin` <> `competition admin`

### DIFF
--- a/functions/gateway/handlers/data_handlers.go
+++ b/functions/gateway/handlers/data_handlers.go
@@ -1236,7 +1236,7 @@ type UpdateEventRegPurchPayload struct {
 	Events                   []rawEvent                              `json:"events" validate:"required"`
 	RegistrationFieldsUpdate internal_types.RegistrationFieldsUpdate `json:"registrationFieldsUpdate"`
 	PurchasableUpdate        internal_types.PurchasableUpdate        `json:"purchasableUpdate"`
-	Rounds []internal_types.CompetitionRoundUpdate `json:"rounds"`
+	Rounds                   []internal_types.CompetitionRoundUpdate `json:"rounds"`
 }
 
 func UpdateEventRegPurchHandler(w http.ResponseWriter, r *http.Request) http.HandlerFunc {
@@ -1292,7 +1292,6 @@ func UpdateEventRegPurchHandler(w http.ResponseWriter, r *http.Request) http.Han
 			createdAt = time.Now().Unix()
 		}
 
-
 		if eventId == "" {
 			eventId = uuid.NewString()
 			updateEventRegPurchPayload.Events[0].Id = eventId
@@ -1326,7 +1325,6 @@ func UpdateEventRegPurchHandler(w http.ResponseWriter, r *http.Request) http.Han
 				return
 			}
 		}
-
 
 		// Update purchasable
 		if updateEventRegPurchPayload.PurchasableUpdate.CreatedAt.IsZero() {
@@ -1455,7 +1453,6 @@ func UpdateEventRegPurchHandler(w http.ResponseWriter, r *http.Request) http.Han
 		transport.SendServerRes(w, jsonResponse, http.StatusOK, nil)
 	}
 }
-
 
 func BulkDeleteEventsHandler(w http.ResponseWriter, r *http.Request) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/functions/gateway/handlers/data_handlers.go
+++ b/functions/gateway/handlers/data_handlers.go
@@ -1236,211 +1236,226 @@ type UpdateEventRegPurchPayload struct {
 	Events                   []rawEvent                              `json:"events" validate:"required"`
 	RegistrationFieldsUpdate internal_types.RegistrationFieldsUpdate `json:"registrationFieldsUpdate"`
 	PurchasableUpdate        internal_types.PurchasableUpdate        `json:"purchasableUpdate"`
+	Rounds []internal_types.CompetitionRoundUpdate `json:"rounds"`
 }
 
 func UpdateEventRegPurchHandler(w http.ResponseWriter, r *http.Request) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		UpdateEventRegPurch(w, r)
-	}
-}
+		ctx := r.Context()
+		vars := mux.Vars(r)
+		eventId := vars[helpers.EVENT_ID_KEY]
 
-func UpdateEventRegPurch(w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
-	vars := mux.Vars(r)
-	eventId := vars[helpers.EVENT_ID_KEY]
+		userInfo := helpers.UserInfo{}
+		if _, ok := ctx.Value("userInfo").(helpers.UserInfo); ok {
+			userInfo = ctx.Value("userInfo").(helpers.UserInfo)
+		}
+		roleClaims := []helpers.RoleClaim{}
+		if claims, ok := ctx.Value("roleClaims").([]helpers.RoleClaim); ok {
+			roleClaims = claims
+		}
 
-	userInfo := helpers.UserInfo{}
-	if _, ok := ctx.Value("userInfo").(helpers.UserInfo); ok {
-		userInfo = ctx.Value("userInfo").(helpers.UserInfo)
-	}
-	roleClaims := []helpers.RoleClaim{}
-	if claims, ok := ctx.Value("roleClaims").([]helpers.RoleClaim); ok {
-		roleClaims = claims
-	}
+		validRoles := []string{"superAdmin", "eventEditor"}
+		userId := userInfo.Sub
+		if userId == "" {
+			transport.SendServerRes(w, []byte("Missing user ID"), http.StatusUnauthorized, nil)
+			return
+		}
 
-	validRoles := []string{"superAdmin", "eventEditor"}
-	userId := userInfo.Sub
-	if userId == "" {
-		transport.SendServerRes(w, []byte("Missing user ID"), http.StatusUnauthorized, nil)
-		return
-	}
+		if !helpers.HasRequiredRole(roleClaims, validRoles) {
+			err := errors.New("only event editors can add or edit events")
+			transport.SendServerRes(w, []byte(err.Error()), http.StatusForbidden, err)
+			return
+		}
 
-	if !helpers.HasRequiredRole(roleClaims, validRoles) {
-		err := errors.New("only event editors can add or edit events")
-		transport.SendServerRes(w, []byte(err.Error()), http.StatusForbidden, err)
-		return
-	}
+		var updateEventRegPurchPayload UpdateEventRegPurchPayload
 
-	var updateEventRegPurchPayload UpdateEventRegPurchPayload
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			transport.SendServerRes(w, []byte("Failed to read request body: "+err.Error()), http.StatusBadRequest, err)
+			return
+		}
 
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		transport.SendServerRes(w, []byte("Failed to read request body: "+err.Error()), http.StatusBadRequest, err)
-		return
-	}
+		err = json.Unmarshal(body, &updateEventRegPurchPayload)
+		if err != nil {
+			transport.SendServerRes(w, []byte("Invalid JSON payload: "+err.Error()), http.StatusUnprocessableEntity, err)
+			return
+		}
 
-	err = json.Unmarshal(body, &updateEventRegPurchPayload)
-	if err != nil {
-		transport.SendServerRes(w, []byte("Invalid JSON payload: "+err.Error()), http.StatusUnprocessableEntity, err)
-		return
-	}
+		// we should use goroutines to parallelize the three distinct database update operations here
+		db := transport.GetDB()
 
-	// we should use goroutines to parallelize the three distinct database update operations here
-	db := transport.GetDB()
+		var createdAt int64
+		updatedAt := time.Now().Unix()
+		if updateEventRegPurchPayload.Events[0].CreatedAt != nil {
+			createdAt = *updateEventRegPurchPayload.Events[0].CreatedAt
+		} else {
+			createdAt = time.Now().Unix()
+		}
 
-	var createdAt int64
-	updatedAt := time.Now().Unix()
-	if updateEventRegPurchPayload.Events[0].CreatedAt != nil {
-		createdAt = *updateEventRegPurchPayload.Events[0].CreatedAt
-	} else {
-		createdAt = time.Now().Unix()
-	}
 
-	if eventId == "" {
-		eventId = uuid.NewString()
-		updateEventRegPurchPayload.Events[0].Id = eventId
-		updateEventRegPurchPayload.RegistrationFieldsUpdate.EventId = eventId
-		updateEventRegPurchPayload.PurchasableUpdate.EventId = eventId
-		if helpers.ES_SERIES_PARENT == updateEventRegPurchPayload.Events[0].EventSourceType {
-			updateEventRegPurchPayload.Events[0].EventSourceId = nil
-			for i, event := range updateEventRegPurchPayload.Events {
-				if i == 0 {
-					event.EventSourceId = nil
-					updateEventRegPurchPayload.Events[i] = event
-				} else {
-					event.EventSourceId = &eventId
-					event.EventSourceType = helpers.ES_SINGLE_EVENT
+		if eventId == "" {
+			eventId = uuid.NewString()
+			updateEventRegPurchPayload.Events[0].Id = eventId
+			updateEventRegPurchPayload.RegistrationFieldsUpdate.EventId = eventId
+			updateEventRegPurchPayload.PurchasableUpdate.EventId = eventId
+			if helpers.ES_SERIES_PARENT == updateEventRegPurchPayload.Events[0].EventSourceType {
+				updateEventRegPurchPayload.Events[0].EventSourceId = nil
+				for i, event := range updateEventRegPurchPayload.Events {
+					if i == 0 {
+						event.EventSourceId = nil
+						updateEventRegPurchPayload.Events[i] = event
+					} else {
+						event.EventSourceId = &eventId
+						event.EventSourceType = helpers.ES_SINGLE_EVENT
+					}
 				}
 			}
 		}
-	}
 
-	// Update purchasable
-	if updateEventRegPurchPayload.PurchasableUpdate.CreatedAt.IsZero() {
-		updateEventRegPurchPayload.PurchasableUpdate.CreatedAt = time.Unix(createdAt, 0)
-	}
-	updateEventRegPurchPayload.PurchasableUpdate.UpdatedAt = time.Unix(updatedAt, 0)
-
-	purchService := dynamodb_service.NewPurchasableService()
-	purchHandler := dynamodb_handlers.NewPurchasableHandler(purchService)
-	purchRes, err := purchHandler.PurchasableService.UpdatePurchasable(r.Context(), db, updateEventRegPurchPayload.PurchasableUpdate)
-	if err != nil {
-		transport.SendServerRes(w, []byte("Failed to update purchasable: "+err.Error()), http.StatusInternalServerError, err)
-		return
-	}
-
-	// Update registration fields
-	updateEventRegPurchPayload.RegistrationFieldsUpdate.UpdatedBy = userId
-	if updateEventRegPurchPayload.RegistrationFieldsUpdate.CreatedAt.IsZero() {
-		updateEventRegPurchPayload.RegistrationFieldsUpdate.CreatedAt = time.Unix(createdAt, 0)
-	}
-	updateEventRegPurchPayload.RegistrationFieldsUpdate.UpdatedAt = time.Unix(updatedAt, 0)
-	regFieldsService := dynamodb_service.NewRegistrationFieldsService()
-	regFieldsHandler := dynamodb_handlers.NewRegistrationFieldsHandler(regFieldsService)
-	regFieldsRes, err := regFieldsHandler.RegistrationFieldsService.UpdateRegistrationFields(r.Context(), db, eventId, updateEventRegPurchPayload.RegistrationFieldsUpdate)
-	if err != nil {
-		transport.SendServerRes(w, []byte("Failed to update registration fields: "+err.Error()), http.StatusInternalServerError, err)
-		return
-	}
-
-	// Update events
-	marqoClient, err := services.GetMarqoClient()
-	if err != nil {
-		transport.SendServerRes(w, []byte("Failed to get marqo client: "+err.Error()), http.StatusInternalServerError, err)
-		return
-	}
-
-	events := make([]types.Event, len(updateEventRegPurchPayload.Events))
-	if updateEventRegPurchPayload.Events[0].Id == "" {
-		events[0].Id = eventId
-	}
-	for i, rawEvent := range updateEventRegPurchPayload.Events {
-		if rawEvent.CreatedAt == nil {
-			rawEvent.CreatedAt = &createdAt
-		}
-		rawEvent.UpdatedAt = &updatedAt
-		rawEvent.Description = updateEventRegPurchPayload.Events[0].Description
-		if updateEventRegPurchPayload.Events[0].EventSourceType == helpers.ES_SERIES_PARENT {
-			rawEvent.EventSourceId = &eventId
-		}
-
-		event, statusCode, err := HandleSingleEventValidation(rawEvent, false)
-		if err != nil {
-			transport.SendServerRes(w, []byte("Failed to validate events: "+err.Error()), statusCode, err)
-			return
-		}
-		events[i] = event
-	}
-
-	// Before pushing the new events, check for outdated child events, we need to search them prior to
-	// the new event upsert because the new events will have unkown IDs and would get deleted by the
-	// delete "sweeper" we do in the `defer` function below
-
-	farFutureTime, _ := time.Parse(time.RFC3339, "2099-05-01T12:00:00Z")
-	childEventsToDelete, err := services.SearchMarqoEvents(marqoClient, "", []float64{0, 0}, 1000000, 0, farFutureTime.Unix(), []string{}, "", "", "", []string{helpers.ES_EVENT_SERIES, helpers.ES_EVENT_SERIES_UNPUB}, []string{eventId})
-	if err != nil {
-		transport.SendServerRes(w, []byte("Failed to search for existing child events: "+err.Error()), http.StatusInternalServerError, err)
-		return
-	}
-
-	// If events being upserted have an ID, they are known and we deny-list them here so they
-	// are NOT deleted by the delete "sweeper" we do in the `defer` function below
-	deleteDenyList := make(map[string]bool)
-	for _, event := range events {
-		deleteDenyList[event.Id] = true
-	}
-
-	// Filter out events we want to keep
-	var eventsToDelete []types.Event
-	for _, event := range childEventsToDelete.Events {
-		if !deleteDenyList[event.Id] {
-			eventsToDelete = append(eventsToDelete, event)
-		}
-	}
-
-	// After pushing the new events, check for outdated child events, we need to search them
-	defer func() {
-		if len(eventsToDelete) > 0 {
-			deleteEventsArr := make([]string, len(eventsToDelete))
-			for i, event := range eventsToDelete {
-				deleteEventsArr[i] = event.Id
+		// Call patch on rounds for eventId only
+		if len(updateEventRegPurchPayload.Rounds) > 0 {
+			// Define which fields to update (excluding eventId)
+			keysToUpdate := []string{
+				"eventId",
 			}
 
-			_, err = services.BulkDeleteEventsFromMarqo(marqoClient, deleteEventsArr)
+			service := dynamodb_service.NewCompetitionRoundService()
+			err = service.BatchPatchCompetitionRounds(ctx, db, updateEventRegPurchPayload.Rounds, keysToUpdate)
 			if err != nil {
-				transport.SendServerRes(w, []byte("Failed to delete old child events: "+err.Error()), http.StatusInternalServerError, err)
+				transport.SendServerRes(w, []byte("Failed to update existing competition rounds: "+err.Error()), http.StatusInternalServerError, err)
 				return
 			}
 		}
-	}()
 
-	eventsRes, err := services.BulkUpsertEventToMarqo(marqoClient, events)
-	if err != nil {
-		transport.SendServerRes(w, []byte("Failed to upsert events to marqo: "+err.Error()), http.StatusInternalServerError, err)
-		return
+
+		// Update purchasable
+		if updateEventRegPurchPayload.PurchasableUpdate.CreatedAt.IsZero() {
+			updateEventRegPurchPayload.PurchasableUpdate.CreatedAt = time.Unix(createdAt, 0)
+		}
+		updateEventRegPurchPayload.PurchasableUpdate.UpdatedAt = time.Unix(updatedAt, 0)
+
+		purchService := dynamodb_service.NewPurchasableService()
+		purchHandler := dynamodb_handlers.NewPurchasableHandler(purchService)
+		purchRes, err := purchHandler.PurchasableService.UpdatePurchasable(r.Context(), db, updateEventRegPurchPayload.PurchasableUpdate)
+		if err != nil {
+			transport.SendServerRes(w, []byte("Failed to update purchasable: "+err.Error()), http.StatusInternalServerError, err)
+			return
+		}
+
+		// Update registration fields
+		updateEventRegPurchPayload.RegistrationFieldsUpdate.UpdatedBy = userId
+		if updateEventRegPurchPayload.RegistrationFieldsUpdate.CreatedAt.IsZero() {
+			updateEventRegPurchPayload.RegistrationFieldsUpdate.CreatedAt = time.Unix(createdAt, 0)
+		}
+		updateEventRegPurchPayload.RegistrationFieldsUpdate.UpdatedAt = time.Unix(updatedAt, 0)
+		regFieldsService := dynamodb_service.NewRegistrationFieldsService()
+		regFieldsHandler := dynamodb_handlers.NewRegistrationFieldsHandler(regFieldsService)
+		regFieldsRes, err := regFieldsHandler.RegistrationFieldsService.UpdateRegistrationFields(r.Context(), db, eventId, updateEventRegPurchPayload.RegistrationFieldsUpdate)
+		if err != nil {
+			transport.SendServerRes(w, []byte("Failed to update registration fields: "+err.Error()), http.StatusInternalServerError, err)
+			return
+		}
+
+		// Update events
+		marqoClient, err := services.GetMarqoClient()
+		if err != nil {
+			transport.SendServerRes(w, []byte("Failed to get marqo client: "+err.Error()), http.StatusInternalServerError, err)
+			return
+		}
+
+		events := make([]types.Event, len(updateEventRegPurchPayload.Events))
+		if updateEventRegPurchPayload.Events[0].Id == "" {
+			events[0].Id = eventId
+		}
+		for i, rawEvent := range updateEventRegPurchPayload.Events {
+			if rawEvent.CreatedAt == nil {
+				rawEvent.CreatedAt = &createdAt
+			}
+			rawEvent.UpdatedAt = &updatedAt
+			rawEvent.Description = updateEventRegPurchPayload.Events[0].Description
+			if updateEventRegPurchPayload.Events[0].EventSourceType == helpers.ES_SERIES_PARENT {
+				rawEvent.EventSourceId = &eventId
+			}
+
+			event, statusCode, err := HandleSingleEventValidation(rawEvent, false)
+			if err != nil {
+				transport.SendServerRes(w, []byte("Failed to validate events: "+err.Error()), statusCode, err)
+				return
+			}
+			events[i] = event
+		}
+
+		// Before pushing the new events, check for outdated child events, we need to search them prior to
+		// the new event upsert because the new events will have unkown IDs and would get deleted by the
+		// delete "sweeper" we do in the `defer` function below
+
+		farFutureTime, _ := time.Parse(time.RFC3339, "2099-05-01T12:00:00Z")
+		childEventsToDelete, err := services.SearchMarqoEvents(marqoClient, "", []float64{0, 0}, 1000000, 0, farFutureTime.Unix(), []string{}, "", "", "", []string{helpers.ES_EVENT_SERIES, helpers.ES_EVENT_SERIES_UNPUB}, []string{eventId})
+		if err != nil {
+			transport.SendServerRes(w, []byte("Failed to search for existing child events: "+err.Error()), http.StatusInternalServerError, err)
+			return
+		}
+
+		// If events being upserted have an ID, they are known and we deny-list them here so they
+		// are NOT deleted by the delete "sweeper" we do in the `defer` function below
+		deleteDenyList := make(map[string]bool)
+		for _, event := range events {
+			deleteDenyList[event.Id] = true
+		}
+
+		// Filter out events we want to keep
+		var eventsToDelete []types.Event
+		for _, event := range childEventsToDelete.Events {
+			if !deleteDenyList[event.Id] {
+				eventsToDelete = append(eventsToDelete, event)
+			}
+		}
+
+		// After pushing the new events, check for outdated child events, we need to search them
+		defer func() {
+			if len(eventsToDelete) > 0 {
+				deleteEventsArr := make([]string, len(eventsToDelete))
+				for i, event := range eventsToDelete {
+					deleteEventsArr[i] = event.Id
+				}
+
+				_, err = services.BulkDeleteEventsFromMarqo(marqoClient, deleteEventsArr)
+				if err != nil {
+					transport.SendServerRes(w, []byte("Failed to delete old child events: "+err.Error()), http.StatusInternalServerError, err)
+					return
+				}
+			}
+		}()
+
+		eventsRes, err := services.BulkUpsertEventToMarqo(marqoClient, events)
+		if err != nil {
+			transport.SendServerRes(w, []byte("Failed to upsert events to marqo: "+err.Error()), http.StatusInternalServerError, err)
+			return
+		}
+
+		// Create response object
+		response := map[string]interface{}{
+			"status":  "success",
+			"message": "Event(s), registration fields, and purchasable(s) updated successfully",
+			"data": map[string]interface{}{
+				"parentEvent": eventsRes.Items[0],
+				"events":      eventsRes,
+				"regFields":   regFieldsRes,
+				"purchasable": purchRes,
+			},
+		}
+
+		// Marshal the response
+		jsonResponse, err := json.Marshal(response)
+		if err != nil {
+			transport.SendServerRes(w, []byte(`{"error": "Failed to create response"}`), http.StatusInternalServerError, err)
+			return
+		}
+
+		transport.SendServerRes(w, jsonResponse, http.StatusOK, nil)
 	}
-
-	// Create response object
-	response := map[string]interface{}{
-		"status":  "success",
-		"message": "Event(s), registration fields, and purchasable(s) updated successfully",
-		"data": map[string]interface{}{
-			"parentEvent": eventsRes.Items[0],
-			"events":      eventsRes,
-			"regFields":   regFieldsRes,
-			"purchasable": purchRes,
-		},
-	}
-
-	// Marshal the response
-	jsonResponse, err := json.Marshal(response)
-	if err != nil {
-		transport.SendServerRes(w, []byte(`{"error": "Failed to create response"}`), http.StatusInternalServerError, err)
-		return
-	}
-
-	transport.SendServerRes(w, jsonResponse, http.StatusOK, nil)
 }
+
 
 func BulkDeleteEventsHandler(w http.ResponseWriter, r *http.Request) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/functions/gateway/handlers/page_handlers.go
+++ b/functions/gateway/handlers/page_handlers.go
@@ -675,7 +675,6 @@ func GetAddEventSourcePage(w http.ResponseWriter, r *http.Request) http.HandlerF
 func GetAddOrEditCompetitionPage(w http.ResponseWriter, r *http.Request) http.HandlerFunc {
 	ctx := r.Context()
 	db := transport.GetDB()
-
 	// Get user info from context
 	userInfo := helpers.UserInfo{}
 	if _, ok := ctx.Value("userInfo").(helpers.UserInfo); ok {
@@ -708,8 +707,8 @@ func GetAddOrEditCompetitionPage(w http.ResponseWriter, r *http.Request) http.Ha
 		pageObj = helpers.SitePages["competition-new"]
 		// Set default values for new competition
 		competitionConfig = internal_types.CompetitionConfig{
-			EventIds: []string{},
-			Status:   "DRAFT",
+			EventIds:     []string{},
+			Status:       "DRAFT",
 			PrimaryOwner: userInfo.Sub,
 		}
 
@@ -717,9 +716,14 @@ func GetAddOrEditCompetitionPage(w http.ResponseWriter, r *http.Request) http.Ha
 		eventCompetitionRoundService := dynamodb_service.NewCompetitionConfigService()
 		pageObj = helpers.SitePages["competition-edit"]
 		competitionConfigResponse, err := eventCompetitionRoundService.GetCompetitionConfigById(ctx, db, competitionId)
-		if err != nil || competitionConfigResponse.CompetitionConfig.Id == "" {
+		if err != nil {
 			return transport.SendHtmlRes(w, []byte("Failed to get competition: "+err.Error()),
 				http.StatusInternalServerError, "page", err)
+		}
+
+		if competitionConfigResponse.CompetitionConfig.Id == "" {
+			return transport.SendHtmlRes(w, []byte("Competition not found"),
+				http.StatusNotFound, "page", errors.New("empty competition ID"))
 		}
 		competitionConfig = competitionConfigResponse.CompetitionConfig
 		users = competitionConfigResponse.Owners

--- a/functions/gateway/handlers/page_handlers.go
+++ b/functions/gateway/handlers/page_handlers.go
@@ -710,7 +710,9 @@ func GetAddOrEditCompetitionPage(w http.ResponseWriter, r *http.Request) http.Ha
 		competitionConfig = internal_types.CompetitionConfig{
 			EventIds: []string{},
 			Status:   "DRAFT",
+			PrimaryOwner: userInfo.Sub,
 		}
+
 	} else {
 		eventCompetitionRoundService := dynamodb_service.NewCompetitionConfigService()
 		pageObj = helpers.SitePages["competition-edit"]

--- a/functions/gateway/services/dynamodb_service/competition_round_service.go
+++ b/functions/gateway/services/dynamodb_service/competition_round_service.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strconv"
+	"sync"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
@@ -78,6 +81,129 @@ func (s *CompetitionRoundService) PutCompetitionRounds(ctx context.Context, dyna
 
 	return *result, nil
 }
+
+func (s *CompetitionRoundService) BatchPatchCompetitionRounds(ctx context.Context, dynamodbClient internal_types.DynamoDBAPI, updates []internal_types.CompetitionRoundUpdate, keysToUpdate []string) error {
+    // Create error channel for goroutines
+    errChan := make(chan error, len(updates))
+    var wg sync.WaitGroup
+
+    // Process each update in parallel
+    for _, update := range updates {
+        wg.Add(1)
+        go func(update internal_types.CompetitionRoundUpdate) {
+            defer wg.Done()
+
+            input := &dynamodb.UpdateItemInput{
+                TableName: aws.String(competitionRoundsTableName),
+                Key: map[string]dynamodb_types.AttributeValue{
+                    "competitionId": &dynamodb_types.AttributeValueMemberS{Value: update.CompetitionId},
+                    "roundNumber":   &dynamodb_types.AttributeValueMemberN{Value: strconv.FormatInt(update.RoundNumber, 10)},
+                },
+                ExpressionAttributeNames:  make(map[string]string),
+                ExpressionAttributeValues: make(map[string]dynamodb_types.AttributeValue),
+                UpdateExpression:          aws.String("SET"),
+            }
+
+            // Build update expression based on keysToUpdate
+			for _, key := range keysToUpdate {
+				switch key {
+				case "eventId":
+					if update.EventId != "" {
+						input.ExpressionAttributeNames["#eventId"] = "eventId"
+						input.ExpressionAttributeValues[":eventId"] = &dynamodb_types.AttributeValueMemberS{Value: update.EventId}
+						*input.UpdateExpression += " #eventId = :eventId,"
+					}
+				case "roundName":
+					if update.RoundName != "" {
+						input.ExpressionAttributeNames["#roundName"] = "roundName"
+						input.ExpressionAttributeValues[":roundName"] = &dynamodb_types.AttributeValueMemberS{Value: update.RoundName}
+						*input.UpdateExpression += " #roundName = :roundName,"
+					}
+				case "competitorA":
+					if update.CompetitorA != "" {
+						input.ExpressionAttributeNames["#competitorA"] = "competitorA"
+						input.ExpressionAttributeValues[":competitorA"] = &dynamodb_types.AttributeValueMemberS{Value: update.CompetitorA}
+						*input.UpdateExpression += " #competitorA = :competitorA,"
+					}
+				case "competitorAScore":
+					input.ExpressionAttributeNames["#competitorAScore"] = "competitorAScore"
+					input.ExpressionAttributeValues[":competitorAScore"] = &dynamodb_types.AttributeValueMemberN{Value: strconv.FormatFloat(update.CompetitorAScore, 'f', -1, 64)}
+					*input.UpdateExpression += " #competitorAScore = :competitorAScore,"
+				case "competitorB":
+					if update.CompetitorB != "" {
+						input.ExpressionAttributeNames["#competitorB"] = "competitorB"
+						input.ExpressionAttributeValues[":competitorB"] = &dynamodb_types.AttributeValueMemberS{Value: update.CompetitorB}
+						*input.UpdateExpression += " #competitorB = :competitorB,"
+					}
+				case "competitorBScore":
+					input.ExpressionAttributeNames["#competitorBScore"] = "competitorBScore"
+					input.ExpressionAttributeValues[":competitorBScore"] = &dynamodb_types.AttributeValueMemberN{Value: strconv.FormatFloat(update.CompetitorBScore, 'f', -1, 64)}
+					*input.UpdateExpression += " #competitorBScore = :competitorBScore,"
+				case "matchup":
+					if update.Matchup != "" {
+						input.ExpressionAttributeNames["#matchup"] = "matchup"
+						input.ExpressionAttributeValues[":matchup"] = &dynamodb_types.AttributeValueMemberS{Value: update.Matchup}
+						*input.UpdateExpression += " #matchup = :matchup,"
+					}
+				case "status":
+					if update.Status != "" {
+						input.ExpressionAttributeNames["#status"] = "status"
+						input.ExpressionAttributeValues[":status"] = &dynamodb_types.AttributeValueMemberS{Value: update.Status}
+						*input.UpdateExpression += " #status = :status,"
+					}
+				case "isPending":
+					input.ExpressionAttributeNames["#isPending"] = "isPending"
+					input.ExpressionAttributeValues[":isPending"] = &dynamodb_types.AttributeValueMemberBOOL{Value: update.IsPending}
+					*input.UpdateExpression += " #isPending = :isPending,"
+				case "isVotingOpen":
+					input.ExpressionAttributeNames["#isVotingOpen"] = "isVotingOpen"
+					input.ExpressionAttributeValues[":isVotingOpen"] = &dynamodb_types.AttributeValueMemberBOOL{Value: update.IsVotingOpen}
+					*input.UpdateExpression += " #isVotingOpen = :isVotingOpen,"
+				case "description":
+					if update.Description != "" {
+						input.ExpressionAttributeNames["#description"] = "description"
+						input.ExpressionAttributeValues[":description"] = &dynamodb_types.AttributeValueMemberS{Value: update.Description}
+						*input.UpdateExpression += " #description = :description,"
+					}
+				}
+			}
+
+            // Always update updatedAt
+            input.ExpressionAttributeNames["#updatedAt"] = "updatedAt"
+            input.ExpressionAttributeValues[":updatedAt"] = &dynamodb_types.AttributeValueMemberN{Value: strconv.FormatInt(time.Now().Unix(), 10)}
+            *input.UpdateExpression += " #updatedAt = :updatedAt"
+
+            // Execute the update
+            _, err := dynamodbClient.UpdateItem(ctx, input)
+            if err != nil {
+                errChan <- fmt.Errorf("failed to update round %s-%d: %w", update.CompetitionId, update.RoundNumber, err)
+                return
+            }
+        }(update)
+    }
+
+    // Wait for all updates to complete
+    go func() {
+        wg.Wait()
+        close(errChan)
+    }()
+
+    // Collect any errors
+    var errors []error
+    for err := range errChan {
+        if err != nil {
+            errors = append(errors, err)
+        }
+    }
+
+    // Return combined error if any occurred
+    if len(errors) > 0 {
+        return fmt.Errorf("batch update errors: %v", errors)
+    }
+
+    return nil
+}
+
 
 func (s *CompetitionRoundService) GetCompetitionRoundByPrimaryKey(ctx context.Context, dynamodbClient internal_types.DynamoDBAPI, competitionId, roundNumber string) (*internal_types.CompetitionRound, error) {
 	queryInput := &dynamodb.GetItemInput{

--- a/functions/gateway/services/marqo_service.go
+++ b/functions/gateway/services/marqo_service.go
@@ -391,7 +391,6 @@ func ConvertEventsToDocuments(events []types.Event) (documents []interface{}) {
 func BulkUpsertEventToMarqo(client *marqo.Client, events []types.Event) (*marqo.UpsertDocumentsResponse, error) {
 	// Bulk upsert multiple events
 	documents := ConvertEventsToDocuments(events)
-	log.Printf(">>> 394 documents: %+v", documents)
 	indexName := GetMarqoIndexName()
 	req := marqo.UpsertDocumentsRequest{
 		Documents: documents,

--- a/functions/gateway/templates/components/user_typeahead_selector.templ
+++ b/functions/gateway/templates/components/user_typeahead_selector.templ
@@ -6,10 +6,15 @@ import (
 	"strconv"
 )
 
-templ UsersSelect(users []types.UserSearchResultDangerous, primaryUser, namespace, label, noun string, showChips bool) {
+templ UsersSelect(users []types.UserSearchResultDangerous, primaryUser, namespace, label, noun string, showChips bool, userRemovedEventName string) {
 	<div
 		x-data="getUsersSelectState($el)"
 		data-namespace={ namespace }
+		if userRemovedEventName != "" {
+			{ templ.Attributes{
+				"@" + userRemovedEventName + ".window": "removeUser($event.detail)",
+			}... }
+		}
 	>
 		<input type="hidden" value={ namespace }/>
 		<div class="form-control">
@@ -58,7 +63,7 @@ templ UsersSelect(users []types.UserSearchResultDangerous, primaryUser, namespac
 						name="userSearch"
 						aria-label={ "Add " + noun + " (search by name, organization, or email)" }
 						@input.throttle="fetchUsers($event.target.value)"
-						x-ref="userSearch"
+						x-ref={ namespace + "-userSearch" }
 						placeholder={ "Add " + noun + " (search by name, organization, or email)" }
 						class="input input-bordered"
 						role="combobox"
@@ -89,7 +94,7 @@ templ UsersSelect(users []types.UserSearchResultDangerous, primaryUser, namespac
 									isOpen = false;
 									openedWithKeyboard = false;
 									$nextTick(() => {
-											document.querySelector('[x-ref=userSearch]').focus();
+											document.querySelector(`[x-ref=${this.namespace + '-userSearch'}]`).focus();
 									});
 								} else {
 										$focus.wrap().previous()
@@ -147,9 +152,9 @@ templ UsersSelect(users []types.UserSearchResultDangerous, primaryUser, namespac
 										this.emitUpdate();
 								},
 								emitUpdate() {
-									this.$dispatch(`users-updated-${this.namespace}`, {
-										...this.users
-									});
+                  this.$dispatch(`users-updated-${this.namespace}`, {
+                    ...this.users
+                  });
 								},
 
 								async fetchUsers(query) {
@@ -174,16 +179,20 @@ templ UsersSelect(users []types.UserSearchResultDangerous, primaryUser, namespac
 								},
 
 								removeUser(userToRemove) {
-										this.users = this.users.filter(user => user !== userToRemove);
-										this.emitUpdate();
+										this.users = this.users.filter(user => user.value !== userToRemove);
+
+										this.$nextTick(() => {
+											this.emitUpdate();
+										});
 								},
 
 								setSelectedUser(option) {
 										this.isOpen = false
 										this.users.push(option);
 										this.options = this.options.filter(o => o.value !== option.value)
+
 										this.$nextTick(() => {
-											document.querySelector('[x-ref=userSearch]').focus();
+											document.querySelector(`[x-ref=${this.namespace + '-userSearch'}]`).focus();
 										})
 										this.emitUpdate();
 								},
@@ -191,7 +200,7 @@ templ UsersSelect(users []types.UserSearchResultDangerous, primaryUser, namespac
 								handleKeydownOnOptions(event) {
 									// if the user presses backspace or the alpha-numeric keys, focus on the search field
 									if (/^[a-zA-Z0-9]$/.test(event.key) || event.key === 'Backspace') {
-											this.$refs.userSearch.focus()
+											this.$refs[`${this.namespace}-userSearch`].focus()
 									}
 								}
 						}

--- a/functions/gateway/templates/components/user_typeahead_selector.templ
+++ b/functions/gateway/templates/components/user_typeahead_selector.templ
@@ -152,9 +152,9 @@ templ UsersSelect(users []types.UserSearchResultDangerous, primaryUser, namespac
 										this.emitUpdate();
 								},
 								emitUpdate() {
-                  this.$dispatch(`users-updated-${this.namespace}`, {
-                    ...this.users
-                  });
+									this.$dispatch(`users-updated-${this.namespace}`, {
+										...this.users
+									});
 								},
 
 								async fetchUsers(query) {

--- a/functions/gateway/templates/pages/competition_add_edit.templ
+++ b/functions/gateway/templates/pages/competition_add_edit.templ
@@ -626,9 +626,9 @@ templ AddOrEditCompetitionPage(pageObj helpers.SitePage, competition types.Compe
 						displayName: competitor.displayName,
 						team: competitor.team
 					};
-					
+
 					console.log('Adding competitor:', competitorToAdd);
-					
+
 					if (competitorToAdd.team === this.ownTeamId || competitorToAdd.userId?.match(/^tm_/)) {
 						// Team creation path...
 						this.teams.push({
@@ -640,20 +640,20 @@ templ AddOrEditCompetitionPage(pageObj helpers.SitePage, competition types.Compe
 					} else {
 						// Find the exact competitor in the waiting room
 						const waitingRoomIndex = this.waitingRoom.findIndex(c => c.userId === competitorToAdd.userId);
-						
+
 						if (waitingRoomIndex === -1) {
 							console.error('Competitor not found in waiting room:', competitorToAdd);
 							return;
 						}
-						
+
 						// Find the target team
 						const teamIndex = this.teams.findIndex(t => t.id === competitorToAdd.team);
-						
+
 						if (teamIndex === -1) {
 							console.error('Selected team not found:', competitorToAdd.team);
 							return;
 						}
-						
+
 						// Create new team array with the updated team
 						this.teams = this.teams.map((team, index) => {
 							if (index === teamIndex) {
@@ -667,11 +667,11 @@ templ AddOrEditCompetitionPage(pageObj helpers.SitePage, competition types.Compe
 							}
 							return team;
 						});
-						
+
 						// Remove from waiting room
 						this.waitingRoom = this.waitingRoom.filter((_, index) => index !== waitingRoomIndex);
 					}
-					
+
 					// Force a UI update
 					this.$nextTick(() => {
 						console.log('Updated state:', {
@@ -827,6 +827,8 @@ templ AddOrEditCompetitionPage(pageObj helpers.SitePage, competition types.Compe
 							})
 						};
 
+            console.log("Rounds field on comp config payload\n", competitionData.rounds);
+
 						competitionData?.rounds?.forEach?.((round, index) => {
 							if (!round?.competitorA || !round?.competitorB) {
 								throw new Error(`Competitor A or B for Round ${index + 1} is empty`)
@@ -879,6 +881,12 @@ templ AddOrEditCompetitionPage(pageObj helpers.SitePage, competition types.Compe
 							message: `Failed to update competition: ${error.message}`,
 						}
 					} finally {
+          // remove the fake keys
+            this.formData?.rounds?.forEach(round => {
+              if (round.eventId === 'fake-event-id-123') {
+                delete round.eventId
+              }
+            })
 						this.saveReqInFlight = false;
 					}
 				}

--- a/functions/gateway/templates/pages/competition_add_edit.templ
+++ b/functions/gateway/templates/pages/competition_add_edit.templ
@@ -83,7 +83,7 @@ templ AddOrEditCompetitionPage(pageObj helpers.SitePage, competition types.Compe
 				</div>
 				<div class="divider"></div>
 				// Replace the owners section with the new component
-				@components.UsersSelect(users, competition.PrimaryOwner, "owners", "Additional Admins", "admins", true)
+				@components.UsersSelect(users, competition.PrimaryOwner, "owners", "Additional Admins", "admins", true, "")
 				<div class="divider"></div>
 				<div class="form-control">
 					<label class="label">Start Time (of First Event)</label>
@@ -116,27 +116,46 @@ templ AddOrEditCompetitionPage(pageObj helpers.SitePage, competition types.Compe
 						</div>
 					</template>
 					<template x-for="competitor in waitingRoom">
-						<div class="flex items-center gap-4 mb-4">
-							<select class="select" x-model.fill="competitor.team">
-								<option selected value="">Select team</option>
-								<template x-for="team in teams">
-									<option
-										:value="team.id"
-									>
-										<span x-text="team.label"></span>
-									</option>
-								</template>
-								<option
-									value="OWN_TEAM"
-								>Own team</option>
-							</select>
-							<button aria-label="add to team" class="btn btn-primary" @click="addCompetitorToTeam(competitor.userId, competitor.team)">
-								Add to Team
-								// <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-								// 	<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"></path>
-								// </svg>
-							</button>
-							<button aria-label="remove competitor" class="btn btn-circle btn-neutral  btn-xs" @click="removeCompetitor(competitor.userId)">
+						<div class="flex gap-4 mb-4 items-end">
+							<div class="w-full md:grow" x-text="competitor?.displayName ?? 'Missing name'"></div>
+							<template x-if="!competitor.userId?.match(/^tm_/)">
+								<div class="form-control w-full md:grow">
+									<label class="label">Add to Team</label>
+									<select class="select" x-model.fill="competitor.team">
+										<option selected value="">Select team</option>
+										<template x-for="team in teams">
+											<option
+												:value="team.id"
+											>
+												<span x-text="team.label"></span>
+											</option>
+										</template>
+										<option
+											:value="ownTeamId"
+										>Own team</option>
+									</select>
+								</div>
+							</template>
+							<template x-if="competitor.userId?.match?.(/^tm_/)">
+								<div class="form-control w-full md:grow">
+									(Previously created team)
+								</div>
+							</template>
+							<template x-if="!competitor.userId?.match?.(/^tm_/)">
+								<button
+									:disabled="competitor.team === '' "
+									class="btn btn-primary"
+									@click="addCompetitorToTeam(competitor)"
+								>
+									<span x-text="competitor?.team === ownTeamId ? 'Add to Own Team' : 'Add to Team'"></span>
+								</button>
+							</template>
+							<template x-if="competitor.userId?.match?.(/^tm_/)">
+								<button class="btn btn-primary" @click="addCompetitorToTeam(competitor)">
+									Add Team
+								</button>
+							</template>
+							<button aria-label="remove competitor" class="btn btn-circle btn-neutral btn-xs mb-2" @click="removeCompetitor(competitor.userId)">
 								<svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
 									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
 								</svg>
@@ -144,7 +163,7 @@ templ AddOrEditCompetitionPage(pageObj helpers.SitePage, competition types.Compe
 						</div>
 					</template>
 				</div>
-				@components.UsersSelect([]types.UserSearchResultDangerous{}, "", "competitors", "Competitors", "competitors", false)
+				@components.UsersSelect([]types.UserSearchResultDangerous{}, "", "competitors", "Competitors", "competitors", false, "competitor-removed")
 				<template x-if="formData?.competitors?.length > 0 && usersDataLoaded">
 					<template x-for="(competitor, idx) in competitors">
 						<div class="flex items-center gap-4 my-4 pl-4">
@@ -194,49 +213,51 @@ templ AddOrEditCompetitionPage(pageObj helpers.SitePage, competition types.Compe
 										</button>
 									</div>
 									<!-- Name -->
-									<h5 class="text-lg font-bold">Name</h5>
-									<div class="form-control">
-										<input
-											type="text"
-											class="input input-bordered"
-											x-model="team.label"
-										/>
-									</div>
+									<h5 class="text-lg font-bold" x-text="team.label"></h5>
 									<h5 class="text-lg font-bold mt-4 border-b border-base-300 pt-4">Members</h5>
-									<div class="form-control">
-										<ul class="p-0">
-											<template x-if="team.competitors.length === 0">
-												<li class="w-full">
-													<div class="flex justify-between py-3">
-														<span>(No members)</span>
-													</div>
-												</li>
-											</template>
-											<template x-for="(competitor, index) in team.competitors">
-												<li class="w-full">
-													<div class="flex justify-between py-3">
-														<span x-text="index + 1 + '. ' + competitor.displayName"></span>
-														<button aria-label="remove competitor" class="btn btn-circle btn-neutral btn-xs" @click="removeCompetitorFromTeam(team.label, competitor)" :disabled="saveReqInFlight">
-															<svg
-																xmlns="http://www.w3.org/2000/svg"
-																class="h-6 w-6"
-																fill="none"
-																viewBox="0 0 24 24"
-																stroke="currentColor"
-															>
-																<path
-																	stroke-linecap="round"
-																	stroke-linejoin="round"
-																	stroke-width="2"
-																	d="M6 18L18 6M6 6l12 12"
-																></path>
-															</svg>
-														</button>
-													</div>
-												</li>
-											</template>
-										</ul>
-									</div>
+									<template x-if="!team.id?.match(/^tm_/)">
+										<div>
+											(Individual Competitor)
+										</div>
+									</template>
+									<template x-if="team.id?.match(/^tm_/)">
+										<div>
+											<div class="form-control">
+												<ul class="p-0">
+													<template x-if="team.competitors.length === 0">
+														<li class="w-full">
+															<div class="flex justify-between py-3">
+																<span>(No members)</span>
+															</div>
+														</li>
+													</template>
+													<template x-for="(competitor, index) in team.competitors">
+														<li class="w-full">
+															<div class="flex justify-between py-3">
+																<span x-text="index + 1 + '. ' + competitor.displayName"></span>
+																<button aria-label="remove competitor" class="btn btn-circle btn-neutral btn-xs" @click="removeCompetitorFromTeam(team, competitor)" :disabled="saveReqInFlight">
+																	<svg
+																		xmlns="http://www.w3.org/2000/svg"
+																		class="h-6 w-6"
+																		fill="none"
+																		viewBox="0 0 24 24"
+																		stroke="currentColor"
+																	>
+																		<path
+																			stroke-linecap="round"
+																			stroke-linejoin="round"
+																			stroke-width="2"
+																			d="M6 18L18 6M6 6l12 12"
+																		></path>
+																	</svg>
+																</button>
+															</div>
+														</li>
+													</template>
+												</ul>
+											</div>
+										</div>
+									</template>
 								</li>
 							</template>
 						</ul>
@@ -518,6 +539,7 @@ templ AddOrEditCompetitionPage(pageObj helpers.SitePage, competition types.Compe
 				emptyTeamName: document.querySelector('#add-edit-competition').getAttribute('data-competition-empty-team-name') ?? null,
 				emptyRoundEventId: document.querySelector('#add-edit-competition').getAttribute('data-round-empty-event-id') ?? null,
 				teamIdPrefix: document.querySelector('#add-edit-competition').getAttribute('data-team-id-prefix') ?? null,
+				ownTeamId: 'OWN_TEAM',
 				formData: {
 					id: document.querySelector('#add-edit-competition').getAttribute('data-competition-id'),
 					name: document.querySelector('#add-edit-competition').getAttribute('data-competition-name'),
@@ -577,9 +599,14 @@ templ AddOrEditCompetitionPage(pageObj helpers.SitePage, competition types.Compe
 				},
 				removeCompetitor(userId) {
 					this.waitingRoom = this.waitingRoom.filter(competitor => competitor.userId !== userId);
+					this.$dispatch('competitor-removed', userId);
 				},
 				removeTeam(team) {
 					this.teams = this.teams.filter(_team => _team.id !== team.id);
+					this.waitingRoom.push({
+						displayName: team.label,
+						userId: team.id
+					})
 				},
 				addTeam(teamName) {
 					this.teams.push({
@@ -593,37 +620,57 @@ templ AddOrEditCompetitionPage(pageObj helpers.SitePage, competition types.Compe
 					});
 				},
 
-				addCompetitorToTeam(userId, teamId) {
-					this.teams = this.teams.map(team => {
-						if (team.id === teamId) {
-							if (!team.competitors.includes(userId)) {
-								const userToAdd = this.waitingRoom.find(competitor => competitor.userId === userId)
-								team.competitors.push({
-									displayName: userToAdd.displayName,
-									userId: userToAdd.userId
+				addCompetitorToTeam(competitor) {
+					if (competitor.team === this.ownTeamId || competitor?.userId?.match(/^tm_/)) {
+						this.teams.push({
+							label:  competitor.displayName,
+							id: competitor.userId,
+							competitors: []
+						})
+						this.waitingRoom = this.waitingRoom.filter(_competitor => _competitor.userId !== competitor.userId)
+					} else {
+						this.teams = this.teams.map(team => {
+							if (team.id === competitor.team) {
+								if (!team.competitors.includes(competitor.userId)) {
+									const userToAdd = this.waitingRoom.find(competitor => competitor.userId === competitor.userId)
+									team.competitors.push({
+										displayName: userToAdd.displayName,
+										userId: userToAdd.userId
+									})
+									this.waitingRoom = this.waitingRoom.filter(competitor => competitor.userId !== competitor.userId);
+								}
+								return ({
+									...team,
 								})
-								this.waitingRoom = this.waitingRoom.filter(competitor => competitor.userId !== userId);
 							}
-							return ({
-								...team,
-							})
-						}
-						return team;
-					});
-					this.competitors = this.teams.flatMap(team => team.competitors)
+							return team;
+						});
+						this.competitors = this.teams.flatMap(team => team.competitors)
+					}
 				},
 
-				removeCompetitorFromTeam(teamName, competitor) {
-					this.teams = this.teams.map(team => {
-						if (team.label === teamName) {
-							team.competitors = team.competitors.filter(_competitor => _competitor.displayName !== competitor.displayName);
-						}
-						return team;
-					});
-
-					this.waitingRoom.push({
+				removeCompetitorFromTeam(team, competitor) {
+					// Create copies of the data we need before modifying the array
+					const teamId = team.id;
+					const competitorToMove = {
 						displayName: competitor.displayName,
 						userId: competitor.userId
+					};
+
+					// Add to waiting room
+					this.waitingRoom.push(competitorToMove);
+
+					// Update teams array
+					this.$nextTick(() => {
+						this.teams = this.teams.map(_team => {
+							if (_team.id === teamId) {
+								return {
+									..._team,
+									competitors: _team.competitors.filter(_competitor => _competitor.userId !== competitorToMove.userId)
+								};
+							}
+							return _team;
+						});
 					});
 				},
 

--- a/functions/gateway/templates/pages/competition_add_edit.templ
+++ b/functions/gateway/templates/pages/competition_add_edit.templ
@@ -726,7 +726,6 @@ templ AddOrEditCompetitionPage(pageObj helpers.SitePage, competition types.Compe
 								const _round  = JSON.parse(JSON.stringify(round))
 								delete _round.competitorADisplayName
 								delete _round.competitorBDisplayName
-                delete _round.eventId
 								return {
 									..._round,
 									...(this.formData.id ? { competitionId: this.formData.id } : {}),

--- a/functions/gateway/templates/pages/competition_add_edit.templ
+++ b/functions/gateway/templates/pages/competition_add_edit.templ
@@ -620,32 +620,65 @@ templ AddOrEditCompetitionPage(pageObj helpers.SitePage, competition types.Compe
 				},
 
 				addCompetitorToTeam(competitor) {
-					if (competitor.team === this.ownTeamId || competitor?.userId?.match(/^tm_/)) {
+					// Create a clean copy of the competitor object
+					const competitorToAdd = {
+						userId: competitor.userId,
+						displayName: competitor.displayName,
+						team: competitor.team
+					};
+					
+					console.log('Adding competitor:', competitorToAdd);
+					
+					if (competitorToAdd.team === this.ownTeamId || competitorToAdd.userId?.match(/^tm_/)) {
+						// Team creation path...
 						this.teams.push({
-							label:  competitor.displayName,
-							id: competitor.userId,
+							label:  competitorToAdd.displayName,
+							id: competitorToAdd.userId,
 							competitors: []
 						})
-						this.waitingRoom = this.waitingRoom.filter(_competitor => _competitor.userId !== competitor.userId)
+						this.waitingRoom = this.waitingRoom.filter(_competitor => _competitor.userId !== competitorToAdd.userId)
 					} else {
-						this.teams = this.teams.map(team => {
-							if (team.id === competitor.team) {
-								if (!team.competitors.includes(competitor.userId)) {
-									const userToAdd = this.waitingRoom.find(competitor => competitor.userId === competitor.userId)
-									team.competitors.push({
-										displayName: userToAdd.displayName,
-										userId: userToAdd.userId
-									})
-									this.waitingRoom = this.waitingRoom.filter(competitor => competitor.userId !== competitor.userId);
-								}
-								return ({
+						// Find the exact competitor in the waiting room
+						const waitingRoomIndex = this.waitingRoom.findIndex(c => c.userId === competitorToAdd.userId);
+						
+						if (waitingRoomIndex === -1) {
+							console.error('Competitor not found in waiting room:', competitorToAdd);
+							return;
+						}
+						
+						// Find the target team
+						const teamIndex = this.teams.findIndex(t => t.id === competitorToAdd.team);
+						
+						if (teamIndex === -1) {
+							console.error('Selected team not found:', competitorToAdd.team);
+							return;
+						}
+						
+						// Create new team array with the updated team
+						this.teams = this.teams.map((team, index) => {
+							if (index === teamIndex) {
+								return {
 									...team,
-								})
+									competitors: [...team.competitors, {
+										displayName: competitorToAdd.displayName,
+										userId: competitorToAdd.userId
+									}]
+								};
 							}
 							return team;
 						});
-						this.competitors = this.teams.flatMap(team => team.competitors)
+						
+						// Remove from waiting room
+						this.waitingRoom = this.waitingRoom.filter((_, index) => index !== waitingRoomIndex);
 					}
+					
+					// Force a UI update
+					this.$nextTick(() => {
+						console.log('Updated state:', {
+							waitingRoom: this.waitingRoom,
+							teams: this.teams
+						});
+					});
 				},
 
 				removeCompetitorFromTeam(team, competitor) {

--- a/functions/gateway/templates/pages/competition_add_edit.templ
+++ b/functions/gateway/templates/pages/competition_add_edit.templ
@@ -726,6 +726,7 @@ templ AddOrEditCompetitionPage(pageObj helpers.SitePage, competition types.Compe
 								const _round  = JSON.parse(JSON.stringify(round))
 								delete _round.competitorADisplayName
 								delete _round.competitorBDisplayName
+                delete _round.eventId
 								return {
 									..._round,
 									...(this.formData.id ? { competitionId: this.formData.id } : {}),
@@ -738,7 +739,7 @@ templ AddOrEditCompetitionPage(pageObj helpers.SitePage, competition types.Compe
 									// isPending
 									// isVotingOpen
 									// status
-									// eventId
+									// eventId - this is removed to prevent out of sync data when round associated with event in event admin
 									// competitorA
 									// competitorB
 									// competitorAScore

--- a/functions/gateway/templates/pages/competition_add_edit.templ
+++ b/functions/gateway/templates/pages/competition_add_edit.templ
@@ -123,7 +123,7 @@ templ AddOrEditCompetitionPage(pageObj helpers.SitePage, competition types.Compe
 									<label class="label">Add to Team</label>
 									<select class="select" x-model.fill="competitor.team">
 										<option selected value="">Select team</option>
-										<template x-for="team in teams">
+										<template x-for="team in teams.filter(team => team.id.startsWith('tm_'))">
 											<option
 												:value="team.id"
 											>

--- a/functions/gateway/templates/pages/competition_add_edit.templ
+++ b/functions/gateway/templates/pages/competition_add_edit.templ
@@ -627,8 +627,6 @@ templ AddOrEditCompetitionPage(pageObj helpers.SitePage, competition types.Compe
 						team: competitor.team
 					};
 
-					console.log('Adding competitor:', competitorToAdd);
-
 					if (competitorToAdd.team === this.ownTeamId || competitorToAdd.userId?.match(/^tm_/)) {
 						// Team creation path...
 						this.teams.push({
@@ -642,6 +640,7 @@ templ AddOrEditCompetitionPage(pageObj helpers.SitePage, competition types.Compe
 						const waitingRoomIndex = this.waitingRoom.findIndex(c => c.userId === competitorToAdd.userId);
 
 						if (waitingRoomIndex === -1) {
+							// eslint-disable-next-line no-console
 							console.error('Competitor not found in waiting room:', competitorToAdd);
 							return;
 						}
@@ -650,6 +649,7 @@ templ AddOrEditCompetitionPage(pageObj helpers.SitePage, competition types.Compe
 						const teamIndex = this.teams.findIndex(t => t.id === competitorToAdd.team);
 
 						if (teamIndex === -1) {
+							// eslint-disable-next-line no-console
 							console.error('Selected team not found:', competitorToAdd.team);
 							return;
 						}
@@ -674,6 +674,7 @@ templ AddOrEditCompetitionPage(pageObj helpers.SitePage, competition types.Compe
 
 					// Force a UI update
 					this.$nextTick(() => {
+						// eslint-disable-next-line no-console
 						console.log('Updated state:', {
 							waitingRoom: this.waitingRoom,
 							teams: this.teams
@@ -805,6 +806,10 @@ templ AddOrEditCompetitionPage(pageObj helpers.SitePage, competition types.Compe
 								const _round  = JSON.parse(JSON.stringify(round))
 								delete _round.competitorADisplayName
 								delete _round.competitorBDisplayName
+								// NOTE: this is removed to prevent out of sync data when round associated with event in event admin
+								if (_round.eventId !== this.emptyRoundEventId) {
+									delete _round.eventId
+								}
 								return {
 									..._round,
 									...(this.formData.id ? { competitionId: this.formData.id } : {}),
@@ -817,7 +822,7 @@ templ AddOrEditCompetitionPage(pageObj helpers.SitePage, competition types.Compe
 									// isPending
 									// isVotingOpen
 									// status
-									// eventId - this is removed to prevent out of sync data when round associated with event in event admin
+									// eventId
 									// competitorA
 									// competitorB
 									// competitorAScore
@@ -826,8 +831,6 @@ templ AddOrEditCompetitionPage(pageObj helpers.SitePage, competition types.Compe
 									}
 							})
 						};
-
-            console.log("Rounds field on comp config payload\n", competitionData.rounds);
 
 						competitionData?.rounds?.forEach?.((round, index) => {
 							if (!round?.competitorA || !round?.competitorB) {
@@ -881,13 +884,13 @@ templ AddOrEditCompetitionPage(pageObj helpers.SitePage, competition types.Compe
 							message: `Failed to update competition: ${error.message}`,
 						}
 					} finally {
-          // remove the fake keys
-            this.formData?.rounds?.forEach(round => {
-              if (round.eventId === 'fake-event-id-123') {
-                delete round.eventId
-              }
-            })
 						this.saveReqInFlight = false;
+						// remove the fake keys
+						this.formData?.rounds?.forEach(round => {
+							if (round.eventId === 'fake-event-id-123') {
+								delete round.eventId
+							}
+						})
 					}
 				}
 			}

--- a/functions/gateway/templates/pages/event_add_edit.templ
+++ b/functions/gateway/templates/pages/event_add_edit.templ
@@ -493,8 +493,22 @@ templ AddOrEditEventPage(pageObj helpers.SitePage, event types.Event, isEditor b
 												/>
 											}
 										</div>
-										<template x-if="child.competitionConfigId">
+										<div x-text="JSON.stringify(child)"></div>
+										<template x-if="child && child.competitionConfigId">
 											<div class="form-control">
+												<div
+													x-init="
+                          console.log('Child event debug:', {
+                              childId: child.id,
+                              hasConfigId: !!child.competitionConfigId,
+                              configId: child.competitionConfigId,
+                              roundsLoaded: competitionRoundsLoaded,
+                              hasRounds: !!child.competitionRounds,
+                              roundsCount: child.competitionRounds?.length,
+                              rounds: child.competitionRounds
+                            })
+                        "
+												></div>
 												<label class="label">Competition Config</label>
 												<a class="link link-primary" :href="'/admin/competition/' + child.competitionConfigId + '/edit' ">
 													View Competition Config
@@ -506,7 +520,11 @@ templ AddOrEditEventPage(pageObj helpers.SitePage, event types.Event, isEditor b
 														<span class="loading loading-spinner loading-sm"></span>
 													</div>
 												</template>
-												<template x-if="child?.competitionConfigId && competitionRoundsLoaded">
+												<template x-if="child && child?.competitionConfigId && competitionRoundsLoaded">
+													<!-- remove this -->
+													<div class="text-sm opacity-50">
+														<div x-text="'Rounds count: ' + (child.competitionRounds?.length || 0)"></div>
+													</div>
 													<template x-for="(competitionRound, index) in child.competitionRounds">
 														<div class="flex justify-between items-center">
 															<div x-text=" (index + 1) + '. ' + competitionRound.roundName"></div>
@@ -1070,73 +1088,99 @@ templ AddOrEditEventPage(pageObj helpers.SitePage, event types.Event, isEditor b
 								}
 
 								try {
-
-										// Wait for eventChildrenLoaded using a Promise, but skip if not an event series
-										if (this.isEventSeries) {
-											await new Promise((resolve) => {
-													const checkLoaded = () => {
-														if (this.eventChildrenLoaded) {
-																	resolve();
-															} else {
-																	setTimeout(checkLoaded, 100);
-															}
-													};
-													checkLoaded();
-											});
-										}
-
-										const allEvents = [this.formData.event, ...Object.values(this.formData.eventChildren)]
-										const competitionIdsToFetch = []
-										const promises = []
-										allEvents.forEach(event => {
-											if (event.competitionConfigId) {
-												competitionIdsToFetch.push(event.competitionConfigId)
-											}
-										})
-
-										competitionIdsToFetch.forEach(competitionId => {
-											promises.push(fetch(`/api/competition-round/competition/${competitionId}`))
-										})
-										this.competitionRoundsLoaded = false
-										const roundResponses = await Promise.all(promises)
-										const roundData = await Promise.all(roundResponses.map(r => r.json()))
-										// Flatten the array of round data arrays
-										const flattenedRoundData = roundData.flat()
-										flattenedRoundData.forEach(round => {
-												// Check parent event first
-												if (this.formData.event.id === round.eventId) {
-														if (!this.formData.event.competitionRounds) {
-																this.formData.event.competitionRounds = [];
-														}
-														this.formData.event.competitionRounds.push(round);
+									// Wait for eventChildrenLoaded using a Promise
+									if (this.isEventSeries) {
+										await new Promise((resolve) => {
+											const checkLoaded = () => {
+												if (this.eventChildrenLoaded) {
+													console.log('Event children loaded:', this.formData.eventChildren);
+													resolve();
 												} else {
-														// Check children events
-														const childIndex = this.formData.eventChildren.findIndex(
-																child => child.id === round.eventId
-														);
-														if (childIndex !== -1) {
-																// instantiate if empty, otherwise keep the existing array
-																// this.formData.eventChildren[childIndex].competitionRounds = this.formData.eventChildren[childIndex]?.competitionRounds || []
-																// this.formData.eventChildren[childIndex].competitionRounds.push(round);
-																if (!this.formData.eventChildren[childIndex]?.competitionRounds?.find?.(r => r.roundNumber === round.roundNumber)) {
-																	if (!Array.isArray(this.formData.eventChildren[childIndex]?.competitionRounds)) {
-																		this.formData.eventChildren[childIndex].competitionRounds = []
-																	}
-																	this.formData.eventChildren[childIndex].competitionRounds.push(round);
-																}
-														}
+													setTimeout(checkLoaded, 100);
 												}
+											};
+											checkLoaded();
 										});
+									}
 
+									const allEvents = [this.formData.event, ...Object.values(this.formData.eventChildren)]
+									console.log('All events before fetching rounds:', allEvents);
 
-										this.competitionRoundsLoaded = true
-										this.$nextTick(() => {
-											// Dispatch event to trigger event child height recalculation
-											window.dispatchEvent(new CustomEvent('child-content-changed'));
-										});
+									const competitionIdsToFetch = []
+									allEvents.forEach(event => {
+										if (event.competitionConfigId) {
+											competitionIdsToFetch.push(event.competitionConfigId)
+										}
+									})
+
+									// Fetch and process rounds
+									const promises = []
+									competitionIdsToFetch.forEach(competitionId => {
+										promises.push(fetch(`/api/competition-round/competition/${competitionId}`))
+									})
+
+									this.competitionRoundsLoaded = false
+									const roundResponses = await Promise.all(promises)
+									const roundData = await Promise.all(roundResponses.map(r => r.json()))
+									const flattenedRoundData = roundData.flat()
+
+									// Process rounds after ensuring children are loaded
+									flattenedRoundData.forEach(round => {
+										const childEvent = this.formData.eventChildren.find(child =>
+											child.id === round.eventId
+										);
+
+										if (childEvent) {
+											console.log('Found matching child event for round:', {
+												roundId: round.id,
+												eventId: childEvent.id,
+												roundNumber: round.roundNumber
+											});
+
+											// Ensure reactive array initialization
+											if (!childEvent.competitionRounds) {
+												this.$nextTick(() => {
+													childEvent.competitionRounds = [];
+												});
+											}
+
+											// Force reactivity by using array spread
+											this.$nextTick(() => {
+												childEvent.competitionRounds = [
+													...(childEvent.competitionRounds || []),
+													round
+												];
+											});
+
+											console.log('Updated child event rounds:', childEvent.competitionRounds);
+										}
+										// If not a child event, check if it belongs to parent
+										else if (this.formData.event.id === round.eventId) {
+											if (!this.formData.event.competitionRounds) {
+												this.formData.event.competitionRounds = [];
+											}
+											this.formData.event.competitionRounds.push(round);
+										}
+									});
+
+									// After processing all rounds
+									this.$nextTick(() => {
+										// Force reactivity update
+										this.formData.eventChildren = [...this.formData.eventChildren];
+										this.competitionRoundsLoaded = true;
+
+										console.log('Verification - Child events after processing:',
+											this.formData.eventChildren.map(child => ({
+												id: child.id,
+												roundsCount: child.competitionRounds?.length || 0,
+												rounds: child.competitionRounds
+											}))
+										);
+									});
+
 								} catch (error) {
-									// eslint-disable-next-line no-console
-									console.error('Error fetching event children:', error);
+									console.error('Error in round initialization:', error);
+									this.competitionRoundsLoaded = true;
 								}
 						})()
 					},
@@ -1671,16 +1715,22 @@ templ AddOrEditEventPage(pageObj helpers.SitePage, event types.Event, isEditor b
 
             const allRounds = [];
 
-            // add parent event rounds
+            // add parent event rounds with explicit eventId
             if (this.formData.event.competitionRounds) {
-                allRounds.push(...this.formData.event.competitionRounds);
+                allRounds.push(...this.formData.event.competitionRounds.map(round => ({
+                    ...round,
+                    eventId: this.formData.event.id
+                })));
             }
 
-            // Add child event rounds
+            // Add child event rounds with explicit eventId
             if (this.formData.eventChildren.length > 0) {
                 this.formData.eventChildren.forEach(child => {
                     if (child.competitionRounds) {
-                        allRounds.push(...child.competitionRounds);
+                        allRounds.push(...child.competitionRounds.map(round => ({
+                            ...round,
+                            eventId: child.id
+                        })));
                     }
                 });
             }
@@ -1688,8 +1738,8 @@ templ AddOrEditEventPage(pageObj helpers.SitePage, event types.Event, isEditor b
             // Add any pending updates, overwriting existing rounds if necessary
             if (this.formData.pendingRoundUpdates) {
                 this.formData.pendingRoundUpdates.forEach(pendingRound => {
-                    const existingIndex = allRounds.findIndex(r => 
-                        r.competitionId === pendingRound.competitionId && 
+                    const existingIndex = allRounds.findIndex(r =>
+                        r.competitionId === pendingRound.competitionId &&
                         r.roundNumber === pendingRound.roundNumber
                     );
                     if (existingIndex !== -1) {
@@ -1730,7 +1780,7 @@ templ AddOrEditEventPage(pageObj helpers.SitePage, event types.Event, isEditor b
                     ...(this.registrationFieldsCreatedAt !== '' ? {created_at: this.registrationFieldsCreatedAt} : {}),
                     fields: this.registrationFields,
                 },
-                rounds: this.formData.pendingRoundUpdates || [],
+                rounds: cleanedRounds,
             }
             if (this.formData.eventChildren.length > 0 && this.isEventSeries) {
                 this.formData.eventChildren.forEach(child => {
@@ -1760,6 +1810,8 @@ templ AddOrEditEventPage(pageObj helpers.SitePage, event types.Event, isEditor b
             }
 
             try {
+                console.log("Checking for issue of sending updates always");
+                console.log("Payload for event, checking rounds \n", payload.rounds);
                 const response = await fetch(`/api/event-reg-purch/${this.formData.event.id}`, {
                     method: 'PUT',
                     headers: {

--- a/functions/gateway/templates/pages/event_add_edit.templ
+++ b/functions/gateway/templates/pages/event_add_edit.templ
@@ -1601,57 +1601,57 @@ templ AddOrEditEventPage(pageObj helpers.SitePage, event types.Event, isEditor b
                 this.saveReqInFlight = false;
             }
           },
-					async handleRemoveCompetitionRoundFromEvent(competitionRound, child) {
-						// Set loading state for this specific round
-						competitionRound.isRemoving = true;
+        async handleRemoveCompetitionRoundFromEvent(competitionRound, child) {
+            // Set loading state for this specific round
+            competitionRound.isRemoving = true;
 
-						try {
-								const _competitionRound = JSON.parse(JSON.stringify(competitionRound))
-								let _roundUpdate = {
-									..._competitionRound,
-									eventId: this.roundEmptyEventId
-								}
-								delete _roundUpdate.isRemoving
-								const response = await fetch(`/api/competition-round/${competitionRound.competitionId}`, {
-										method: 'PUT',
-										headers: {
-												'Content-Type': 'application/json',
-										},
-										body: JSON.stringify([_roundUpdate]),
-								});
+            try {
+                    const _competitionRound = JSON.parse(JSON.stringify(competitionRound))
+                    let _roundUpdate = {
+                        ..._competitionRound,
+                        eventId: this.roundEmptyEventId
+                    }
+                    delete _roundUpdate.isRemoving
+                    const response = await fetch(`/api/competition-round/${competitionRound.competitionId}`, {
+                            method: 'PUT',
+                            headers: {
+                                    'Content-Type': 'application/json',
+                            },
+                            body: JSON.stringify([_roundUpdate]),
+                    });
 
-								if (!response.ok) {
-										throw new Error('Failed to remove competition round');
-								}
+                    if (!response.ok) {
+                            throw new Error('Failed to remove competition round');
+                    }
 
-								// Remove the round from child.competitionRounds
-								child.competitionRounds = child.competitionRounds.filter(round =>
-										round.roundNumber !== competitionRound.roundNumber
-								);
+                    // Remove the round from child.competitionRounds
+                    child.competitionRounds = child.competitionRounds.filter(round =>
+                            round.roundNumber !== competitionRound.roundNumber
+                    );
 
-								// Update allCompetitionRounds if it exists
-								if (this.allCompetitionRounds) {
-										this.allCompetitionRounds = this.allCompetitionRounds.filter(round =>
-												!(round.roundNumber === competitionRound.roundNumber &&
-													round.competitionConfigId === competitionRound.competitionConfigId)
-										);
-								}
+                    // Update allCompetitionRounds if it exists
+                    if (this.allCompetitionRounds) {
+                            this.allCompetitionRounds = this.allCompetitionRounds.filter(round =>
+                                    !(round.roundNumber === competitionRound.roundNumber &&
+                                        round.competitionConfigId === competitionRound.competitionConfigId)
+                            );
+                    }
 
-						} catch (error) {
-								// eslint-disable-next-line no-console
-								console.error('Error removing competition round from event:', error);
-								// Reset loading state on error
-								competitionRound.isRemoving = false;
+            } catch (error) {
+                    // eslint-disable-next-line no-console
+                    console.error('Error removing competition round from event:', error);
+                    // Reset loading state on error
+                    competitionRound.isRemoving = false;
 
-								this.showToast = true;
-								this.toastContent = {
-										type: 'error',
-										message: 'Failed to remove competition round'
-								};
-						}
-					},
+                    this.showToast = true;
+                    this.toastContent = {
+                            type: 'error',
+                            message: 'Failed to remove competition round'
+                    };
+            }
+        },
 
-					async handlePublishClick() {
+        async handlePublishClick() {
             if (this.formData.pendingRoundUpdates.length > 100) {
                 this.showToast = true;
                 this.toastContent = {
@@ -1662,100 +1662,140 @@ templ AddOrEditEventPage(pageObj helpers.SitePage, event types.Event, isEditor b
                 return;
             }
 
-						this.saveReqInFlight = true
-						const _parentEvent = JSON.parse(JSON.stringify(this.transformEventToPayload(this.formData.event)))
-						this.purchasables = this.purchasables.map(p => ({
-							...p,
-							currency: this.formData.event.currency,
-						}))
-						// NOTE: never set the eventSourceId on the parent event, it IS the parent
-						delete _parentEvent.eventSourceId
-						delete _parentEvent.competitionRounds
+            this.saveReqInFlight = true
+            const _parentEvent = JSON.parse(JSON.stringify(this.transformEventToPayload(this.formData.event)))
+            this.purchasables = this.purchasables.map(p => ({
+                ...p,
+                currency: this.formData.event.currency,
+            }))
 
-						let payload = {
-							events: [{
-								..._parentEvent,
-							}],
-							purchasableUpdate: {
-								event_id: this.formData.event.id,
-								...(this.purchasablesCreatedAt !== '' ? {created_at: this.purchasablesCreatedAt} : {}),
-								purchasable_items: this.purchasables.map(p => ({
-									...p,
-									expires_on: p.expires_on ? p.expires_on + this.timeZuluSuffix : null,
-									cost: (p.cost * 100),
-									inventory: p.inventory,
-								})),
-							},
-							registrationFieldsUpdate: {
-								...(this.registrationFieldsCreatedAt !== '' ? {created_at: this.registrationFieldsCreatedAt} : {}),
-								fields: this.registrationFields,
-							},
-							rounds: this.formData.pendingRoundUpdates || [],
-						}
-						if (this.formData.eventChildren.length > 0 && this.isEventSeries) {
-							this.formData.eventChildren.forEach(child => {
-								// NOTE: this is importantly set to null to
-								// prevent the payload from violaiting request
-								// body size limit constraints. The API will
-								// always take the parent event's description
-								// and seed it to each child event
-								const _childEvent = JSON.parse(JSON.stringify(child))
+            const allRounds = [];
 
-								delete _parentEvent.description
-								delete _childEvent.description
+            // add parent event rounds
+            if (this.formData.event.competitionRounds) {
+                allRounds.push(...this.formData.event.competitionRounds);
+            }
 
-								delete _childEvent.competitionRounds
-								// NOTE: never override the child event's id with the parent id
-								delete _parentEvent.id
-								const _mergedEvent = {..._parentEvent, ..._childEvent}
-								payload.events.push({
-									..._mergedEvent,
-									eventSourceId: this.formData.event.id,
-									eventSourceType: this.deriveEventSourceTypeFromDropdown(_mergedEvent, this.publishStatus, this.isEventSeries, true),
-									startTime: child.startTime ? child.startTime + this.timeZuluSuffix : null,
-									endTime: child.endTime ? child.endTime + this.timeZuluSuffix : null,
-									// eventSourceType: this.isEventSeries ? this.eventTypeSeriesChildConstant : this.eventTypeSingleConstant,
-								})
-							})
-						}
+            // Add child event rounds
+            if (this.formData.eventChildren.length > 0) {
+                this.formData.eventChildren.forEach(child => {
+                    if (child.competitionRounds) {
+                        allRounds.push(...child.competitionRounds);
+                    }
+                });
+            }
 
-						try {
-							const response = await fetch(`/api/event-reg-purch/${this.formData.event.id}`, {
-								method: 'PUT',
-								headers: {
-									'Content-Type': 'application/json',
-								},
-								body: JSON.stringify(payload),
-							});
-							const json = await response.json()
-							if (json.status === 'success') {
-								this.saveReqInFlight = false
-								this.showToast = true;
-								this.toastContent = {
-									type: 'success',
-									message: 'Event updated successfully',
-								}
-								// NOTE: this API path should come from a data-* attribute
-								// that uses the `SitePages` constant for this API path
-								const newUrl = `/admin/event/${json.data.parentEvent._id}/edit`;
-								window.history.pushState({ path: newUrl }, '', newUrl);
-								this.formData.event.id = json.data.parentEvent._id
-							} else {
-								throw new Error(`Failed to update event ${ json?.error?.message ? ": " + json.error.message : ''}`)
-							}
-						} catch (error) {
-							// eslint-disable-next-line no-console
-							console.error('Failed to update event:', error);
-							this.saveReqInFlight = false
-							this.showToast = true;
-							this.toastContent = {
-								type: 'error',
-								message: error,
-							}
-						}
-					}
-				}
-			}
+            // Add any pending updates, overwriting existing rounds if necessary
+            if (this.formData.pendingRoundUpdates) {
+                this.formData.pendingRoundUpdates.forEach(pendingRound => {
+                    const existingIndex = allRounds.findIndex(r => 
+                        r.competitionId === pendingRound.competitionId && 
+                        r.roundNumber === pendingRound.roundNumber
+                    );
+                    if (existingIndex !== -1) {
+                        allRounds[existingIndex] = pendingRound;
+                    } else {
+                        allRounds.push(pendingRound);
+                    }
+                });
+            }
+
+            // Remove any UI-specific properties from rounds
+            const cleanedRounds = allRounds.map(round => {
+                const cleanRound = { ...round };
+                delete cleanRound.isRemoving;
+                return cleanRound;
+            });
+
+
+            // NOTE: never set the eventSourceId on the parent event, it IS the parent
+            delete _parentEvent.eventSourceId
+            delete _parentEvent.competitionRounds
+
+            let payload = {
+                events: [{
+                    ..._parentEvent,
+                }],
+                purchasableUpdate: {
+                    event_id: this.formData.event.id,
+                    ...(this.purchasablesCreatedAt !== '' ? {created_at: this.purchasablesCreatedAt} : {}),
+                    purchasable_items: this.purchasables.map(p => ({
+                        ...p,
+                        expires_on: p.expires_on ? p.expires_on + this.timeZuluSuffix : null,
+                        cost: (p.cost * 100),
+                        inventory: p.inventory,
+                    })),
+                },
+                registrationFieldsUpdate: {
+                    ...(this.registrationFieldsCreatedAt !== '' ? {created_at: this.registrationFieldsCreatedAt} : {}),
+                    fields: this.registrationFields,
+                },
+                rounds: this.formData.pendingRoundUpdates || [],
+            }
+            if (this.formData.eventChildren.length > 0 && this.isEventSeries) {
+                this.formData.eventChildren.forEach(child => {
+                    // NOTE: this is importantly set to null to
+                    // prevent the payload from violaiting request
+                    // body size limit constraints. The API will
+                    // always take the parent event's description
+                    // and seed it to each child event
+                    const _childEvent = JSON.parse(JSON.stringify(child))
+
+                    delete _parentEvent.description
+                    delete _childEvent.description
+
+                    delete _childEvent.competitionRounds
+                    // NOTE: never override the child event's id with the parent id
+                    delete _parentEvent.id
+                    const _mergedEvent = {..._parentEvent, ..._childEvent}
+                    payload.events.push({
+                        ..._mergedEvent,
+                        eventSourceId: this.formData.event.id,
+                        eventSourceType: this.deriveEventSourceTypeFromDropdown(_mergedEvent, this.publishStatus, this.isEventSeries, true),
+                        startTime: child.startTime ? child.startTime + this.timeZuluSuffix : null,
+                        endTime: child.endTime ? child.endTime + this.timeZuluSuffix : null,
+                        // eventSourceType: this.isEventSeries ? this.eventTypeSeriesChildConstant : this.eventTypeSingleConstant,
+                    })
+                })
+            }
+
+            try {
+                const response = await fetch(`/api/event-reg-purch/${this.formData.event.id}`, {
+                    method: 'PUT',
+                    headers: {
+                        'Content-Type': 'application/json',
+                    },
+                    body: JSON.stringify(payload),
+                });
+                const json = await response.json()
+                if (json.status === 'success') {
+                    this.saveReqInFlight = false
+                    this.showToast = true;
+                    this.toastContent = {
+                        type: 'success',
+                        message: 'Event updated successfully',
+                    }
+                    // NOTE: this API path should come from a data-* attribute
+                    // that uses the `SitePages` constant for this API path
+                    const newUrl = `/admin/event/${json.data.parentEvent._id}/edit`;
+                    window.history.pushState({ path: newUrl }, '', newUrl);
+                    this.formData.event.id = json.data.parentEvent._id
+                } else {
+                    throw new Error(`Failed to update event ${ json?.error?.message ? ": " + json.error.message : ''}`)
+                }
+            } catch (error) {
+                // eslint-disable-next-line no-console
+                console.error('Failed to update event:', error);
+                this.saveReqInFlight = false
+                this.showToast = true;
+                this.toastContent = {
+                    type: 'error',
+                    message: error,
+                }
+            }
+        }
+    }
+}
 	</script>
 	}
 }

--- a/functions/gateway/templates/pages/event_add_edit.templ
+++ b/functions/gateway/templates/pages/event_add_edit.templ
@@ -323,7 +323,7 @@ templ AddOrEditEventPage(pageObj helpers.SitePage, event types.Event, isEditor b
 									<div class="flex justify-between items-center">
 										<div x-text=" (index + 1) + '. ' + competitionRound.roundName"></div>
 										<button
-											@click="handleRemoveCompetitionRoundFromEvent(competitionRound, formData.event)"
+											@click="handleRemoveCompetitionRoundFromEvent(competitionRound)"
 											class="btn btn-ghost btn-circle btn-sm"
 											:disabled="competitionRound.isRemoving || saveReqInFlight"
 											aria-label="remove this competition round from event"
@@ -493,22 +493,8 @@ templ AddOrEditEventPage(pageObj helpers.SitePage, event types.Event, isEditor b
 												/>
 											}
 										</div>
-										<div x-text="JSON.stringify(child)"></div>
-										<template x-if="child && child.competitionConfigId">
+										<template x-if="child.competitionConfigId">
 											<div class="form-control">
-												<div
-													x-init="
-                          console.log('Child event debug:', {
-                              childId: child.id,
-                              hasConfigId: !!child.competitionConfigId,
-                              configId: child.competitionConfigId,
-                              roundsLoaded: competitionRoundsLoaded,
-                              hasRounds: !!child.competitionRounds,
-                              roundsCount: child.competitionRounds?.length,
-                              rounds: child.competitionRounds
-                            })
-                        "
-												></div>
 												<label class="label">Competition Config</label>
 												<a class="link link-primary" :href="'/admin/competition/' + child.competitionConfigId + '/edit' ">
 													View Competition Config
@@ -520,16 +506,12 @@ templ AddOrEditEventPage(pageObj helpers.SitePage, event types.Event, isEditor b
 														<span class="loading loading-spinner loading-sm"></span>
 													</div>
 												</template>
-												<template x-if="child && child?.competitionConfigId && competitionRoundsLoaded">
-													<!-- remove this -->
-													<div class="text-sm opacity-50">
-														<div x-text="'Rounds count: ' + (child.competitionRounds?.length || 0)"></div>
-													</div>
+												<template x-if="child?.competitionConfigId && competitionRoundsLoaded">
 													<template x-for="(competitionRound, index) in child.competitionRounds">
 														<div class="flex justify-between items-center">
 															<div x-text=" (index + 1) + '. ' + competitionRound.roundName"></div>
 															<button
-																@click="handleRemoveCompetitionRoundFromEvent(competitionRound, child)"
+																@click="handleRemoveCompetitionRoundFromEvent(competitionRound)"
 																class="btn btn-ghost btn-circle btn-sm"
 																:disabled="competitionRound.isRemoving || saveReqInFlight"
 																aria-label="remove this competition round from event"
@@ -1088,99 +1070,73 @@ templ AddOrEditEventPage(pageObj helpers.SitePage, event types.Event, isEditor b
 								}
 
 								try {
-									// Wait for eventChildrenLoaded using a Promise
-									if (this.isEventSeries) {
-										await new Promise((resolve) => {
-											const checkLoaded = () => {
-												if (this.eventChildrenLoaded) {
-													console.log('Event children loaded:', this.formData.eventChildren);
-													resolve();
+
+										// Wait for eventChildrenLoaded using a Promise, but skip if not an event series
+										if (this.isEventSeries) {
+											await new Promise((resolve) => {
+													const checkLoaded = () => {
+														if (this.eventChildrenLoaded) {
+																	resolve();
+															} else {
+																	setTimeout(checkLoaded, 100);
+															}
+													};
+													checkLoaded();
+											});
+										}
+
+										const allEvents = [this.formData.event, ...Object.values(this.formData.eventChildren)]
+										const competitionIdsToFetch = []
+										const promises = []
+										allEvents.forEach(event => {
+											if (event.competitionConfigId) {
+												competitionIdsToFetch.push(event.competitionConfigId)
+											}
+										})
+
+										competitionIdsToFetch.forEach(competitionId => {
+											promises.push(fetch(`/api/competition-round/competition/${competitionId}`))
+										})
+										this.competitionRoundsLoaded = false
+										const roundResponses = await Promise.all(promises)
+										const roundData = await Promise.all(roundResponses.map(r => r.json()))
+										// Flatten the array of round data arrays
+										const flattenedRoundData = roundData.flat()
+										flattenedRoundData.forEach(round => {
+												// Check parent event first
+												if (this.formData.event.id === round.eventId) {
+														if (!this.formData.event.competitionRounds) {
+																this.formData.event.competitionRounds = [];
+														}
+														this.formData.event.competitionRounds.push(round);
 												} else {
-													setTimeout(checkLoaded, 100);
+														// Check children events
+														const childIndex = this.formData.eventChildren.findIndex(
+																child => child.id === round.eventId
+														);
+														if (childIndex !== -1) {
+																// instantiate if empty, otherwise keep the existing array
+																// this.formData.eventChildren[childIndex].competitionRounds = this.formData.eventChildren[childIndex]?.competitionRounds || []
+																// this.formData.eventChildren[childIndex].competitionRounds.push(round);
+																if (!this.formData.eventChildren[childIndex]?.competitionRounds?.find?.(r => r.roundNumber === round.roundNumber)) {
+																	if (!Array.isArray(this.formData.eventChildren[childIndex]?.competitionRounds)) {
+																		this.formData.eventChildren[childIndex].competitionRounds = []
+																	}
+																	this.formData.eventChildren[childIndex].competitionRounds.push(round);
+																}
+														}
 												}
-											};
-											checkLoaded();
 										});
-									}
 
-									const allEvents = [this.formData.event, ...Object.values(this.formData.eventChildren)]
-									console.log('All events before fetching rounds:', allEvents);
 
-									const competitionIdsToFetch = []
-									allEvents.forEach(event => {
-										if (event.competitionConfigId) {
-											competitionIdsToFetch.push(event.competitionConfigId)
-										}
-									})
-
-									// Fetch and process rounds
-									const promises = []
-									competitionIdsToFetch.forEach(competitionId => {
-										promises.push(fetch(`/api/competition-round/competition/${competitionId}`))
-									})
-
-									this.competitionRoundsLoaded = false
-									const roundResponses = await Promise.all(promises)
-									const roundData = await Promise.all(roundResponses.map(r => r.json()))
-									const flattenedRoundData = roundData.flat()
-
-									// Process rounds after ensuring children are loaded
-									flattenedRoundData.forEach(round => {
-										const childEvent = this.formData.eventChildren.find(child =>
-											child.id === round.eventId
-										);
-
-										if (childEvent) {
-											console.log('Found matching child event for round:', {
-												roundId: round.id,
-												eventId: childEvent.id,
-												roundNumber: round.roundNumber
-											});
-
-											// Ensure reactive array initialization
-											if (!childEvent.competitionRounds) {
-												this.$nextTick(() => {
-													childEvent.competitionRounds = [];
-												});
-											}
-
-											// Force reactivity by using array spread
-											this.$nextTick(() => {
-												childEvent.competitionRounds = [
-													...(childEvent.competitionRounds || []),
-													round
-												];
-											});
-
-											console.log('Updated child event rounds:', childEvent.competitionRounds);
-										}
-										// If not a child event, check if it belongs to parent
-										else if (this.formData.event.id === round.eventId) {
-											if (!this.formData.event.competitionRounds) {
-												this.formData.event.competitionRounds = [];
-											}
-											this.formData.event.competitionRounds.push(round);
-										}
-									});
-
-									// After processing all rounds
-									this.$nextTick(() => {
-										// Force reactivity update
-										this.formData.eventChildren = [...this.formData.eventChildren];
-										this.competitionRoundsLoaded = true;
-
-										console.log('Verification - Child events after processing:',
-											this.formData.eventChildren.map(child => ({
-												id: child.id,
-												roundsCount: child.competitionRounds?.length || 0,
-												rounds: child.competitionRounds
-											}))
-										);
-									});
-
+										this.competitionRoundsLoaded = true
+										this.$nextTick(() => {
+											// Dispatch event to trigger event child height recalculation
+											window.dispatchEvent(new CustomEvent('child-content-changed'));
+										});
 								} catch (error) {
-									console.error('Error in round initialization:', error);
-									this.competitionRoundsLoaded = true;
+									// eslint-disable-next-line no-console
+									console.error('Error fetching event children:', error);
 								}
 						})()
 					},
@@ -1207,7 +1163,7 @@ templ AddOrEditEventPage(pageObj helpers.SitePage, event types.Event, isEditor b
 					},
 					publishStatus: document.querySelector('#publishStatus')?.value ?? null,
 					isCompetitionAdmin: document.querySelector('#add-edit-event').getAttribute('data-is-competition-admin') ?? false,
-					roundEmptyEventId: document.querySelector('#add-edit-event').getAttribute('data-round-empty-event-id') ?? null,
+					emptyRoundEventId: document.querySelector('#add-edit-event').getAttribute('data-round-empty-event-id') ?? null,
 					competitionConfigs: [],
 					competitionModalIndex: null,
 					competitionModalEventSelection: null,
@@ -1248,11 +1204,6 @@ templ AddOrEditEventPage(pageObj helpers.SitePage, event types.Event, isEditor b
 					options: [],
 					isOpen: false,
 					openedWithKeyboard: false,
-					// END: Event Owners typeahead state
-					getFormChildrenData() {
-						return JSON.stringify(this.formData.eventChildren);
-					},
-					// BEGIN: Event Owners typeahead helper functions
 					async fetchUsers(query) {
 						if (query.length >= 3) {
 							await fetch(`/api/user-search?q=${query}`).then(res => {
@@ -1568,286 +1519,182 @@ templ AddOrEditEventPage(pageObj helpers.SitePage, event types.Event, isEditor b
 							this.competitionModalRoundsLoading = false
 						}
 					},
-          async handleAddRoundClick() {
-            this.saveReqInFlight = true;
-            try {
-              // Create array of new round updates, preserving all selected rounds
-              const newRoundUpdates = this.competitionModalRounds
-                  .filter(round => this.competitionModalRoundSelections.includes(round.roundNumber.toString()))
-                  .map(round => {
-                      // Create a new round object with the eventId for the selected event
-                      return {
-                          ...round,
-                          eventId: this.competitionModalEventSelection.id,
-                          competitionId: this.competitionModalCompetitionSelection
-                      };
-                  });
+					handleAddRoundClick() {
+						try {
+								const roundsUpdatePayload = this.competitionModalRounds.map(round => ({
+										...round,
+										// NOTE: reverting eventId association requires us to save it as
+										// a fake eventId, because round update database schema requires it
+										...(this.competitionModalRoundSelections.includes(round.roundNumber.toString()) ? {
+											eventId: this.competitionModalEventSelection.id
+										} : {eventId: this.emptyRoundEventId})
+									})
+								);
 
-              // Initialize pendingRoundUpdates if doesn't exist
-              if (!this.formData.pendingRoundUpdates) {
-                  this.formData.pendingRoundUpdates = [];
-              }
+								// Update local state
+								if (this.formData.event.id === this.competitionModalEventSelection.id) {
+										// Preserve existing event data
+										this.formData.event = {
+												...this.formData.event,
+												competitionConfigId: this.competitionModalCompetitionSelection,
+												competitionRounds: roundsUpdatePayload
+										};
+								} else {
+										// Check children events
+										const childIndex = this.formData.eventChildren.findIndex(child =>
+												child.id === this.competitionModalEventSelection.id
+										);
+										if (childIndex !== -1) {
+												// Preserve existing child event data
+												this.formData.eventChildren[childIndex] = {
+														...this.formData.eventChildren[childIndex],
+														competitionConfigId: this.competitionModalCompetitionSelection,
+														competitionRounds: roundsUpdatePayload
+												};
+										}
+								}
 
-              // Update local state with all selected rounds
-              if (this.formData.event.id === this.competitionModalEventSelection.id) {
-                  this.formData.event = {
-                      ...this.formData.event,
-                      competitionConfigId: this.competitionModalCompetitionSelection,
-                      competitionRounds: [...(this.formData.event.competitionRounds || []), ...newRoundUpdates]
-                  };
-              } else {
-                  const childIndex = this.formData.eventChildren.findIndex(child =>
-                      child.id === this.competitionModalEventSelection.id
-                  );
-                  if (childIndex !== -1) {
-                      this.formData.eventChildren[childIndex] = {
-                          ...this.formData.eventChildren[childIndex],
-                          competitionConfigId: this.competitionModalCompetitionSelection,
-                          competitionRounds: [...(this.formData.eventChildren[childIndex].competitionRounds || []), ...newRoundUpdates]
-                      };
-                  }
-              }
+								// Store pending updates
+								this.formData.pendingRoundUpdates = roundsUpdatePayload;
 
-              // Add new updates to pending updates
-              this.formData.pendingRoundUpdates = [
-                  ...this.formData.pendingRoundUpdates,
-                  ...newRoundUpdates
-              ];
+								// Update other events' rounds
+								const allEvents = [this.formData.event, ...Object.values(this.formData.eventChildren)];
+								roundsUpdatePayload.forEach(round => {
+										const events = allEvents.filter(event =>
+												event?.competitionRounds?.find(r => r.roundNumber === round.roundNumber)
+										);
+										if (events.length > 0) {
+												events.forEach(event => {
+														if (round.eventId !== event.id) {
+																event.competitionRounds = event.competitionRounds.filter(
+																		r => r.roundNumber !== round.roundNumber
+																);
+														}
+												});
+										}
+								});
 
-                // Update other events' rounds
-                const allEvents = [this.formData.event, ...Object.values(this.formData.eventChildren)];
-                newRoundUpdates.forEach(round => {
-                    const events = allEvents.filter(event =>
-                        event?.competitionRounds?.find(r => r.roundNumber === round.roundNumber)
-                    );
-                    if (events.length > 0) {
-                        events.forEach(event => {
-                            if (round.eventId !== event.id) {
-                                event.competitionRounds = event.competitionRounds.filter(
-                                    r => r.roundNumber !== round.roundNumber
-                                );
-                            }
-                        });
-                    }
-                });
+								this.$nextTick(() => {
+										window.dispatchEvent(new CustomEvent('child-content-changed'));
+								});
+						} catch (error) {
+								// eslint-disable-next-line no-console
+								console.error('Error preparing rounds:', error);
+						} finally {
+								document.getElementById('add-competition-modal').close();
+								this.competitionModalEventSelection = null;
+								this.competitionModalCompetitionSelection = null;
+								this.competitionModalRounds = [];
+								this.competitionModalRoundSelections = [];
+						}
+					},
+					handleRemoveCompetitionRoundFromEvent(competitionRound) {
+						this.formData.pendingRoundUpdates = this.formData.pendingRoundUpdates.filter(round => round.id !== competitionRound.id)
+						this.formData.pendingRoundUpdates.push({
+							...competitionRound,
+							eventId: this.emptyRoundEventId
+						})
 
-                this.$nextTick(() => {
-                    window.dispatchEvent(new CustomEvent('child-content-changed'));
-                });
-            } catch (error) {
-                console.error('Error preparing rounds:', error);
-            } finally {
-                document.getElementById('add-competition-modal').close();
-                this.competitionModalEventSelection = null;
-                this.competitionModalCompetitionSelection = null;
-                this.competitionModalRounds = [];
-                this.competitionModalRoundSelections = [];
-                this.saveReqInFlight = false;
-            }
-          },
-        async handleRemoveCompetitionRoundFromEvent(competitionRound, child) {
-            // Set loading state for this specific round
-            competitionRound.isRemoving = true;
+						this.$nextTick(() => {
+							window.dispatchEvent(new CustomEvent('child-content-changed'));
+						})
+					},
 
-            try {
-                    const _competitionRound = JSON.parse(JSON.stringify(competitionRound))
-                    let _roundUpdate = {
-                        ..._competitionRound,
-                        eventId: this.roundEmptyEventId
-                    }
-                    delete _roundUpdate.isRemoving
-                    const response = await fetch(`/api/competition-round/${competitionRound.competitionId}`, {
-                            method: 'PUT',
-                            headers: {
-                                    'Content-Type': 'application/json',
-                            },
-                            body: JSON.stringify([_roundUpdate]),
-                    });
+					async handlePublishClick() {
+						this.saveReqInFlight = true
+						const _parentEvent = JSON.parse(JSON.stringify(this.transformEventToPayload(this.formData.event)))
+						this.purchasables = this.purchasables.map(p => ({
+							...p,
+							currency: this.formData.event.currency,
+						}))
+						// NOTE: never set the eventSourceId on the parent event, it IS the parent
+						delete _parentEvent.eventSourceId
+						delete _parentEvent.competitionRounds
 
-                    if (!response.ok) {
-                            throw new Error('Failed to remove competition round');
-                    }
+						let payload = {
+							events: [{
+								..._parentEvent,
+							}],
+							purchasableUpdate: {
+								event_id: this.formData.event.id,
+								...(this.purchasablesCreatedAt !== '' ? {created_at: this.purchasablesCreatedAt} : {}),
+								purchasable_items: this.purchasables.map(p => ({
+									...p,
+									expires_on: p.expires_on ? p.expires_on + this.timeZuluSuffix : null,
+									cost: (p.cost * 100),
+									inventory: p.inventory,
+								})),
+							},
+							registrationFieldsUpdate: {
+								...(this.registrationFieldsCreatedAt !== '' ? {created_at: this.registrationFieldsCreatedAt} : {}),
+								fields: this.registrationFields,
+							},
+							rounds: this.formData.pendingRoundUpdates || [],
+						}
+						if (this.formData.eventChildren.length > 0 && this.isEventSeries) {
+							this.formData.eventChildren.forEach(child => {
+								// NOTE: this is importantly set to null to
+								// prevent the payload from violaiting request
+								// body size limit constraints. The API will
+								// always take the parent event's description
+								// and seed it to each child event
+								const _childEvent = JSON.parse(JSON.stringify(child))
 
-                    // Remove the round from child.competitionRounds
-                    child.competitionRounds = child.competitionRounds.filter(round =>
-                            round.roundNumber !== competitionRound.roundNumber
-                    );
+								delete _parentEvent.description
+								delete _childEvent.description
 
-                    // Update allCompetitionRounds if it exists
-                    if (this.allCompetitionRounds) {
-                            this.allCompetitionRounds = this.allCompetitionRounds.filter(round =>
-                                    !(round.roundNumber === competitionRound.roundNumber &&
-                                        round.competitionConfigId === competitionRound.competitionConfigId)
-                            );
-                    }
+								delete _childEvent.competitionRounds
+								// NOTE: never override the child event's id with the parent id
+								delete _parentEvent.id
+								const _mergedEvent = {..._parentEvent, ..._childEvent}
+								payload.events.push({
+									..._mergedEvent,
+									eventSourceId: this.formData.event.id,
+									eventSourceType: this.deriveEventSourceTypeFromDropdown(_mergedEvent, this.publishStatus, this.isEventSeries, true),
+									startTime: child.startTime ? child.startTime + this.timeZuluSuffix : null,
+									endTime: child.endTime ? child.endTime + this.timeZuluSuffix : null,
+									// eventSourceType: this.isEventSeries ? this.eventTypeSeriesChildConstant : this.eventTypeSingleConstant,
+								})
+							})
+						}
 
-            } catch (error) {
-                    // eslint-disable-next-line no-console
-                    console.error('Error removing competition round from event:', error);
-                    // Reset loading state on error
-                    competitionRound.isRemoving = false;
-
-                    this.showToast = true;
-                    this.toastContent = {
-                            type: 'error',
-                            message: 'Failed to remove competition round'
-                    };
-            }
-        },
-
-        async handlePublishClick() {
-            if (this.formData.pendingRoundUpdates.length > 100) {
-                this.showToast = true;
-                this.toastContent = {
-                    type: 'error',
-                    message: 'Warning: You are attempting to publish more than 100 rounds. This is currently not supported. Please contact an administrator with questions.',
-                };
-                // Return early to prevent publish
-                return;
-            }
-
-            this.saveReqInFlight = true
-            const _parentEvent = JSON.parse(JSON.stringify(this.transformEventToPayload(this.formData.event)))
-            this.purchasables = this.purchasables.map(p => ({
-                ...p,
-                currency: this.formData.event.currency,
-            }))
-
-            const allRounds = [];
-
-            // add parent event rounds with explicit eventId
-            if (this.formData.event.competitionRounds) {
-                allRounds.push(...this.formData.event.competitionRounds.map(round => ({
-                    ...round,
-                    eventId: this.formData.event.id
-                })));
-            }
-
-            // Add child event rounds with explicit eventId
-            if (this.formData.eventChildren.length > 0) {
-                this.formData.eventChildren.forEach(child => {
-                    if (child.competitionRounds) {
-                        allRounds.push(...child.competitionRounds.map(round => ({
-                            ...round,
-                            eventId: child.id
-                        })));
-                    }
-                });
-            }
-
-            // Add any pending updates, overwriting existing rounds if necessary
-            if (this.formData.pendingRoundUpdates) {
-                this.formData.pendingRoundUpdates.forEach(pendingRound => {
-                    const existingIndex = allRounds.findIndex(r =>
-                        r.competitionId === pendingRound.competitionId &&
-                        r.roundNumber === pendingRound.roundNumber
-                    );
-                    if (existingIndex !== -1) {
-                        allRounds[existingIndex] = pendingRound;
-                    } else {
-                        allRounds.push(pendingRound);
-                    }
-                });
-            }
-
-            // Remove any UI-specific properties from rounds
-            const cleanedRounds = allRounds.map(round => {
-                const cleanRound = { ...round };
-                delete cleanRound.isRemoving;
-                return cleanRound;
-            });
-
-
-            // NOTE: never set the eventSourceId on the parent event, it IS the parent
-            delete _parentEvent.eventSourceId
-            delete _parentEvent.competitionRounds
-
-            let payload = {
-                events: [{
-                    ..._parentEvent,
-                }],
-                purchasableUpdate: {
-                    event_id: this.formData.event.id,
-                    ...(this.purchasablesCreatedAt !== '' ? {created_at: this.purchasablesCreatedAt} : {}),
-                    purchasable_items: this.purchasables.map(p => ({
-                        ...p,
-                        expires_on: p.expires_on ? p.expires_on + this.timeZuluSuffix : null,
-                        cost: (p.cost * 100),
-                        inventory: p.inventory,
-                    })),
-                },
-                registrationFieldsUpdate: {
-                    ...(this.registrationFieldsCreatedAt !== '' ? {created_at: this.registrationFieldsCreatedAt} : {}),
-                    fields: this.registrationFields,
-                },
-                rounds: cleanedRounds,
-            }
-            if (this.formData.eventChildren.length > 0 && this.isEventSeries) {
-                this.formData.eventChildren.forEach(child => {
-                    // NOTE: this is importantly set to null to
-                    // prevent the payload from violaiting request
-                    // body size limit constraints. The API will
-                    // always take the parent event's description
-                    // and seed it to each child event
-                    const _childEvent = JSON.parse(JSON.stringify(child))
-
-                    delete _parentEvent.description
-                    delete _childEvent.description
-
-                    delete _childEvent.competitionRounds
-                    // NOTE: never override the child event's id with the parent id
-                    delete _parentEvent.id
-                    const _mergedEvent = {..._parentEvent, ..._childEvent}
-                    payload.events.push({
-                        ..._mergedEvent,
-                        eventSourceId: this.formData.event.id,
-                        eventSourceType: this.deriveEventSourceTypeFromDropdown(_mergedEvent, this.publishStatus, this.isEventSeries, true),
-                        startTime: child.startTime ? child.startTime + this.timeZuluSuffix : null,
-                        endTime: child.endTime ? child.endTime + this.timeZuluSuffix : null,
-                        // eventSourceType: this.isEventSeries ? this.eventTypeSeriesChildConstant : this.eventTypeSingleConstant,
-                    })
-                })
-            }
-
-            try {
-                console.log("Checking for issue of sending updates always");
-                console.log("Payload for event, checking rounds \n", payload.rounds);
-                const response = await fetch(`/api/event-reg-purch/${this.formData.event.id}`, {
-                    method: 'PUT',
-                    headers: {
-                        'Content-Type': 'application/json',
-                    },
-                    body: JSON.stringify(payload),
-                });
-                const json = await response.json()
-                if (json.status === 'success') {
-                    this.saveReqInFlight = false
-                    this.showToast = true;
-                    this.toastContent = {
-                        type: 'success',
-                        message: 'Event updated successfully',
-                    }
-                    // NOTE: this API path should come from a data-* attribute
-                    // that uses the `SitePages` constant for this API path
-                    const newUrl = `/admin/event/${json.data.parentEvent._id}/edit`;
-                    window.history.pushState({ path: newUrl }, '', newUrl);
-                    this.formData.event.id = json.data.parentEvent._id
-                } else {
-                    throw new Error(`Failed to update event ${ json?.error?.message ? ": " + json.error.message : ''}`)
-                }
-            } catch (error) {
-                // eslint-disable-next-line no-console
-                console.error('Failed to update event:', error);
-                this.saveReqInFlight = false
-                this.showToast = true;
-                this.toastContent = {
-                    type: 'error',
-                    message: error,
-                }
-            }
-        }
-    }
-}
+						try {
+							const response = await fetch(`/api/event-reg-purch/${this.formData.event.id}`, {
+								method: 'PUT',
+								headers: {
+									'Content-Type': 'application/json',
+								},
+								body: JSON.stringify(payload),
+							});
+							const json = await response.json()
+							if (json.status === 'success') {
+								this.saveReqInFlight = false
+								this.showToast = true;
+								this.toastContent = {
+									type: 'success',
+									message: 'Event updated successfully',
+								}
+								// NOTE: this API path should come from a data-* attribute
+								// that uses the `SitePages` constant for this API path
+								const newUrl = `/admin/event/${json.data.parentEvent._id}/edit`;
+								window.history.pushState({ path: newUrl }, '', newUrl);
+								this.formData.event.id = json.data.parentEvent._id
+							} else {
+								throw new Error(`Failed to update event ${ json?.error?.message ? ": " + json.error.message : ''}`)
+							}
+						} catch (error) {
+							// eslint-disable-next-line no-console
+							console.error('Failed to update event:', error);
+							this.saveReqInFlight = false
+							this.showToast = true;
+							this.toastContent = {
+								type: 'error',
+								message: error,
+							}
+						}
+					}
+				}
+			}
 	</script>
 	}
 }

--- a/functions/gateway/templates/pages/event_add_edit.templ
+++ b/functions/gateway/templates/pages/event_add_edit.templ
@@ -1141,7 +1141,7 @@ templ AddOrEditEventPage(pageObj helpers.SitePage, event types.Event, isEditor b
 						})()
 					},
 					formData: {
-            pendingRoundUpdates: [], // store rounds that need to be updated or published
+						pendingRoundUpdates: [], // store rounds that need to be updated or published
 						eventChildren: [],
 						event: {
 							competitionConfigId: document.querySelector('#add-edit-event').getAttribute('data-competition-config-id') ?? null,
@@ -1524,74 +1524,74 @@ templ AddOrEditEventPage(pageObj helpers.SitePage, event types.Event, isEditor b
 							this.competitionModalRoundsLoading = false
 						}
 					},
-          async handleAddRoundClick() {
-            this.saveReqInFlight = true;
-            try {
-                // Create array of round updates for pending updates (includes eventId)
-                const roundsUpdatePayload = this.competitionModalRounds.filter(round =>
-                    this.competitionModalRoundSelections.includes(round.roundNumber.toString())
-                ).map(round => ({
-                    ...round,
-                    eventId: this.competitionModalEventSelection.id
-                }));
+					async handleAddRoundClick() {
+						this.saveReqInFlight = true;
+						try {
+								// Create array of round updates for pending updates (includes eventId)
+								const roundsUpdatePayload = this.competitionModalRounds.filter(round =>
+										this.competitionModalRoundSelections.includes(round.roundNumber.toString())
+								).map(round => ({
+										...round,
+										eventId: this.competitionModalEventSelection.id
+								}));
 
-                // Update local state
-                if (this.formData.event.id === this.competitionModalEventSelection.id) {
-                    // Preserve existing event data
-                    this.formData.event = {
-                        ...this.formData.event,
-                        competitionConfigId: this.competitionModalCompetitionSelection,
-                        competitionRounds: roundsUpdatePayload
-                    };
-                } else {
-                    // Check children events
-                    const childIndex = this.formData.eventChildren.findIndex(child =>
-                        child.id === this.competitionModalEventSelection.id
-                    );
-                    if (childIndex !== -1) {
-                        // Preserve existing child event data
-                        this.formData.eventChildren[childIndex] = {
-                            ...this.formData.eventChildren[childIndex],
-                            competitionConfigId: this.competitionModalCompetitionSelection,
-                            competitionRounds: roundsUpdatePayload
-                        };
-                    }
-                }
+								// Update local state
+								if (this.formData.event.id === this.competitionModalEventSelection.id) {
+										// Preserve existing event data
+										this.formData.event = {
+												...this.formData.event,
+												competitionConfigId: this.competitionModalCompetitionSelection,
+												competitionRounds: roundsUpdatePayload
+										};
+								} else {
+										// Check children events
+										const childIndex = this.formData.eventChildren.findIndex(child =>
+												child.id === this.competitionModalEventSelection.id
+										);
+										if (childIndex !== -1) {
+												// Preserve existing child event data
+												this.formData.eventChildren[childIndex] = {
+														...this.formData.eventChildren[childIndex],
+														competitionConfigId: this.competitionModalCompetitionSelection,
+														competitionRounds: roundsUpdatePayload
+												};
+										}
+								}
 
-                // Store pending updates
-                this.formData.pendingRoundUpdates = roundsUpdatePayload;
+								// Store pending updates
+								this.formData.pendingRoundUpdates = roundsUpdatePayload;
 
-                // Update other events' rounds
-                const allEvents = [this.formData.event, ...Object.values(this.formData.eventChildren)];
-                roundsUpdatePayload.forEach(round => {
-                    const events = allEvents.filter(event =>
-                        event?.competitionRounds?.find(r => r.roundNumber === round.roundNumber)
-                    );
-                    if (events.length > 0) {
-                        events.forEach(event => {
-                            if (round.eventId !== event.id) {
-                                event.competitionRounds = event.competitionRounds.filter(
-                                    r => r.roundNumber !== round.roundNumber
-                                );
-                            }
-                        });
-                    }
-                });
+								// Update other events' rounds
+								const allEvents = [this.formData.event, ...Object.values(this.formData.eventChildren)];
+								roundsUpdatePayload.forEach(round => {
+										const events = allEvents.filter(event =>
+												event?.competitionRounds?.find(r => r.roundNumber === round.roundNumber)
+										);
+										if (events.length > 0) {
+												events.forEach(event => {
+														if (round.eventId !== event.id) {
+																event.competitionRounds = event.competitionRounds.filter(
+																		r => r.roundNumber !== round.roundNumber
+																);
+														}
+												});
+										}
+								});
 
-                this.$nextTick(() => {
-                    window.dispatchEvent(new CustomEvent('child-content-changed'));
-                });
-            } catch (error) {
-                console.error('Error preparing rounds:', error);
-            } finally {
-                document.getElementById('add-competition-modal').close();
-                this.competitionModalEventSelection = null;
-                this.competitionModalCompetitionSelection = null;
-                this.competitionModalRounds = [];
-                this.competitionModalRoundSelections = [];
-                this.saveReqInFlight = false;
-            }
-        },
+								this.$nextTick(() => {
+										window.dispatchEvent(new CustomEvent('child-content-changed'));
+								});
+						} catch (error) {
+								console.error('Error preparing rounds:', error);
+						} finally {
+								document.getElementById('add-competition-modal').close();
+								this.competitionModalEventSelection = null;
+								this.competitionModalCompetitionSelection = null;
+								this.competitionModalRounds = [];
+								this.competitionModalRoundSelections = [];
+								this.saveReqInFlight = false;
+						}
+				},
 					async handleRemoveCompetitionRoundFromEvent(competitionRound, child) {
 						// Set loading state for this specific round
 						competitionRound.isRemoving = true;
@@ -1671,7 +1671,7 @@ templ AddOrEditEventPage(pageObj helpers.SitePage, event types.Event, isEditor b
 								...(this.registrationFieldsCreatedAt !== '' ? {created_at: this.registrationFieldsCreatedAt} : {}),
 								fields: this.registrationFields,
 							},
-              rounds: this.formData.pendingRoundUpdates || [],
+							rounds: this.formData.pendingRoundUpdates || [],
 						}
 						if (this.formData.eventChildren.length > 0 && this.isEventSeries) {
 							this.formData.eventChildren.forEach(child => {

--- a/functions/gateway/templates/pages/event_add_edit.templ
+++ b/functions/gateway/templates/pages/event_add_edit.templ
@@ -1142,6 +1142,7 @@ templ AddOrEditEventPage(pageObj helpers.SitePage, event types.Event, isEditor b
 						})()
 					},
 					formData: {
+            pendingRoundUpdates: [], // store rounds that need to be updated or published
 						eventChildren: [],
 						event: {
 							competitionConfigId: document.querySelector('#add-edit-event').getAttribute('data-competition-config-id') ?? null,
@@ -1524,88 +1525,74 @@ templ AddOrEditEventPage(pageObj helpers.SitePage, event types.Event, isEditor b
 							this.competitionModalRoundsLoading = false
 						}
 					},
+          async handleAddRoundClick() {
+            this.saveReqInFlight = true;
+            try {
+                // Create array of round updates for pending updates (includes eventId)
+                const roundsUpdatePayload = this.competitionModalRounds.filter(round =>
+                    this.competitionModalRoundSelections.includes(round.roundNumber.toString())
+                ).map(round => ({
+                    ...round,
+                    eventId: this.competitionModalEventSelection.id
+                }));
 
-					async handleAddRoundClick() {
-							this.saveReqInFlight = true
-							// First update local state
-							if (this.formData.event.id === this.competitionModalEventSelection.id) {
-									this.formData.event.competitionConfigId = this.competitionModalCompetitionSelection;
-									this.formData.event.competitionRounds = [...this.competitionModalRounds.filter(round =>
-											this.competitionModalRoundSelections.includes(round.roundNumber.toString())
-									)]
-							} else {
-									// Check children events
-									const childIndex = this.formData.eventChildren.findIndex(child => child.id === this.competitionModalEventSelection.id);
-									if (childIndex !== -1) {
-											this.formData.eventChildren[childIndex].competitionConfigId = this.competitionModalCompetitionSelection;
-											this.formData.eventChildren[childIndex].competitionRounds = [...this.competitionModalRounds.filter(round =>
-													this.competitionModalRoundSelections.includes(round.roundNumber.toString())
-											)]
-									}
-							}
+                // Update local state
+                if (this.formData.event.id === this.competitionModalEventSelection.id) {
+                    // Preserve existing event data
+                    this.formData.event = {
+                        ...this.formData.event,
+                        competitionConfigId: this.competitionModalCompetitionSelection,
+                        competitionRounds: roundsUpdatePayload
+                    };
+                } else {
+                    // Check children events
+                    const childIndex = this.formData.eventChildren.findIndex(child =>
+                        child.id === this.competitionModalEventSelection.id
+                    );
+                    if (childIndex !== -1) {
+                        // Preserve existing child event data
+                        this.formData.eventChildren[childIndex] = {
+                            ...this.formData.eventChildren[childIndex],
+                            competitionConfigId: this.competitionModalCompetitionSelection,
+                            competitionRounds: roundsUpdatePayload
+                        };
+                    }
+                }
 
-							// Create array of round updates
-							const roundsUpdatePayload = this.competitionModalRounds.filter(round =>
-									this.competitionModalRoundSelections.includes(round.roundNumber.toString())
-							).map(round => ({
-									...round,
-									eventId: this.competitionModalEventSelection.id,
-									competitionId: this.competitionModalCompetitionSelection
-							}));
+                // Store pending updates
+                this.formData.pendingRoundUpdates = roundsUpdatePayload;
 
-							// Send update request
-							try {
-								const response = await fetch(`/api/competition-round/${this.competitionModalCompetitionSelection}`, {
-										method: 'PUT',
-										headers: {
-											'Content-Type': 'application/json',
-									},
-									body: JSON.stringify(roundsUpdatePayload),
-								});
-								if (!response.ok) {
-									throw new Error(`HTTP error! status: ${response.status}`)
-								}
-								await response.json()
+                // Update other events' rounds
+                const allEvents = [this.formData.event, ...Object.values(this.formData.eventChildren)];
+                roundsUpdatePayload.forEach(round => {
+                    const events = allEvents.filter(event =>
+                        event?.competitionRounds?.find(r => r.roundNumber === round.roundNumber)
+                    );
+                    if (events.length > 0) {
+                        events.forEach(event => {
+                            if (round.eventId !== event.id) {
+                                event.competitionRounds = event.competitionRounds.filter(
+                                    r => r.roundNumber !== round.roundNumber
+                                );
+                            }
+                        });
+                    }
+                });
 
-								const allEvents = [this.formData.event, ...Object.values(this.formData.eventChildren)]
-
-								roundsUpdatePayload.forEach(round => {
-									// find all event.competitionRounds with the given roundNumber
-									// if there are multiple, we need to prune one of them
-									const events = allEvents.filter(event => event?.competitionRounds?.find(r => r.roundNumber === round.roundNumber));
-									if (events.length > 0) {
-										events.forEach(event => {
-											// prune the round from `event.competitionRounds` if `round.eventId` DOES NOT match `event.id`
-											if (round.eventId !== event.id) {
-												const newVal = event.competitionRounds.filter(r => r.roundNumber !== round.roundNumber);
-												event.competitionRounds = newVal;
-											}
-										})
-									}
-								});
-							} catch (error) {
-								// eslint-disable-next-line no-console
-								console.error('Error adding rounds:', error)
-							} finally {
-
-
-								this.$nextTick(() => {
-									// Dispatch event to trigger event child height recalculation
-									window.dispatchEvent(new CustomEvent('child-content-changed'));
-								});
-
-								// Close the modal
-								document.getElementById('add-competition-modal').close();
-
-								// Reset selections
-								this.competitionModalEventSelection = null;
-								this.competitionModalCompetitionSelection = null;
-								this.competitionModalRounds = [];
-								this.competitionModalRoundSelections = [];
-								this.saveReqInFlight = false
-						}
-					},
-
+                this.$nextTick(() => {
+                    window.dispatchEvent(new CustomEvent('child-content-changed'));
+                });
+            } catch (error) {
+                console.error('Error preparing rounds:', error);
+            } finally {
+                document.getElementById('add-competition-modal').close();
+                this.competitionModalEventSelection = null;
+                this.competitionModalCompetitionSelection = null;
+                this.competitionModalRounds = [];
+                this.competitionModalRoundSelections = [];
+                this.saveReqInFlight = false;
+            }
+        },
 					async handleRemoveCompetitionRoundFromEvent(competitionRound, child) {
 						// Set loading state for this specific round
 						competitionRound.isRemoving = true;
@@ -1685,6 +1672,7 @@ templ AddOrEditEventPage(pageObj helpers.SitePage, event types.Event, isEditor b
 								...(this.registrationFieldsCreatedAt !== '' ? {created_at: this.registrationFieldsCreatedAt} : {}),
 								fields: this.registrationFields,
 							},
+              rounds: this.formData.pendingRoundUpdates || [],
 						}
 						if (this.formData.eventChildren.length > 0 && this.isEventSeries) {
 							this.formData.eventChildren.forEach(child => {

--- a/functions/gateway/templates/pages/event_add_edit.templ
+++ b/functions/gateway/templates/pages/event_add_edit.templ
@@ -1524,74 +1524,83 @@ templ AddOrEditEventPage(pageObj helpers.SitePage, event types.Event, isEditor b
 							this.competitionModalRoundsLoading = false
 						}
 					},
-					async handleAddRoundClick() {
-						this.saveReqInFlight = true;
-						try {
-								// Create array of round updates for pending updates (includes eventId)
-								const roundsUpdatePayload = this.competitionModalRounds.filter(round =>
-										this.competitionModalRoundSelections.includes(round.roundNumber.toString())
-								).map(round => ({
-										...round,
-										eventId: this.competitionModalEventSelection.id
-								}));
+          async handleAddRoundClick() {
+            this.saveReqInFlight = true;
+            try {
+              // Create array of new round updates, preserving all selected rounds
+              const newRoundUpdates = this.competitionModalRounds
+                  .filter(round => this.competitionModalRoundSelections.includes(round.roundNumber.toString()))
+                  .map(round => {
+                      // Create a new round object with the eventId for the selected event
+                      return {
+                          ...round,
+                          eventId: this.competitionModalEventSelection.id,
+                          competitionId: this.competitionModalCompetitionSelection
+                      };
+                  });
 
-								// Update local state
-								if (this.formData.event.id === this.competitionModalEventSelection.id) {
-										// Preserve existing event data
-										this.formData.event = {
-												...this.formData.event,
-												competitionConfigId: this.competitionModalCompetitionSelection,
-												competitionRounds: roundsUpdatePayload
-										};
-								} else {
-										// Check children events
-										const childIndex = this.formData.eventChildren.findIndex(child =>
-												child.id === this.competitionModalEventSelection.id
-										);
-										if (childIndex !== -1) {
-												// Preserve existing child event data
-												this.formData.eventChildren[childIndex] = {
-														...this.formData.eventChildren[childIndex],
-														competitionConfigId: this.competitionModalCompetitionSelection,
-														competitionRounds: roundsUpdatePayload
-												};
-										}
-								}
+              // Initialize pendingRoundUpdates if doesn't exist
+              if (!this.formData.pendingRoundUpdates) {
+                  this.formData.pendingRoundUpdates = [];
+              }
 
-								// Store pending updates
-								this.formData.pendingRoundUpdates = roundsUpdatePayload;
+              // Update local state with all selected rounds
+              if (this.formData.event.id === this.competitionModalEventSelection.id) {
+                  this.formData.event = {
+                      ...this.formData.event,
+                      competitionConfigId: this.competitionModalCompetitionSelection,
+                      competitionRounds: [...(this.formData.event.competitionRounds || []), ...newRoundUpdates]
+                  };
+              } else {
+                  const childIndex = this.formData.eventChildren.findIndex(child =>
+                      child.id === this.competitionModalEventSelection.id
+                  );
+                  if (childIndex !== -1) {
+                      this.formData.eventChildren[childIndex] = {
+                          ...this.formData.eventChildren[childIndex],
+                          competitionConfigId: this.competitionModalCompetitionSelection,
+                          competitionRounds: [...(this.formData.eventChildren[childIndex].competitionRounds || []), ...newRoundUpdates]
+                      };
+                  }
+              }
 
-								// Update other events' rounds
-								const allEvents = [this.formData.event, ...Object.values(this.formData.eventChildren)];
-								roundsUpdatePayload.forEach(round => {
-										const events = allEvents.filter(event =>
-												event?.competitionRounds?.find(r => r.roundNumber === round.roundNumber)
-										);
-										if (events.length > 0) {
-												events.forEach(event => {
-														if (round.eventId !== event.id) {
-																event.competitionRounds = event.competitionRounds.filter(
-																		r => r.roundNumber !== round.roundNumber
-																);
-														}
-												});
-										}
-								});
+              // Add new updates to pending updates
+              this.formData.pendingRoundUpdates = [
+                  ...this.formData.pendingRoundUpdates,
+                  ...newRoundUpdates
+              ];
 
-								this.$nextTick(() => {
-										window.dispatchEvent(new CustomEvent('child-content-changed'));
-								});
-						} catch (error) {
-								console.error('Error preparing rounds:', error);
-						} finally {
-								document.getElementById('add-competition-modal').close();
-								this.competitionModalEventSelection = null;
-								this.competitionModalCompetitionSelection = null;
-								this.competitionModalRounds = [];
-								this.competitionModalRoundSelections = [];
-								this.saveReqInFlight = false;
-						}
-				},
+                // Update other events' rounds
+                const allEvents = [this.formData.event, ...Object.values(this.formData.eventChildren)];
+                newRoundUpdates.forEach(round => {
+                    const events = allEvents.filter(event =>
+                        event?.competitionRounds?.find(r => r.roundNumber === round.roundNumber)
+                    );
+                    if (events.length > 0) {
+                        events.forEach(event => {
+                            if (round.eventId !== event.id) {
+                                event.competitionRounds = event.competitionRounds.filter(
+                                    r => r.roundNumber !== round.roundNumber
+                                );
+                            }
+                        });
+                    }
+                });
+
+                this.$nextTick(() => {
+                    window.dispatchEvent(new CustomEvent('child-content-changed'));
+                });
+            } catch (error) {
+                console.error('Error preparing rounds:', error);
+            } finally {
+                document.getElementById('add-competition-modal').close();
+                this.competitionModalEventSelection = null;
+                this.competitionModalCompetitionSelection = null;
+                this.competitionModalRounds = [];
+                this.competitionModalRoundSelections = [];
+                this.saveReqInFlight = false;
+            }
+          },
 					async handleRemoveCompetitionRoundFromEvent(competitionRound, child) {
 						// Set loading state for this specific round
 						competitionRound.isRemoving = true;
@@ -1643,6 +1652,16 @@ templ AddOrEditEventPage(pageObj helpers.SitePage, event types.Event, isEditor b
 					},
 
 					async handlePublishClick() {
+            if (this.formData.pendingRoundUpdates.length > 100) {
+                this.showToast = true;
+                this.toastContent = {
+                    type: 'error',
+                    message: 'Warning: You are attempting to publish more than 100 rounds. This is currently not supported. Please contact an administrator with questions.',
+                };
+                // Return early to prevent publish
+                return;
+            }
+
 						this.saveReqInFlight = true
 						const _parentEvent = JSON.parse(JSON.stringify(this.transformEventToPayload(this.formData.event)))
 						this.purchasables = this.purchasables.map(p => ({

--- a/functions/gateway/templates/pages/layout.templ
+++ b/functions/gateway/templates/pages/layout.templ
@@ -23,7 +23,7 @@ templ Layout(sitePage helpers.SitePage, userInfo helpers.UserInfo, pageContent t
 			<link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400&family=Ubuntu+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Anton&family=Unbounded:wght@900&display=swap" rel="stylesheet"/>
 			// 🚨 WARNING 🚨 This filename is automatically updated by PostCSS
 			// ✅ DO commit it to version control whenever you see it change
-			<link rel="stylesheet" href={ templ.EscapeString(os.Getenv("STATIC_BASE_URL") + "/assets/styles.dc34d0fc.css") }/>
+			<link rel="stylesheet" href={ templ.EscapeString(os.Getenv("STATIC_BASE_URL") + "/assets/styles.91c19089.css") }/>
 			<meta name="viewport" content="width=device-width, initial-scale=1"/>
 			<script src="https://unpkg.com/htmx.org@1.9.12"></script>
 			<script src="https://unpkg.com/htmx.org@1.9.12/dist/ext/json-enc.js"></script>

--- a/functions/gateway/templates/pages/layout.templ
+++ b/functions/gateway/templates/pages/layout.templ
@@ -23,7 +23,7 @@ templ Layout(sitePage helpers.SitePage, userInfo helpers.UserInfo, pageContent t
 			<link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400&family=Ubuntu+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Anton&family=Unbounded:wght@900&display=swap" rel="stylesheet"/>
 			// 🚨 WARNING 🚨 This filename is automatically updated by PostCSS
 			// ✅ DO commit it to version control whenever you see it change
-			<link rel="stylesheet" href={ templ.EscapeString(os.Getenv("STATIC_BASE_URL") + "/assets/styles.e687893b.css") }/>
+			<link rel="stylesheet" href={ templ.EscapeString(os.Getenv("STATIC_BASE_URL") + "/assets/styles.dc34d0fc.css") }/>
 			<meta name="viewport" content="width=device-width, initial-scale=1"/>
 			<script src="https://unpkg.com/htmx.org@1.9.12"></script>
 			<script src="https://unpkg.com/htmx.org@1.9.12/dist/ext/json-enc.js"></script>

--- a/functions/gateway/templates/pages/layout.templ
+++ b/functions/gateway/templates/pages/layout.templ
@@ -23,7 +23,7 @@ templ Layout(sitePage helpers.SitePage, userInfo helpers.UserInfo, pageContent t
 			<link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400&family=Ubuntu+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Anton&family=Unbounded:wght@900&display=swap" rel="stylesheet"/>
 			// 🚨 WARNING 🚨 This filename is automatically updated by PostCSS
 			// ✅ DO commit it to version control whenever you see it change
-			<link rel="stylesheet" href={ templ.EscapeString(os.Getenv("STATIC_BASE_URL") + "/assets/styles.86d56404.css") }/>
+			<link rel="stylesheet" href={ templ.EscapeString(os.Getenv("STATIC_BASE_URL") + "/assets/styles.e687893b.css") }/>
 			<meta name="viewport" content="width=device-width, initial-scale=1"/>
 			<script src="https://unpkg.com/htmx.org@1.9.12"></script>
 			<script src="https://unpkg.com/htmx.org@1.9.12/dist/ext/json-enc.js"></script>

--- a/functions/gateway/types/competitions.go
+++ b/functions/gateway/types/competitions.go
@@ -17,6 +17,7 @@ type CompetitionConfigServiceInterface interface {
 // CompetitionRoundServiceInterface defines the methods for competition round operations
 type CompetitionRoundServiceInterface interface {
 	PutCompetitionRounds(ctx context.Context, dynamodbClient DynamoDBAPI, roundUpdate *[]CompetitionRoundUpdate) (dynamodb.BatchWriteItemOutput, error)
+	BatchPatchCompetitionRounds(ctx context.Context, dynamodbClient DynamoDBAPI, roundUpdate []CompetitionRoundUpdate, keysToUpdate []string) error
 	GetCompetitionRounds(ctx context.Context, dynamodbClient DynamoDBAPI, competitionId string) (*[]CompetitionRound, error)
 	GetCompetitionRoundsByEventId(ctx context.Context, dynamodbClient DynamoDBAPI, competitionId string) (*[]CompetitionRound, error)
 	GetCompetitionRoundByPrimaryKey(ctx context.Context, dynamodbClient DynamoDBAPI, competitionId, roundNumber string) (*CompetitionRound, error)


### PR DESCRIPTION
This PR closes #309

It removes the direct call to the rounds api from "Add Selected Rounds" and attaches round updates to the Publish payload. It passes in the new associated eventId and only updates the eventId from the event admin page. It also modifies the competitioinConfig Update function to call BatchPatchRounds to only add eventId if it is the placeholder 'fake-event' etc. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Event registration and purchasing now support updates for competition rounds.
  - Competition management has been enhanced for smoother team assignments, including streamlined addition and removal of competitors.
  - Event pages now manage pending round updates with a safeguard against publishing too many rounds.
  - The user selection component has been improved for dynamic handling during removals.
  - When creating new competitions, the creator is automatically designated as the primary owner.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->