### PR TITLE
[feature] Add Bocce support

### DIFF
--- a/functions/gateway/templates/pages/competition_add_edit.templ
+++ b/functions/gateway/templates/pages/competition_add_edit.templ
@@ -61,7 +61,7 @@ templ AddOrEditCompetitionPage(pageObj helpers.SitePage, competition types.Compe
 					>
 						<option value="">Select module type</option>
 						<option value="KARAOKE">Karaoke</option>
-						<option value="BOCCE" disabled>Bocce</option>
+						<option value="BOCCE">Bocce</option>
 					</select>
 				</div>
 				// Scoring Method
@@ -76,7 +76,7 @@ templ AddOrEditCompetitionPage(pageObj helpers.SitePage, competition types.Compe
 					>
 						<option value="">Select scoring method</option>
 						<option value="VOTE_MATCHUPS">Vote Matchups (Win, Loss, Draw)</option>
-						<option value="POINT_MATHCUPS" disabled>Point Matchups (Win, Loss, Draw)</option>
+						<option value="POINT_MATHCUPS">Point Matchups (Win, Loss, Draw)</option>
 						<option value="VOTE_TOTAL" disabled>Votes (Total)</option>
 						<option value="POINT_TOTAL" disabled>Points (Total)</option>
 					</select>
@@ -366,45 +366,49 @@ templ AddOrEditCompetitionPage(pageObj helpers.SitePage, competition types.Compe
 											</select>
 										</div>
 									</div>
-									<div class="divider"></div>
-									<div class="form-control mb-4">
-										<label class="cursor-pointer">
-											<input
-												name="isVotingOpen"
-												type="checkbox"
-												class="toggle toggle-primary"
-												x-model.fill="round.isVotingOpen"
-												:disabled="saveReqInFlight"
-											/>
-											<span class="label-text text-lg">Voting is <strong><span x-text="round.isVotingOpen ? 'open' : 'closed'"></span></strong></span>
-										</label>
-									</div>
+									<template x-if="formData.scoringMethod === 'VOTE_MATCHUPS'">
+										<div class="divider"></div>
+										<div class="form-control mb-4">
+											<label class="cursor-pointer">
+												<input
+													name="isVotingOpen"
+													type="checkbox"
+													class="toggle toggle-primary"
+													x-model.fill="round.isVotingOpen"
+													:disabled="saveReqInFlight"
+												/>
+												<span class="label-text text-lg">Voting is <strong><span x-text="round.isVotingOpen ? 'open' : 'closed'"></span></strong></span>
+											</label>
+										</div>
+									</template>
 									<template x-if="formData.scoringMethod === 'VOTE_MATCHUPS' ">
 										<div class="flex items-center gap-4 mb-4">
 											<button class="btn btn-primary" @click="tallyVotes(round)">Tally Votes</button>
 										</div>
 									</template>
 									<br/>
-									<div class="flex items-center gap-4 mb-4 rounded-box bg-base-100 p-4">
-										<div>
-											<span x-text="round.competitorADisplayName + ' votes: ' "></span>
-											<template x-if="!$data['tallyVotesReqInFlight' + round.roundNumber]">
-												<span x-text="(round.competitorAVotes || '?')"></span>
-											</template>
-											<template x-if="$data['tallyVotesReqInFlight' + round.roundNumber]">
-												<span class="loading loading-spinner loading-xs text-primary"></span>
-											</template>
+									<template x-if="formData.scoringMethod === 'VOTE_MATCHUPS' ">
+										<div class="flex items-center gap-4 mb-4 rounded-box bg-base-100 p-4">
+											<div>
+												<span x-text="round.competitorADisplayName + ' votes: ' "></span>
+												<template x-if="!$data['tallyVotesReqInFlight' + round.roundNumber]">
+													<span x-text="(round.competitorAVotes || '?')"></span>
+												</template>
+												<template x-if="$data['tallyVotesReqInFlight' + round.roundNumber]">
+													<span class="loading loading-spinner loading-xs text-primary"></span>
+												</template>
+											</div>
+											<div>
+												<span x-text="round.competitorBDisplayName + ' votes: ' "></span>
+												<template x-if="!$data['tallyVotesReqInFlight' + round.roundNumber]">
+													<span x-text="(round.competitorBVotes || '?')"></span>
+												</template>
+												<template x-if="$data['tallyVotesReqInFlight' + round.roundNumber]">
+													<span class="loading loading-spinner loading-xs text-primary"></span>
+												</template>
+											</div>
 										</div>
-										<div>
-											<span x-text="round.competitorBDisplayName + ' votes: ' "></span>
-											<template x-if="!$data['tallyVotesReqInFlight' + round.roundNumber]">
-												<span x-text="(round.competitorBVotes || '?')"></span>
-											</template>
-											<template x-if="$data['tallyVotesReqInFlight' + round.roundNumber]">
-												<span class="loading loading-spinner loading-xs text-primary"></span>
-											</template>
-										</div>
-									</div>
+									</template>
 									<br/>
 									<div class="flow-root md:flex items-center md:gap-4 mb-4">
 										<div class="form-control w-full md:grow">

--- a/functions/gateway/templates/pages/competition_add_edit.templ
+++ b/functions/gateway/templates/pages/competition_add_edit.templ
@@ -76,7 +76,7 @@ templ AddOrEditCompetitionPage(pageObj helpers.SitePage, competition types.Compe
 					>
 						<option value="">Select scoring method</option>
 						<option value="VOTE_MATCHUPS">Vote Matchups (Win, Loss, Draw)</option>
-						<option value="POINT_MATHCUPS">Point Matchups (Win, Loss, Draw)</option>
+						<option value="POINT_MATCHUPS">Point Matchups (Win, Loss, Draw)</option>
 						<option value="VOTE_TOTAL" disabled>Votes (Total)</option>
 						<option value="POINT_TOTAL" disabled>Points (Total)</option>
 					</select>


### PR DESCRIPTION
This PR adds support for `Bocce` and `Vote Point Matchups` in the dropdown for creating competitions


# Before
![image](https://github.com/user-attachments/assets/7cff451a-f459-4704-8ea0-8f0eeaf80660)
![image](https://github.com/user-attachments/assets/6bf9fbd6-8ba3-4297-96d0-b071da6796aa)

![image](https://github.com/user-attachments/assets/31d090cd-832d-41bb-aedc-82a1a2fc0312)



# After
![image](https://github.com/user-attachments/assets/53353e99-a5de-44de-bf58-a286f51d8038)

![image](https://github.com/user-attachments/assets/b7570fae-3615-446e-a26f-7b035132dc11)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced dynamic voting controls that appear when a specific scoring method is selected, including a checkbox for enabling voting and a display for competitor vote counts.
- **Bug Fixes**
  - Enabled additional competition options in dropdown menus by correcting a typo and removing disabled restrictions, ensuring users can select these choices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->