### PR TITLE
fix: hide Signup / Login on community / user pages 

### DIFF
--- a/functions/gateway/handlers/page_handlers.go
+++ b/functions/gateway/handlers/page_handlers.go
@@ -335,7 +335,7 @@ func GetHomeOrUserPage(w http.ResponseWriter, r *http.Request) http.HandlerFunc 
 		userInfo = ctx.Value("userInfo").(helpers.UserInfo)
 	}
 
-	layoutTemplate := pages.Layout(helpers.SitePages["home"], userInfo, homePage, types.Event{}, []string{"https://cdn.jsdelivr.net/npm/@alpinejs/focus@3.x.x/dist/cdn.min.js"})
+	layoutTemplate := pages.Layout(helpers.SitePages["home"], userInfo, homePage, types.Event{}, pageUser, []string{"https://cdn.jsdelivr.net/npm/@alpinejs/focus@3.x.x/dist/cdn.min.js"})
 
 	var buf bytes.Buffer
 	err = layoutTemplate.Render(ctx, &buf)
@@ -350,7 +350,7 @@ func GetAboutPage(w http.ResponseWriter, r *http.Request) http.HandlerFunc {
 	aboutPage := pages.AboutPage()
 	ctx := r.Context()
 
-	layoutTemplate := pages.Layout(helpers.SitePages["about"], helpers.UserInfo{}, aboutPage, types.Event{}, []string{})
+	layoutTemplate := pages.Layout(helpers.SitePages["about"], helpers.UserInfo{}, aboutPage, types.Event{}, nil, []string{})
 	var buf bytes.Buffer
 	err = layoutTemplate.Render(ctx, &buf)
 	if err != nil {
@@ -381,7 +381,7 @@ func GetProfilePage(w http.ResponseWriter, r *http.Request) http.HandlerFunc {
 	userSubdomain := helpers.GetBase64ValueFromMap(userMetaClaims, helpers.SUBDOMAIN_KEY)
 	userAboutData, err := helpers.GetOtherUserMetaByID(userInfo.Sub, helpers.META_ABOUT_KEY)
 	adminPage := pages.ProfilePage(userInfo, roleClaims, userInterests, userSubdomain, userAboutData)
-	layoutTemplate := pages.Layout(helpers.SitePages["profile"], userInfo, adminPage, types.Event{}, []string{})
+	layoutTemplate := pages.Layout(helpers.SitePages["profile"], userInfo, adminPage, types.Event{}, nil, []string{})
 	var buf bytes.Buffer
 	err = layoutTemplate.Render(ctx, &buf)
 	if err != nil {
@@ -404,7 +404,7 @@ func GetProfileSettingsPage(w http.ResponseWriter, r *http.Request) http.Handler
 	}
 	parsedInterests := helpers.GetUserInterestFromMap(userMetaClaims, helpers.INTERESTS_KEY)
 	settingsPage := pages.ProfileSettingsPage(parsedInterests)
-	layoutTemplate := pages.Layout(helpers.SitePages["settings"], userInfo, settingsPage, types.Event{}, []string{})
+	layoutTemplate := pages.Layout(helpers.SitePages["settings"], userInfo, settingsPage, types.Event{}, nil, []string{})
 
 	var buf bytes.Buffer
 	err = layoutTemplate.Render(ctx, &buf)
@@ -479,7 +479,7 @@ func GetAddOrEditEventPage(w http.ResponseWriter, r *http.Request) http.HandlerF
 
 	addOrEditEventPage := pages.AddOrEditEventPage(pageObj, event, isEditor, cfLocationLat, cfLocationLon, isCompetitionAdmin)
 
-	layoutTemplate := pages.Layout(pageObj, userInfo, addOrEditEventPage, event, []string{"https://cdn.jsdelivr.net/npm/@alpinejs/focus@3.x.x/dist/cdn.min.js", "https://cdn.jsdelivr.net/npm/@alpinejs/sort@3.x.x/dist/cdn.min.js", "https://cdn.jsdelivr.net/npm/@alpinejs/mask@3.x.x/dist/cdn.min.js"})
+	layoutTemplate := pages.Layout(pageObj, userInfo, addOrEditEventPage, event, nil, []string{"https://cdn.jsdelivr.net/npm/@alpinejs/focus@3.x.x/dist/cdn.min.js", "https://cdn.jsdelivr.net/npm/@alpinejs/sort@3.x.x/dist/cdn.min.js", "https://cdn.jsdelivr.net/npm/@alpinejs/mask@3.x.x/dist/cdn.min.js"})
 
 	var buf bytes.Buffer
 	err := layoutTemplate.Render(ctx, &buf)
@@ -537,7 +537,7 @@ func GetEventAttendeesPage(w http.ResponseWriter, r *http.Request) http.HandlerF
 
 	addOrEditEventPage := pages.EventAttendeesPage(pageObj, event, isEditor)
 
-	layoutTemplate := pages.Layout(pageObj, userInfo, addOrEditEventPage, event, []string{})
+	layoutTemplate := pages.Layout(pageObj, userInfo, addOrEditEventPage, event, nil, []string{})
 
 	var buf bytes.Buffer
 	err := layoutTemplate.Render(ctx, &buf)
@@ -557,7 +557,7 @@ func GetMapEmbedPage(w http.ResponseWriter, r *http.Request) http.HandlerFunc {
 	queryParameters := apiGwV2Req.QueryStringParameters
 
 	mapEmbedPage := pages.MapEmbedPage(queryParameters["address"])
-	layoutTemplate := pages.Layout(helpers.SitePages["embed"], userInfo, mapEmbedPage, types.Event{}, []string{})
+	layoutTemplate := pages.Layout(helpers.SitePages["embed"], userInfo, mapEmbedPage, types.Event{}, nil, []string{})
 	var buf bytes.Buffer
 	err := layoutTemplate.Render(ctx, &buf)
 	if err != nil {
@@ -574,7 +574,7 @@ func GetPrivacyPolicyPage(w http.ResponseWriter, r *http.Request) http.HandlerFu
 		userInfo = ctx.Value("userInfo").(helpers.UserInfo)
 	}
 	privacyPolicyPage := pages.PrivacyPolicyPage(helpers.SitePages["privacy-policy"])
-	layoutTemplate := pages.Layout(helpers.SitePages["privacy-policy"], userInfo, privacyPolicyPage, types.Event{}, []string{})
+	layoutTemplate := pages.Layout(helpers.SitePages["privacy-policy"], userInfo, privacyPolicyPage, types.Event{}, nil, []string{})
 	var buf bytes.Buffer
 	err := layoutTemplate.Render(ctx, &buf)
 	if err != nil {
@@ -590,7 +590,7 @@ func GetDataRequestPage(w http.ResponseWriter, r *http.Request) http.HandlerFunc
 		userInfo = ctx.Value("userInfo").(helpers.UserInfo)
 	}
 	dataRequestPage := pages.DataRequestPage(helpers.SitePages["data-request"])
-	layoutTemplate := pages.Layout(helpers.SitePages["data-request"], userInfo, dataRequestPage, types.Event{}, []string{})
+	layoutTemplate := pages.Layout(helpers.SitePages["data-request"], userInfo, dataRequestPage, types.Event{}, nil, []string{})
 	var buf bytes.Buffer
 	err := layoutTemplate.Render(ctx, &buf)
 	if err != nil {
@@ -606,7 +606,7 @@ func GetTermsOfServicePage(w http.ResponseWriter, r *http.Request) http.HandlerF
 		userInfo = ctx.Value("userInfo").(helpers.UserInfo)
 	}
 	termsOfServicePage := pages.TermsOfServicePage(helpers.SitePages["terms-of-service"], userInfo)
-	layoutTemplate := pages.Layout(helpers.SitePages["terms-of-service"], userInfo, termsOfServicePage, types.Event{}, []string{})
+	layoutTemplate := pages.Layout(helpers.SitePages["terms-of-service"], userInfo, termsOfServicePage, types.Event{}, nil, []string{})
 	var buf bytes.Buffer
 	err := layoutTemplate.Render(ctx, &buf)
 	if err != nil {
@@ -646,7 +646,7 @@ func GetEventDetailsPage(w http.ResponseWriter, r *http.Request) http.HandlerFun
 	canEdit := helpers.CanEditEvent(event, &userInfo, roleClaims)
 
 	eventDetailsPage := pages.EventDetailsPage(*event, userInfo, canEdit)
-	layoutTemplate := pages.Layout(helpers.SitePages["event-detail"], userInfo, eventDetailsPage, *event, []string{})
+	layoutTemplate := pages.Layout(helpers.SitePages["event-detail"], userInfo, eventDetailsPage, *event, nil, []string{})
 	var buf bytes.Buffer
 	err = layoutTemplate.Render(ctx, &buf)
 	if err != nil {
@@ -663,7 +663,7 @@ func GetAddEventSourcePage(w http.ResponseWriter, r *http.Request) http.HandlerF
 		userInfo = ctx.Value("userInfo").(helpers.UserInfo)
 	}
 	adminPage := pages.AddEventSource()
-	layoutTemplate := pages.Layout(helpers.SitePages["add-event-source"], userInfo, adminPage, types.Event{}, []string{})
+	layoutTemplate := pages.Layout(helpers.SitePages["add-event-source"], userInfo, adminPage, types.Event{}, nil, []string{})
 	var buf bytes.Buffer
 	err := layoutTemplate.Render(ctx, &buf)
 	if err != nil {
@@ -724,7 +724,7 @@ func GetAddOrEditCompetitionPage(w http.ResponseWriter, r *http.Request) http.Ha
 	}
 
 	competitionPage := pages.AddOrEditCompetitionPage(pageObj, competitionConfig, users)
-	layoutTemplate := pages.Layout(pageObj, userInfo, competitionPage, internal_types.Event{}, []string{"https://cdn.jsdelivr.net/npm/@alpinejs/focus@3.x.x/dist/cdn.min.js"})
+	layoutTemplate := pages.Layout(pageObj, userInfo, competitionPage, internal_types.Event{}, nil, []string{"https://cdn.jsdelivr.net/npm/@alpinejs/focus@3.x.x/dist/cdn.min.js"})
 
 	var buf bytes.Buffer
 	err := layoutTemplate.Render(ctx, &buf)

--- a/functions/gateway/templates/components/navbar.templ
+++ b/functions/gateway/templates/components/navbar.templ
@@ -26,9 +26,9 @@ templ MiniProfileInNav(userInfo helpers.UserInfo) {
 	</ul>
 }
 
-templ NavListItems(userInfo helpers.UserInfo) {
+templ NavListItems(userInfo helpers.UserInfo, pageUser *types.UserSearchResult) {
 	<li><a href="/about" class="px-5 py-3">About</a></li>
-	if userInfo.Email == "" {
+	if userInfo.Email == "" && pageUser == nil {
 		<li><a href="/auth/login" class="px-5 py-3">Login</a></li>
 		<li><a href="/auth/login" class="btn btn-primary update-text-if-cookie">Signup</a></li>
 	}
@@ -192,7 +192,7 @@ templ RegistrationFieldsByType(nestedInPurchasable bool) {
 	</template>
 }
 
-templ Navbar(userInfo helpers.UserInfo, subnavTabs []string, event types.Event) {
+templ Navbar(userInfo helpers.UserInfo, subnavTabs []string, event types.Event, pageUser *types.UserSearchResult) {
 	<div class="drawer drawer-end">
 		<input id="main-drawer" type="checkbox" class="drawer-toggle"/>
 		<div class="drawer-content flex flex-col">
@@ -208,7 +208,7 @@ templ Navbar(userInfo helpers.UserInfo, subnavTabs []string, event types.Event) 
 					<div class="navbar-end flex">
 						<div class="items-center lg:flex">
 							<ul class="menu menu-horizontal px-1 hidden lg:inline-flex">
-								@NavListItems(userInfo)
+								@NavListItems(userInfo, pageUser)
 							</ul>
 							if userInfo.Email != "" {
 								<div class="dropdown dropdown-end px-3 hidden lg:inline-block">
@@ -311,7 +311,7 @@ templ Navbar(userInfo helpers.UserInfo, subnavTabs []string, event types.Event) 
 					<div role="tabpanel" class="tab-content p-2">
 						<ul class="">
 							<!-- Sidebar content here -->
-							@NavListItems(userInfo)
+							@NavListItems(userInfo, pageUser)
 						</ul>
 					</div>
 					if helpers.ArrFindFirst(subnavTabs, []string{helpers.SubnavItems[helpers.NvFilters]}) != "" {

--- a/functions/gateway/templates/components/navbar_templ_test.go
+++ b/functions/gateway/templates/components/navbar_templ_test.go
@@ -19,6 +19,7 @@ func TestAddEventSource(t *testing.T) {
 		expectedContent  []string
 		doNotShowContent []string
 		event            types.Event
+		pageUser         *types.UserSearchResult
 	}{
 		{
 			name:        string("Event Details, registration / purchasable"),
@@ -32,7 +33,8 @@ func TestAddEventSource(t *testing.T) {
 				">Checkout<",
 				">Register<",
 			},
-			event: types.Event{},
+			event:    types.Event{},
+			pageUser: nil,
 		},
 		{
 			name:        string("Event Details, with purchasable"),
@@ -45,7 +47,8 @@ func TestAddEventSource(t *testing.T) {
 			doNotShowContent: []string{
 				">Register<",
 			},
-			event: types.Event{HasPurchasable: true},
+			event:    types.Event{HasPurchasable: true},
+			pageUser: nil,
 		},
 		{
 			name:        string("Event Details, with registration"),
@@ -58,7 +61,8 @@ func TestAddEventSource(t *testing.T) {
 			doNotShowContent: []string{
 				">Checkout<",
 			},
-			event: types.Event{HasRegistrationFields: true},
+			event:    types.Event{HasRegistrationFields: true},
+			pageUser: nil,
 		},
 		{
 			name:        string("About page"),
@@ -70,7 +74,8 @@ func TestAddEventSource(t *testing.T) {
 				"flyout-tab-cart",
 				"flyout-tab-filters",
 			},
-			event: types.Event{HasPurchasable: true},
+			event:    types.Event{HasPurchasable: true},
+			pageUser: nil,
 		},
 		{
 			name:        string("Home / event search page"),
@@ -82,7 +87,23 @@ func TestAddEventSource(t *testing.T) {
 			doNotShowContent: []string{
 				"flyout-tab-cart",
 			},
+			event:    types.Event{HasPurchasable: true},
+			pageUser: nil,
+		}, {
+			name:        string("Home / event search page, with pageUser"),
+			subnavItems: helpers.SitePages["home"].SubnavItems,
+			expectedContent: []string{
+				"John Doe",
+				"flyout-tab-filters",
+			},
+			doNotShowContent: []string{
+				"flyout-tab-cart",
+				"Sign Up",
+			},
 			event: types.Event{HasPurchasable: true},
+			pageUser: &types.UserSearchResult{
+				DisplayName: "John Doe",
+			},
 		},
 	}
 
@@ -101,7 +122,7 @@ func TestAddEventSource(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			component := Navbar(mockUserInfo, tt.subnavItems, tt.event)
+			component := Navbar(mockUserInfo, tt.subnavItems, tt.event, tt.pageUser)
 			// Render the template
 			var buf bytes.Buffer
 			err := component.Render(context.Background(), &buf)

--- a/functions/gateway/templates/pages/about_templ_test.go
+++ b/functions/gateway/templates/pages/about_templ_test.go
@@ -29,7 +29,7 @@ func TestAboutPage(t *testing.T) {
 	aboutPage := AboutPage()
 
 	// Create a layout template
-	layoutTemplate := Layout(helpers.SitePages["profile"], mockUserInfo, aboutPage, types.Event{}, []string{})
+	layoutTemplate := Layout(helpers.SitePages["profile"], mockUserInfo, aboutPage, types.Event{}, nil, []string{})
 
 	// Render the template
 	var buf bytes.Buffer

--- a/functions/gateway/templates/pages/add_event_source_templ_test.go
+++ b/functions/gateway/templates/pages/add_event_source_templ_test.go
@@ -15,7 +15,7 @@ func TestAddEventSource(t *testing.T) {
 	component := AddEventSource()
 
 	// Create a layout template
-	layoutTemplate := Layout(helpers.SitePages["add-event-source"], helpers.UserInfo{}, component, types.Event{}, []string{})
+	layoutTemplate := Layout(helpers.SitePages["add-event-source"], helpers.UserInfo{}, component, types.Event{}, nil, []string{})
 
 	// Render the template
 	var buf bytes.Buffer

--- a/functions/gateway/templates/pages/event_details_templ_test.go
+++ b/functions/gateway/templates/pages/event_details_templ_test.go
@@ -333,7 +333,7 @@ func TestEventDetailsPage(t *testing.T) {
 			component := EventDetailsPage(tt.event, helpers.UserInfo{}, tt.canEdit)
 
 			// Wrap the component with Layout
-			layoutTemplate := Layout(helpers.SitePages["event-detail"], helpers.UserInfo{}, component, tt.event, []string{})
+			layoutTemplate := Layout(helpers.SitePages["event-detail"], helpers.UserInfo{}, component, tt.event, nil, []string{})
 
 			// Render the component to a string
 			var buf bytes.Buffer

--- a/functions/gateway/templates/pages/layout.templ
+++ b/functions/gateway/templates/pages/layout.templ
@@ -7,7 +7,7 @@ import (
 	"os"
 )
 
-templ Layout(sitePage helpers.SitePage, userInfo helpers.UserInfo, pageContent templ.Component, event types.Event, scripts []string) {
+templ Layout(sitePage helpers.SitePage, userInfo helpers.UserInfo, pageContent templ.Component, event types.Event, pageUser *types.UserSearchResult, scripts []string) {
 	<!DOCTYPE html>
 	<html data-theme="cyberpunk">
 		<head>
@@ -39,7 +39,7 @@ templ Layout(sitePage helpers.SitePage, userInfo helpers.UserInfo, pageContent t
 		</head>
 		<body class="h-[calc(100vh)] overflow-y-auto">
 			<div id="top-loading-bar" class="hidden fixed top-0 left-0 w-0 h-[3px] bg-[#00ff00] transition-[width] duration-300 ease-out z-[9999]"></div>
-			@components.Navbar(userInfo, sitePage.SubnavItems, event) {
+			@components.Navbar(userInfo, sitePage.SubnavItems, event, pageUser) {
 				<div class="container mx-auto">
 					<div id="content" class="p-4 space-y-4 relative">
 						@pageContent

--- a/functions/gateway/templates/pages/layout_templ_test.go
+++ b/functions/gateway/templates/pages/layout_templ_test.go
@@ -60,7 +60,7 @@ func TestLayout(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			component := Layout(tc.sitePage, helpers.UserInfo{}, templ.Raw("hello world!"), tc.event, []string{})
+			component := Layout(tc.sitePage, helpers.UserInfo{}, templ.Raw("hello world!"), tc.event, nil, []string{})
 
 			var buf bytes.Buffer
 			err := component.Render(context.Background(), &buf)

--- a/functions/gateway/templates/pages/profile_templ_test.go
+++ b/functions/gateway/templates/pages/profile_templ_test.go
@@ -50,7 +50,7 @@ func TestProfilePage(t *testing.T) {
 	profilePage := ProfilePage(mockUserInfo, mockRoleClaims, interests, subdomain, "Test about me text")
 
 	// Create a layout template
-	layoutTemplate := Layout(helpers.SitePages["profile"], mockUserInfo, profilePage, types.Event{}, []string{})
+	layoutTemplate := Layout(helpers.SitePages["profile"], mockUserInfo, profilePage, types.Event{}, nil, []string{})
 
 	// Render the template
 	var buf bytes.Buffer

--- a/functions/gateway/transport/http.go
+++ b/functions/gateway/transport/http.go
@@ -60,7 +60,7 @@ func SendHtmlErrorPage(body []byte, status int) http.HandlerFunc {
 		}
 
 		errorPartial := pages.ErrorPage(body, requestID)
-		layoutTemplate := pages.Layout(helpers.SitePages["home"], userInfo, errorPartial, types.Event{}, []string{})
+		layoutTemplate := pages.Layout(helpers.SitePages["home"], userInfo, errorPartial, types.Event{}, nil, []string{})
 		var buf bytes.Buffer
 		err := layoutTemplate.Render(ctx, &buf)
 		if err != nil {


### PR DESCRIPTION
Unfortunately, subdomain login is not supported by zitadel, because of the oauth standard. We will need a middleware endpoint or some other way of passing along the callback response and cookies to the subdomain context