### PR TITLE
[fix] Don't send entire `competitionRound` payload from event admin

### DIFF
--- a/functions/gateway/templates/pages/event_add_edit.templ
+++ b/functions/gateway/templates/pages/event_add_edit.templ
@@ -1136,7 +1136,6 @@ templ AddOrEditEventPage(pageObj helpers.SitePage, event types.Event, isEditor b
 						})()
 					},
 					formData: {
-						pendingRoundUpdates: [], // store rounds that need to be updated or published
 						eventChildren: [],
 						event: {
 							competitionConfigId: document.querySelector('#add-edit-event').getAttribute('data-competition-config-id') ?? null,
@@ -1534,7 +1533,11 @@ templ AddOrEditEventPage(pageObj helpers.SitePage, event types.Event, isEditor b
 							// so we can safely add the round to the change queue if an existing one isn't found
 							return [...acc, (existingRound || round)]
 						}, [])
-				},
+					},
+					getAllCompetitionRounds() {
+						const allEvents = [this.formData.event, ...this.formData.eventChildren]
+						return allEvents?.flatMap?.(event => event?.competitionRounds || []);
+					},
 					handleAddRoundClick() {
 							const roundsUpdatePayload = this.competitionModalRounds.map(round => ({
 									...round,
@@ -1548,7 +1551,7 @@ templ AddOrEditEventPage(pageObj helpers.SitePage, event types.Event, isEditor b
 
 							// Now assign rounds to their respective events based on eventId
 							const allEvents = [this.formData.event, ...this.formData.eventChildren]
-							const allEventsCompetitionRounds = allEvents?.flatMap(event => event?.competitionRounds || []);
+							const allEventsCompetitionRounds = this.getAllCompetitionRounds();
 							const reconciledRounds = this.getReconciledRounds(roundsUpdatePayload, allEventsCompetitionRounds, this.competitionModalEventSelection.id);
 
 							// Now assign rounds to their respective events based on eventId
@@ -1568,7 +1571,6 @@ templ AddOrEditEventPage(pageObj helpers.SitePage, event types.Event, isEditor b
 											}
 									}
 							});
-							this.formData.pendingRoundUpdates = reconciledRounds;
 
 							this.$nextTick(() => {
 									window.dispatchEvent(new CustomEvent('child-content-changed'));
@@ -1671,7 +1673,13 @@ templ AddOrEditEventPage(pageObj helpers.SitePage, event types.Event, isEditor b
 								...(this.registrationFieldsCreatedAt !== '' ? {created_at: this.registrationFieldsCreatedAt} : {}),
 								fields: this.registrationFields,
 							},
-							rounds: this.formData.pendingRoundUpdates || [],
+							// we explicitly avoid sending more data than necessary, if we include other keys, those keys will
+							// likely conflict and cause issues with save requests potentially coming from competition admin
+							rounds: this.getAllCompetitionRounds()?.map?.(round => ({
+								roundNumber: round.roundNumber,
+								competitionId: round.competitionId,
+								eventId: round.eventId
+							})) || [],
 						}
 						if (this.formData.eventChildren.length > 0 && this.isEventSeries) {
 							this.formData.eventChildren.forEach(child => {


### PR DESCRIPTION
sending too much data causes status like `isVotingOpen` to get overwritten. In the previous release to dev, saving from Event Admin if loaded in a stale state could overwrite `competitionRound` keys that have an intentionally high change rate like `isVotingOpen` or `competitor(A|B)Score`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced the event creation and editing experience by consolidating round details into a unified view. This update streamlines event scheduling workflows by automatically integrating relevant round information, ensuring that only essential details are processed during event publishing for a smoother overall experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->