### PR TITLE
[fix] Add auth handling for cookie subdomains + persist current / active page on login / logout

### DIFF
--- a/functions/gateway/handlers/auth_handlers.go
+++ b/functions/gateway/handlers/auth_handlers.go
@@ -4,9 +4,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"net/url"
 	"os"
-	"strings"
 
 	"github.com/meetnearme/api/functions/gateway/services"
 )
@@ -15,12 +13,7 @@ var codeChallenge, codeVerifier, err = services.GenerateCodeChallengeAndVerifier
 
 func HandleLogin(w http.ResponseWriter, r *http.Request) http.HandlerFunc {
 	queryParams := r.URL.Query()
-	redirectUser := queryParams.Get("redirect")
-
-	// Extract subdomain from host
-	host := r.Host
-	parts := strings.Split(host, ".")
-	var subdomain string
+	redirectQueryParam := queryParams.Get("redirect")
 
 	apexURL := os.Getenv("APEX_URL")
 	if apexURL == "" {
@@ -28,32 +21,7 @@ func HandleLogin(w http.ResponseWriter, r *http.Request) http.HandlerFunc {
 		return http.HandlerFunc(nil)
 	}
 
-	parsedApex, err := url.Parse(apexURL)
-	if err != nil {
-		http.Error(w, "Invalid APEX_URL", http.StatusInternalServerError)
-		return http.HandlerFunc(nil)
-	}
-
-	baseDomain := strings.Split(parsedApex.Host, ".")
-	if len(baseDomain) < 2 {
-		http.Error(w, "Invalid APEX_URL format", http.StatusInternalServerError)
-		return http.HandlerFunc(nil)
-	}
-
-	// Find where the base domain starts
-	baseIndex := len(parts)
-	for i := len(parts) - 1; i >= 0; i-- {
-		if parts[i] == baseDomain[0] { // This will match "example" from example.com
-			baseIndex = i
-			break
-		}
-	}
-
-	if baseIndex > 0 {
-		subdomain = strings.Join(parts[:baseIndex], ".")
-	}
-
-	authURL, err := services.BuildAuthorizeRequest(codeChallenge, redirectUser, subdomain)
+	authURL, err := services.BuildAuthorizeRequest(codeChallenge, redirectQueryParam)
 	if err != nil {
 		http.Error(w, "Failed to authorize request", http.StatusBadRequest)
 		return http.HandlerFunc(nil)
@@ -101,22 +69,13 @@ func HandleCallback(w http.ResponseWriter, r *http.Request) http.HandlerFunc {
 		return http.HandlerFunc(nil)
 	}
 
-	http.SetCookie(w, &http.Cookie{
-		Name:  "access_token",
-		Value: accessToken,
-		Path:  "/",
-	})
-
-	http.SetCookie(w, &http.Cookie{
-		Name:  "refresh_token",
-		Value: refreshToken,
-		Path:  "/",
-	})
-
 	var userRedirectURL string = "/"
 	if appState != "" {
 		userRedirectURL = appState
 	}
+
+	http.SetCookie(w, services.SetContextualCookie("access_token", accessToken))
+	http.SetCookie(w, services.SetContextualCookie("refresh_token", refreshToken))
 
 	return func(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, userRedirectURL, http.StatusFound)

--- a/functions/gateway/handlers/page_handlers.go
+++ b/functions/gateway/handlers/page_handlers.go
@@ -335,7 +335,7 @@ func GetHomeOrUserPage(w http.ResponseWriter, r *http.Request) http.HandlerFunc 
 		userInfo = ctx.Value("userInfo").(helpers.UserInfo)
 	}
 
-	layoutTemplate := pages.Layout(helpers.SitePages["home"], userInfo, homePage, types.Event{}, pageUser, []string{"https://cdn.jsdelivr.net/npm/@alpinejs/focus@3.x.x/dist/cdn.min.js"})
+	layoutTemplate := pages.Layout(helpers.SitePages["home"], userInfo, homePage, types.Event{}, []string{"https://cdn.jsdelivr.net/npm/@alpinejs/focus@3.x.x/dist/cdn.min.js"})
 
 	var buf bytes.Buffer
 	err = layoutTemplate.Render(ctx, &buf)
@@ -350,7 +350,7 @@ func GetAboutPage(w http.ResponseWriter, r *http.Request) http.HandlerFunc {
 	aboutPage := pages.AboutPage()
 	ctx := r.Context()
 
-	layoutTemplate := pages.Layout(helpers.SitePages["about"], helpers.UserInfo{}, aboutPage, types.Event{}, nil, []string{})
+	layoutTemplate := pages.Layout(helpers.SitePages["about"], helpers.UserInfo{}, aboutPage, types.Event{}, []string{})
 	var buf bytes.Buffer
 	err = layoutTemplate.Render(ctx, &buf)
 	if err != nil {
@@ -381,7 +381,7 @@ func GetProfilePage(w http.ResponseWriter, r *http.Request) http.HandlerFunc {
 	userSubdomain := helpers.GetBase64ValueFromMap(userMetaClaims, helpers.SUBDOMAIN_KEY)
 	userAboutData, err := helpers.GetOtherUserMetaByID(userInfo.Sub, helpers.META_ABOUT_KEY)
 	adminPage := pages.ProfilePage(userInfo, roleClaims, userInterests, userSubdomain, userAboutData)
-	layoutTemplate := pages.Layout(helpers.SitePages["profile"], userInfo, adminPage, types.Event{}, nil, []string{})
+	layoutTemplate := pages.Layout(helpers.SitePages["profile"], userInfo, adminPage, types.Event{}, []string{})
 	var buf bytes.Buffer
 	err = layoutTemplate.Render(ctx, &buf)
 	if err != nil {
@@ -404,7 +404,7 @@ func GetProfileSettingsPage(w http.ResponseWriter, r *http.Request) http.Handler
 	}
 	parsedInterests := helpers.GetUserInterestFromMap(userMetaClaims, helpers.INTERESTS_KEY)
 	settingsPage := pages.ProfileSettingsPage(parsedInterests)
-	layoutTemplate := pages.Layout(helpers.SitePages["settings"], userInfo, settingsPage, types.Event{}, nil, []string{})
+	layoutTemplate := pages.Layout(helpers.SitePages["settings"], userInfo, settingsPage, types.Event{}, []string{})
 
 	var buf bytes.Buffer
 	err = layoutTemplate.Render(ctx, &buf)
@@ -479,7 +479,7 @@ func GetAddOrEditEventPage(w http.ResponseWriter, r *http.Request) http.HandlerF
 
 	addOrEditEventPage := pages.AddOrEditEventPage(pageObj, event, isEditor, cfLocationLat, cfLocationLon, isCompetitionAdmin)
 
-	layoutTemplate := pages.Layout(pageObj, userInfo, addOrEditEventPage, event, nil, []string{"https://cdn.jsdelivr.net/npm/@alpinejs/focus@3.x.x/dist/cdn.min.js", "https://cdn.jsdelivr.net/npm/@alpinejs/sort@3.x.x/dist/cdn.min.js", "https://cdn.jsdelivr.net/npm/@alpinejs/mask@3.x.x/dist/cdn.min.js"})
+	layoutTemplate := pages.Layout(pageObj, userInfo, addOrEditEventPage, event, []string{"https://cdn.jsdelivr.net/npm/@alpinejs/focus@3.x.x/dist/cdn.min.js", "https://cdn.jsdelivr.net/npm/@alpinejs/sort@3.x.x/dist/cdn.min.js", "https://cdn.jsdelivr.net/npm/@alpinejs/mask@3.x.x/dist/cdn.min.js"})
 
 	var buf bytes.Buffer
 	err := layoutTemplate.Render(ctx, &buf)
@@ -537,7 +537,7 @@ func GetEventAttendeesPage(w http.ResponseWriter, r *http.Request) http.HandlerF
 
 	addOrEditEventPage := pages.EventAttendeesPage(pageObj, event, isEditor)
 
-	layoutTemplate := pages.Layout(pageObj, userInfo, addOrEditEventPage, event, nil, []string{})
+	layoutTemplate := pages.Layout(pageObj, userInfo, addOrEditEventPage, event, []string{})
 
 	var buf bytes.Buffer
 	err := layoutTemplate.Render(ctx, &buf)
@@ -557,7 +557,7 @@ func GetMapEmbedPage(w http.ResponseWriter, r *http.Request) http.HandlerFunc {
 	queryParameters := apiGwV2Req.QueryStringParameters
 
 	mapEmbedPage := pages.MapEmbedPage(queryParameters["address"])
-	layoutTemplate := pages.Layout(helpers.SitePages["embed"], userInfo, mapEmbedPage, types.Event{}, nil, []string{})
+	layoutTemplate := pages.Layout(helpers.SitePages["embed"], userInfo, mapEmbedPage, types.Event{}, []string{})
 	var buf bytes.Buffer
 	err := layoutTemplate.Render(ctx, &buf)
 	if err != nil {
@@ -574,7 +574,7 @@ func GetPrivacyPolicyPage(w http.ResponseWriter, r *http.Request) http.HandlerFu
 		userInfo = ctx.Value("userInfo").(helpers.UserInfo)
 	}
 	privacyPolicyPage := pages.PrivacyPolicyPage(helpers.SitePages["privacy-policy"])
-	layoutTemplate := pages.Layout(helpers.SitePages["privacy-policy"], userInfo, privacyPolicyPage, types.Event{}, nil, []string{})
+	layoutTemplate := pages.Layout(helpers.SitePages["privacy-policy"], userInfo, privacyPolicyPage, types.Event{}, []string{})
 	var buf bytes.Buffer
 	err := layoutTemplate.Render(ctx, &buf)
 	if err != nil {
@@ -590,7 +590,7 @@ func GetDataRequestPage(w http.ResponseWriter, r *http.Request) http.HandlerFunc
 		userInfo = ctx.Value("userInfo").(helpers.UserInfo)
 	}
 	dataRequestPage := pages.DataRequestPage(helpers.SitePages["data-request"])
-	layoutTemplate := pages.Layout(helpers.SitePages["data-request"], userInfo, dataRequestPage, types.Event{}, nil, []string{})
+	layoutTemplate := pages.Layout(helpers.SitePages["data-request"], userInfo, dataRequestPage, types.Event{}, []string{})
 	var buf bytes.Buffer
 	err := layoutTemplate.Render(ctx, &buf)
 	if err != nil {
@@ -606,7 +606,7 @@ func GetTermsOfServicePage(w http.ResponseWriter, r *http.Request) http.HandlerF
 		userInfo = ctx.Value("userInfo").(helpers.UserInfo)
 	}
 	termsOfServicePage := pages.TermsOfServicePage(helpers.SitePages["terms-of-service"], userInfo)
-	layoutTemplate := pages.Layout(helpers.SitePages["terms-of-service"], userInfo, termsOfServicePage, types.Event{}, nil, []string{})
+	layoutTemplate := pages.Layout(helpers.SitePages["terms-of-service"], userInfo, termsOfServicePage, types.Event{}, []string{})
 	var buf bytes.Buffer
 	err := layoutTemplate.Render(ctx, &buf)
 	if err != nil {
@@ -646,7 +646,7 @@ func GetEventDetailsPage(w http.ResponseWriter, r *http.Request) http.HandlerFun
 	canEdit := helpers.CanEditEvent(event, &userInfo, roleClaims)
 
 	eventDetailsPage := pages.EventDetailsPage(*event, userInfo, canEdit)
-	layoutTemplate := pages.Layout(helpers.SitePages["event-detail"], userInfo, eventDetailsPage, *event, nil, []string{})
+	layoutTemplate := pages.Layout(helpers.SitePages["event-detail"], userInfo, eventDetailsPage, *event, []string{})
 	var buf bytes.Buffer
 	err = layoutTemplate.Render(ctx, &buf)
 	if err != nil {
@@ -663,7 +663,7 @@ func GetAddEventSourcePage(w http.ResponseWriter, r *http.Request) http.HandlerF
 		userInfo = ctx.Value("userInfo").(helpers.UserInfo)
 	}
 	adminPage := pages.AddEventSource()
-	layoutTemplate := pages.Layout(helpers.SitePages["add-event-source"], userInfo, adminPage, types.Event{}, nil, []string{})
+	layoutTemplate := pages.Layout(helpers.SitePages["add-event-source"], userInfo, adminPage, types.Event{}, []string{})
 	var buf bytes.Buffer
 	err := layoutTemplate.Render(ctx, &buf)
 	if err != nil {
@@ -724,7 +724,7 @@ func GetAddOrEditCompetitionPage(w http.ResponseWriter, r *http.Request) http.Ha
 	}
 
 	competitionPage := pages.AddOrEditCompetitionPage(pageObj, competitionConfig, users)
-	layoutTemplate := pages.Layout(pageObj, userInfo, competitionPage, internal_types.Event{}, nil, []string{"https://cdn.jsdelivr.net/npm/@alpinejs/focus@3.x.x/dist/cdn.min.js"})
+	layoutTemplate := pages.Layout(pageObj, userInfo, competitionPage, internal_types.Event{}, []string{"https://cdn.jsdelivr.net/npm/@alpinejs/focus@3.x.x/dist/cdn.min.js"})
 
 	var buf bytes.Buffer
 	err := layoutTemplate.Render(ctx, &buf)

--- a/functions/gateway/main.go
+++ b/functions/gateway/main.go
@@ -4,11 +4,13 @@ package main
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"flag"
 	"fmt"
 	"log"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/aws/aws-lambda-go/events"
@@ -213,13 +215,14 @@ func (app *App) addRoute(route Route) {
 				if err != nil {
 					refreshTokenCookie, refreshTokenCookieErr = r.Cookie("refresh_token")
 					if refreshTokenCookieErr != nil {
-						http.Redirect(w, r, "/auth/login"+"?redirect="+redirectUrl, http.StatusFound)
+						state := base64.URLEncoding.EncodeToString([]byte(redirectUrl))
+						loginURL := fmt.Sprintf("/auth/login?state=%s&redirect=%s", state, url.QueryEscape(redirectUrl))
+						http.Redirect(w, r, loginURL, http.StatusFound)
 						return
 					}
 
 					tokens, refreshAccessTokenErr := services.RefreshAccessToken(refreshTokenCookie.Value)
 					if refreshAccessTokenErr != nil {
-						log.Printf("Authentication Failed: %v", refreshAccessTokenErr)
 						http.Error(w, "Authentication failed", http.StatusUnauthorized)
 						return
 					}
@@ -239,19 +242,8 @@ func (app *App) addRoute(route Route) {
 					}
 
 					// Store tokens in cookies
-					http.SetCookie(w, &http.Cookie{
-						Name:     "access_token",
-						Value:    newAccessToken,
-						Path:     "/",
-						HttpOnly: true,
-					})
-
-					http.SetCookie(w, &http.Cookie{
-						Name:     "refresh_token",
-						Value:    refreshToken,
-						Path:     "/",
-						HttpOnly: true,
-					})
+					http.SetCookie(w, services.SetContextualCookie("access_token", newAccessToken))
+					http.SetCookie(w, services.SetContextualCookie("refresh_token", refreshToken))
 
 					accessToken = newAccessToken
 					http.Redirect(w, r, redirectUrl, http.StatusFound)
@@ -267,8 +259,10 @@ func (app *App) addRoute(route Route) {
 				if strings.HasPrefix(authHeader, "Bearer ") {
 					http.Error(w, "Unauthorized", http.StatusUnauthorized)
 				} else {
-					log.Printf("Redirecting to login, redirect is: %v", redirectUrl)
-					http.Redirect(w, r, "/auth/login"+"?redirect="+redirectUrl, http.StatusFound)
+					// Store the original host and URL in the state parameter
+					state := base64.URLEncoding.EncodeToString([]byte(redirectUrl))
+					loginURL := fmt.Sprintf("/auth/login?state=%s&redirect=%s", state, url.QueryEscape(redirectUrl))
+					http.Redirect(w, r, loginURL, http.StatusFound)
 				}
 				return
 			}

--- a/functions/gateway/services/auth_service.go
+++ b/functions/gateway/services/auth_service.go
@@ -291,10 +291,11 @@ func GetPublicKey(jwks *JWKS, kid string) (*rsa.PublicKey, error) {
 func SetContextualCookie(cookieName string, cookieValue string) *http.Cookie {
 	apexURLCookieWildcard := strings.Replace(os.Getenv("APEX_URL"), "https://", "", 1)
 	cookie := &http.Cookie{
-		Name:   cookieName,
-		Value:  cookieValue,
-		Path:   "/",
-		Domain: apexURLCookieWildcard,
+		Name:     cookieName,
+		Value:    cookieValue,
+		Path:     "/",
+		Domain:   apexURLCookieWildcard,
+		HttpOnly: true,
 	}
 	return cookie
 }

--- a/functions/gateway/templates/components/navbar.templ
+++ b/functions/gateway/templates/components/navbar.templ
@@ -22,15 +22,27 @@ templ MiniProfileInNav(userInfo helpers.UserInfo) {
 				// <span class="badge">New</span>
 			</a>
 		</li>
-		<li><a href="/auth/logout">Logout</a></li>
+		<li><a x-data="" :href="'/auth/logout?post_logout_redirect_uri=' + window.location.href">Logout</a></li>
 	</ul>
 }
 
 templ NavListItems(userInfo helpers.UserInfo, pageUser *types.UserSearchResult) {
 	<li><a href="/about" class="px-5 py-3">About</a></li>
-	if userInfo.Email == "" && pageUser == nil {
-		<li><a href="/auth/login" class="px-5 py-3">Login</a></li>
-		<li><a href="/auth/login" class="btn btn-primary update-text-if-cookie">Signup</a></li>
+	if userInfo.Email == "" {
+		<li>
+			<a
+				x-data=""
+				:href="'/auth/login?redirect=' + window.location.href"
+				class="px-5 py-3"
+			>Login</a>
+		</li>
+		<li>
+			<a
+				x-data=""
+				:href="'/auth/login?redirect=' + window.location.href"
+				class="btn btn-primary update-text-if-cookie"
+			>Signup</a>
+		</li>
 	}
 	// Change back to "Add an Event" when we release Seshu
 	// if userInfo.Email != "" {
@@ -536,7 +548,7 @@ templ Navbar(userInfo helpers.UserInfo, subnavTabs []string, event types.Event, 
 								})
 							});
 							if (response.status === 401) {
-								this.errors['checkout'] = `You must be logged in to purchase tickets. <br /><a class="btn mt-4 btn-sm" href="/auth/login?redirect=/event/${this.eventId}">Register or Login now</a>`;
+								this.errors['checkout'] = `You must be logged in to purchase tickets. <br /><a class="btn mt-4 btn-sm" href="/auth/login?redirect=${window.location.href}">Register or Login now</a>`;
 								this.reqInFlight = false;
 								return
 							}

--- a/functions/gateway/templates/components/navbar.templ
+++ b/functions/gateway/templates/components/navbar.templ
@@ -26,24 +26,24 @@ templ MiniProfileInNav(userInfo helpers.UserInfo) {
 	</ul>
 }
 
-templ NavListItems(userInfo helpers.UserInfo, pageUser *types.UserSearchResult) {
-	<li><a href="/about" class="px-5 py-3">About</a></li>
+templ NavListItems(userInfo helpers.UserInfo) {
 	if userInfo.Email == "" {
 		<li>
 			<a
 				x-data=""
 				:href="'/auth/login?redirect=' + window.location.href"
-				class="px-5 py-3"
-			>Login</a>
+				class="btn btn-outline btn-primary mr-2 mb-2"
+			>Sign In</a>
 		</li>
 		<li>
 			<a
 				x-data=""
 				:href="'/auth/login?redirect=' + window.location.href"
 				class="btn btn-primary update-text-if-cookie"
-			>Signup</a>
+			>Sign Up</a>
 		</li>
 	}
+	<li><a href="/about" class="px-5 py-3">About</a></li>
 	// Change back to "Add an Event" when we release Seshu
 	// if userInfo.Email != "" {
 	// 	<li><a href="/admin/add-event-source" class="btn btn-primary">Add an Event</a></li>
@@ -204,7 +204,7 @@ templ RegistrationFieldsByType(nestedInPurchasable bool) {
 	</template>
 }
 
-templ Navbar(userInfo helpers.UserInfo, subnavTabs []string, event types.Event, pageUser *types.UserSearchResult) {
+templ Navbar(userInfo helpers.UserInfo, subnavTabs []string, event types.Event) {
 	<div class="drawer drawer-end">
 		<input id="main-drawer" type="checkbox" class="drawer-toggle"/>
 		<div class="drawer-content flex flex-col">
@@ -220,7 +220,7 @@ templ Navbar(userInfo helpers.UserInfo, subnavTabs []string, event types.Event, 
 					<div class="navbar-end flex">
 						<div class="items-center lg:flex">
 							<ul class="menu menu-horizontal px-1 hidden lg:inline-flex">
-								@NavListItems(userInfo, pageUser)
+								@NavListItems(userInfo)
 							</ul>
 							if userInfo.Email != "" {
 								<div class="dropdown dropdown-end px-3 hidden lg:inline-block">
@@ -323,7 +323,7 @@ templ Navbar(userInfo helpers.UserInfo, subnavTabs []string, event types.Event, 
 					<div role="tabpanel" class="tab-content p-2">
 						<ul class="">
 							<!-- Sidebar content here -->
-							@NavListItems(userInfo, pageUser)
+							@NavListItems(userInfo)
 						</ul>
 					</div>
 					if helpers.ArrFindFirst(subnavTabs, []string{helpers.SubnavItems[helpers.NvFilters]}) != "" {

--- a/functions/gateway/templates/components/navbar_templ_test.go
+++ b/functions/gateway/templates/components/navbar_templ_test.go
@@ -19,7 +19,6 @@ func TestAddEventSource(t *testing.T) {
 		expectedContent  []string
 		doNotShowContent []string
 		event            types.Event
-		pageUser         *types.UserSearchResult
 	}{
 		{
 			name:        string("Event Details, registration / purchasable"),
@@ -33,8 +32,7 @@ func TestAddEventSource(t *testing.T) {
 				">Checkout<",
 				">Register<",
 			},
-			event:    types.Event{},
-			pageUser: nil,
+			event: types.Event{},
 		},
 		{
 			name:        string("Event Details, with purchasable"),
@@ -47,8 +45,7 @@ func TestAddEventSource(t *testing.T) {
 			doNotShowContent: []string{
 				">Register<",
 			},
-			event:    types.Event{HasPurchasable: true},
-			pageUser: nil,
+			event: types.Event{HasPurchasable: true},
 		},
 		{
 			name:        string("Event Details, with registration"),
@@ -61,8 +58,7 @@ func TestAddEventSource(t *testing.T) {
 			doNotShowContent: []string{
 				">Checkout<",
 			},
-			event:    types.Event{HasRegistrationFields: true},
-			pageUser: nil,
+			event: types.Event{HasRegistrationFields: true},
 		},
 		{
 			name:        string("About page"),
@@ -74,8 +70,7 @@ func TestAddEventSource(t *testing.T) {
 				"flyout-tab-cart",
 				"flyout-tab-filters",
 			},
-			event:    types.Event{HasPurchasable: true},
-			pageUser: nil,
+			event: types.Event{HasPurchasable: true},
 		},
 		{
 			name:        string("Home / event search page"),
@@ -87,23 +82,7 @@ func TestAddEventSource(t *testing.T) {
 			doNotShowContent: []string{
 				"flyout-tab-cart",
 			},
-			event:    types.Event{HasPurchasable: true},
-			pageUser: nil,
-		}, {
-			name:        string("Home / event search page, with pageUser"),
-			subnavItems: helpers.SitePages["home"].SubnavItems,
-			expectedContent: []string{
-				"John Doe",
-				"flyout-tab-filters",
-			},
-			doNotShowContent: []string{
-				"flyout-tab-cart",
-				"Sign Up",
-			},
 			event: types.Event{HasPurchasable: true},
-			pageUser: &types.UserSearchResult{
-				DisplayName: "John Doe",
-			},
 		},
 	}
 
@@ -122,7 +101,7 @@ func TestAddEventSource(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			component := Navbar(mockUserInfo, tt.subnavItems, tt.event, tt.pageUser)
+			component := Navbar(mockUserInfo, tt.subnavItems, tt.event)
 			// Render the template
 			var buf bytes.Buffer
 			err := component.Render(context.Background(), &buf)

--- a/functions/gateway/templates/pages/event_details.templ
+++ b/functions/gateway/templates/pages/event_details.templ
@@ -95,7 +95,7 @@ templ EventDetailsPage(event types.Event, userInfo helpers.UserInfo, canEdit boo
 					<div id="vote-header" class="fixed sticky-under-top-nav alert alert-info rounded-none left-0 w-full z-50 flex items-center">
 						<div class="container mx-auto flex items-center justify-center">
 							<div role="alert">
-								<p>This event is part of a competition, log in to participate <a class="btn btn-xs" href="/auth/login">Login</a></p>
+								<p>This event is part of a competition, log in to participate <a class="btn btn-xs" x-data="" :href="'/auth/login?redirect=' + window.location.href">Login</a></p>
 							</div>
 						</div>
 					</div>

--- a/functions/gateway/templates/pages/layout.templ
+++ b/functions/gateway/templates/pages/layout.templ
@@ -7,7 +7,7 @@ import (
 	"os"
 )
 
-templ Layout(sitePage helpers.SitePage, userInfo helpers.UserInfo, pageContent templ.Component, event types.Event, pageUser *types.UserSearchResult, scripts []string) {
+templ Layout(sitePage helpers.SitePage, userInfo helpers.UserInfo, pageContent templ.Component, event types.Event, scripts []string) {
 	<!DOCTYPE html>
 	<html data-theme="cyberpunk">
 		<head>
@@ -39,7 +39,7 @@ templ Layout(sitePage helpers.SitePage, userInfo helpers.UserInfo, pageContent t
 		</head>
 		<body class="h-[calc(100vh)] overflow-y-auto">
 			<div id="top-loading-bar" class="hidden fixed top-0 left-0 w-0 h-[3px] bg-[#00ff00] transition-[width] duration-300 ease-out z-[9999]"></div>
-			@components.Navbar(userInfo, sitePage.SubnavItems, event, pageUser) {
+			@components.Navbar(userInfo, sitePage.SubnavItems, event) {
 				<div class="container mx-auto">
 					<div id="content" class="p-4 space-y-4 relative">
 						@pageContent

--- a/functions/gateway/transport/http.go
+++ b/functions/gateway/transport/http.go
@@ -60,7 +60,7 @@ func SendHtmlErrorPage(body []byte, status int) http.HandlerFunc {
 		}
 
 		errorPartial := pages.ErrorPage(body, requestID)
-		layoutTemplate := pages.Layout(helpers.SitePages["home"], userInfo, errorPartial, types.Event{}, nil, []string{})
+		layoutTemplate := pages.Layout(helpers.SitePages["home"], userInfo, errorPartial, types.Event{}, []string{})
 		var buf bytes.Buffer
 		err := layoutTemplate.Render(ctx, &buf)
 		if err != nil {


### PR DESCRIPTION
Most of what is seen in this screenshot did not work before (you would go back to the APEX url any time you logged out) and logging in would also take you to the APEX url rather than where you intended to navigate.

Also, subdomain login was specifically hidden (the login button) on community pages, because it didn't work properly


![Screen_Recording_2025-02-21_at_7 30 43 AM](https://github.com/user-attachments/assets/42275140-0969-4513-815b-9ca0bdc406fc)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Updated authentication flows across the site. Login, signup, and logout links now include dynamic redirection, ensuring you return to your current page after authenticating.
	- Ticket purchase error messages now provide a direct link that sends you back to the same page post-login for a smoother experience.
	- Enhanced security in redirect URL handling during authentication processes.

- **Bug Fixes**
	- Streamlined error handling for authentication failures, ensuring consistent user feedback without unnecessary logging.

- **Refactor**
	- Simplified cookie management and layout rendering processes to improve maintainability and clarity.
	- Removed unnecessary parameters in function calls to enhance code clarity and reduce complexity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->