### PR TITLE
[fix] geolocation / event distance search radius

### DIFF
--- a/functions/gateway/handlers/dynamodb_handlers/purchase_handlers.go
+++ b/functions/gateway/handlers/dynamodb_handlers/purchase_handlers.go
@@ -365,8 +365,8 @@ func HasPurchaseForEventHandler(w http.ResponseWriter, r *http.Request) http.Han
 			return
 		}
 
-		if hasPurchasePayload.ChildEventId == "" && hasPurchasePayload.ParentEventId == "" {
-			transport.SendServerRes(w, []byte("Missing childEventId or parentEventId"), http.StatusBadRequest, nil)
+		if hasPurchasePayload.ParentEventId == "" {
+			transport.SendServerRes(w, []byte("Missing required parentEventId"), http.StatusBadRequest, nil)
 			return
 		}
 

--- a/functions/gateway/handlers/page_handlers.go
+++ b/functions/gateway/handlers/page_handlers.go
@@ -152,12 +152,12 @@ func GetSearchParamsFromReq(r *http.Request) (query string, userLocation []float
 
 	if radius < 0.0001 && (cfLocationLat != services.InitialEmptyLatLong && cfLocationLon != services.InitialEmptyLatLong ||
 		lat != US_GEO_CENTER_LAT && long != US_GEO_CENTER_LONG) {
-		radius = float64(150.0)
+		radius = helpers.DEFAULT_SEARCH_RADIUS
 		// we still don't have lat/lon, which means we'll be using "geographic center of US"
 		// which is in the middle of nowhere. Expand the radius to show all of the country
 		// showing events from anywhere
 	} else if radius == 0.0 {
-		radius = float64(2500.0)
+		radius = helpers.DEFAULT_EXPANDED_SEARCH_RADIUS
 	}
 
 	startTimeUnix, endTimeUnix := ParseStartEndTime(startTimeStr, endTimeStr)

--- a/functions/gateway/handlers/page_handlers.go
+++ b/functions/gateway/handlers/page_handlers.go
@@ -162,6 +162,10 @@ func GetSearchParamsFromReq(r *http.Request) (query string, userLocation []float
 
 	startTimeUnix, endTimeUnix := ParseStartEndTime(startTimeStr, endTimeStr)
 
+	if startTimeUnix < time.Now().Unix() && endTimeStr == "" {
+		endTimeUnix = time.Now().Unix()
+	}
+
 	// Handle owners query parameter
 	ownerIds = []string{}
 	if owners != "" {
@@ -477,7 +481,7 @@ func GetAddOrEditEventPage(w http.ResponseWriter, r *http.Request) http.HandlerF
 
 	isCompetitionAdmin := helpers.HasRequiredRole(roleClaims, []string{"superAdmin", "competitionAdmin"})
 
-	addOrEditEventPage := pages.AddOrEditEventPage(pageObj, event, isEditor, cfLocationLat, cfLocationLon, isCompetitionAdmin)
+	addOrEditEventPage := pages.AddOrEditEventPage(pageObj, userInfo, event, isEditor, cfLocationLat, cfLocationLon, isCompetitionAdmin)
 
 	layoutTemplate := pages.Layout(pageObj, userInfo, addOrEditEventPage, event, []string{"https://cdn.jsdelivr.net/npm/@alpinejs/focus@3.x.x/dist/cdn.min.js", "https://cdn.jsdelivr.net/npm/@alpinejs/sort@3.x.x/dist/cdn.min.js", "https://cdn.jsdelivr.net/npm/@alpinejs/mask@3.x.x/dist/cdn.min.js"})
 

--- a/functions/gateway/handlers/page_handlers_test.go
+++ b/functions/gateway/handlers/page_handlers_test.go
@@ -485,7 +485,7 @@ func TestGetSearchParamsFromReq(t *testing.T) {
 			cfRay:          "",
 			expectedQuery:  "",
 			expectedLoc:    []float64{40.7128, -74.0060},
-			expectedRadius: 150,
+			expectedRadius: helpers.DEFAULT_SEARCH_RADIUS,
 			expectedStart:  4070908800,
 			expectedEnd:    4071808800,
 			expectedCfLoc:  helpers.CdnLocation{},
@@ -536,7 +536,7 @@ func TestGetSearchParamsFromReq(t *testing.T) {
 			cfRay:          "1234567890000-LAX",
 			expectedLoc:    []float64{helpers.CfLocationMap["LAX"].Lat, helpers.CfLocationMap["LAX"].Lon}, // Los Angeles coordinates
 			expectedCfLoc:  helpers.CfLocationMap["LAX"],
-			expectedRadius: 150.0,
+			expectedRadius: helpers.DEFAULT_SEARCH_RADIUS,
 		},
 	}
 

--- a/functions/gateway/handlers/partial_handlers.go
+++ b/functions/gateway/handlers/partial_handlers.go
@@ -214,7 +214,6 @@ func GetEventAdminChildrenPartial(w http.ResponseWriter, r *http.Request) http.H
 }
 
 func GeoLookup(w http.ResponseWriter, r *http.Request) http.HandlerFunc {
-	log.Println("START GeoLookup")
 	ctx := r.Context()
 	var inputPayload GeoLookupInputPayload
 	body, err := io.ReadAll(r.Body)

--- a/functions/gateway/helpers/constants.go
+++ b/functions/gateway/helpers/constants.go
@@ -52,6 +52,8 @@ const AUTH_METADATA_KEY = "urn:zitadel:iam:user:metadata"
 
 const DEFAULT_PAGINATION_LIMIT = 50
 const DEFAULT_MAX_RADIUS = 999999
+const DEFAULT_SEARCH_RADIUS = 500.0
+const DEFAULT_EXPANDED_SEARCH_RADIUS = 2500.0
 
 // placeholder for unset end time, December 4th, 292,277,026,596 AD, at 20:10:55 UTC
 const DEFAULT_UNDEFINED_END_TIME = math.MaxInt64

--- a/functions/gateway/helpers/utils.go
+++ b/functions/gateway/helpers/utils.go
@@ -660,11 +660,12 @@ func CreateTeamUserWithMembers(displayName, candidateUUID string, members []stri
 	email := strings.Replace(emailSchema, "<replace>", candidateUUID, 1)
 
 	nameParts := strings.SplitN(displayName, " ", 2)
-	if len(nameParts) < 2 {
-		return types.UserSearchResultDangerous{}, fmt.Errorf("display name must contain first and last name")
-	}
 	firstPartName := nameParts[0]
-	secondPartName := nameParts[1]
+	// NOTE: this is a hack, zitadel doesn't accept omission of first + last names
+	secondPartName := "."
+	if strings.Contains(displayName, " ") {
+		secondPartName = nameParts[1]
+	}
 
 	// Create the payload struct
 	payload := createUserPayload{

--- a/functions/gateway/services/dynamodb_service/purchases_service.go
+++ b/functions/gateway/services/dynamodb_service/purchases_service.go
@@ -281,8 +281,8 @@ func (s *PurchaseService) HasPurchaseForEvent(ctx context.Context, dynamodbClien
 	selectInput := &dynamodb.ExecuteStatementInput{
 		Statement: aws.String(fmt.Sprintf(
 			`SELECT * FROM "%s"
-			 WHERE begins_with(compositeKey, '%s_%s')
-			 OR begins_with(compositeKey, '%s_%s')
+			 WHERE (begins_with(compositeKey, '%s_%s')
+			 	 OR begins_with(compositeKey, '%s_%s'))
 			 AND status <> 'INTERESTED'`,
 			purchasesTableName,
 			childEventId, userId,

--- a/functions/gateway/services/dynamodb_service/purchases_service.go
+++ b/functions/gateway/services/dynamodb_service/purchases_service.go
@@ -275,12 +275,16 @@ func (s *PurchaseService) DeletePurchase(ctx context.Context, dynamodbClient int
 }
 
 func (s *PurchaseService) HasPurchaseForEvent(ctx context.Context, dynamodbClient internal_types.DynamoDBAPI, childEventId, parentEventId, userId string) (bool, error) {
+	// NOTE: right now we filter out INTERESTED items as they are a lower commitment
+	// from the end user, we expect they have "registered" via purchasable,
+	// even if that item is FREE / $0
 	selectInput := &dynamodb.ExecuteStatementInput{
 		Statement: aws.String(fmt.Sprintf(
 			`SELECT * FROM "%s"
-             WHERE begins_with(compositeKey, '%s_%s')
-             OR begins_with(compositeKey, '%s_%s')`,
-			purchasesTableName, // Note: changed from purchasablesTableName
+			 WHERE begins_with(compositeKey, '%s_%s')
+			 OR begins_with(compositeKey, '%s_%s')
+			 AND status <> 'INTERESTED'`,
+			purchasesTableName,
 			childEventId, userId,
 			parentEventId, userId,
 		)),

--- a/functions/gateway/services/geo_service.go
+++ b/functions/gateway/services/geo_service.go
@@ -3,7 +3,6 @@ package services
 import (
 	"fmt"
 	"regexp"
-	"strings"
 )
 
 const (
@@ -25,24 +24,21 @@ func (s *RealGeoService) GetGeo(location string, baseUrl string) (lat string, lo
 		return "", "", "", err
 	}
 	// this regex specifically captures the pattern of a lat/lon pair e.g. [40.7128, -74.0060]
-	re := regexp.MustCompile(`\[\-?\+?([1-8]?\d(\.\d+)?|90(\.0+)?),\s*\-?\+?(180(\.0+)?|((1[0-7]\d)|([1-9]?\d))(\.\d+)?)\]`)
-	latLon := re.FindString(htmlString)
-	if latLon == "" {
+	re := regexp.MustCompile(`\[(\-?(?:[1-8]?\d(?:\.\d+)?|90(?:\.0+)?)),\s*(\-?(?:180(?:\.0+)?|(?:1[0-7]\d|[1-9]?\d)(?:\.\d+)?))\]`)
+
+	matches := re.FindStringSubmatch(htmlString)
+	if len(matches) < 3 {
 		return "", "", "", fmt.Errorf("location is not valid")
 	}
 
-	latLonArr := strings.Split(latLon, ",")
-	lat = latLonArr[0]
-	lon = latLonArr[1]
-	re = regexp.MustCompile(`[^\d.]`)
-	lat = re.ReplaceAllString(lat, "")
-	lon = re.ReplaceAllString(lon, "")
+	lat = matches[1]
+	lon = matches[2]
 
-	// Regular expression pattern
-	pattern := `"([^"]*)"\s*,\s*\` + latLon
+	// This regex captures the pattern of an address string that is wrapped in double quotes
+	// and followed by a lat/lon pair e.g. "123 Main St", [40.7128, -74.0060]
+	pattern := `"([^"]*)"\s*,\s*\[\s*` + regexp.QuoteMeta(lat) + `\s*,\s*` + regexp.QuoteMeta(lon) + `\s*\]`
 	re = regexp.MustCompile(pattern)
-
-	matches := re.FindStringSubmatch(htmlString)
+	matches = re.FindStringSubmatch(htmlString)
 	if len(matches) > 0 {
 		address = matches[1]
 	} else {

--- a/functions/gateway/services/marqo_service_test.go
+++ b/functions/gateway/services/marqo_service_test.go
@@ -380,6 +380,26 @@ func TestSearchMarqoEvents(t *testing.T) {
 			"latitude":       10.0,
 			"longitude":      0.1,
 		},
+		{
+			"_id":            "9",
+			"name":           "East Event (100 miles apart)",
+			"startTime":      now.Unix(),
+			"eventOwners":    []interface{}{"239"},
+			"eventOwnerName": "Pair Event Host",
+			"description":    "Paired Event East side",
+			"latitude":       35.685837,
+			"longitude":      -105.945083,
+		},
+		{
+			"_id":            "10",
+			"name":           "West Event (100 miles apart)",
+			"startTime":      now.Unix(),
+			"eventOwners":    []interface{}{"239"},
+			"eventOwnerName": "Pair Event Host",
+			"description":    "Paired Event West side",
+			"latitude":       35.685837,
+			"longitude":      -106.945083,
+		},
 	}
 
 	tests := []struct {
@@ -464,6 +484,15 @@ func TestSearchMarqoEvents(t *testing.T) {
 			expectedIds: []string{"8"},
 		},
 		{
+			name:        "Pair of Events, 56.25 miles apart",
+			query:       "",
+			startTime:   now.Unix(),
+			endTime:     now.Add(24 * time.Hour).Unix(),
+			location:    []float64{35.685837, -106.945083},
+			distance:    56.25,
+			expectedIds: []string{"9", "10"},
+		},
+		{
 			name:        "This week's events",
 			query:       "",
 			startTime:   now.Unix(),
@@ -488,7 +517,7 @@ func TestSearchMarqoEvents(t *testing.T) {
 			endTime:     now.Add(24 * time.Hour).Unix(),
 			location:    []float64{0.0, 0.0},
 			distance:    12500.0,
-			expectedIds: []string{"1", "4", "5", "6", "7", "8"},
+			expectedIds: []string{"1", "4", "5", "6", "7", "8", "9", "10"},
 		},
 	}
 

--- a/functions/gateway/templates/pages/competition_add_edit.templ
+++ b/functions/gateway/templates/pages/competition_add_edit.templ
@@ -73,6 +73,7 @@ templ AddOrEditCompetitionPage(pageObj helpers.SitePage, competition types.Compe
 							value={ competition.ScoringMethod }
 						}
 						x-model.fill="formData.scoringMethod"
+						:disabled="saveReqInFlight"
 					>
 						<option value="">Select scoring method</option>
 						<option value="VOTE_MATCHUPS">Vote Matchups (Win, Loss, Draw)</option>

--- a/functions/gateway/templates/pages/event_add_edit.templ
+++ b/functions/gateway/templates/pages/event_add_edit.templ
@@ -9,7 +9,7 @@ import (
 	"strings"
 )
 
-templ AddOrEditEventPage(pageObj helpers.SitePage, event types.Event, isEditor bool, cfLocationLat float64, cfLocationLon float64, isCompetitionAdmin bool) {
+templ AddOrEditEventPage(pageObj helpers.SitePage, userInfo helpers.UserInfo, event types.Event, isEditor bool, cfLocationLat float64, cfLocationLon float64, isCompetitionAdmin bool) {
 	if event.EventSourceType == helpers.ES_EVENT_SERIES || event.EventSourceType == helpers.ES_EVENT_SERIES_UNPUB {
 		<header class="page-header bg-base-100 shadow-md sticky sticky-under-top-nav z-40 py-4">
 			<h1 class="text-3xl mb-4 truncate whitespace-nowrap overflow-hidden max-w-full">
@@ -990,7 +990,8 @@ templ AddOrEditEventPage(pageObj helpers.SitePage, event types.Event, isEditor b
 				</div>
 			</template>
 		</div>
-		<script id="add-edit-event" data-event-id={ event.Id } data-event-owners={ string(helpers.ToJSON(event.EventOwners)) } data-event-owner-name={ event.EventOwnerName } data-event-owner-delimiter={ helpers.EventOwnerNameDelimiter } data-event-tags={ string(helpers.ToJSON(event.Tags)) } data-event-categories={ string(helpers.ToJSON(event.Categories)) } data-event-type-single={ helpers.ES_SINGLE_EVENT } data-event-type-series-parent={ helpers.ES_SERIES_PARENT } data-event-type-series-child={ helpers.ES_EVENT_SERIES } data-event-lat={ strconv.FormatFloat(event.Lat, 'f', -1, 64) } data-event-long={ strconv.FormatFloat(event.Long, 'f', -1, 64) } data-event-address={ event.Address } data-event-source-id={ event.EventSourceId } data-payee-id={ event.PayeeId } data-event-hide-cross-promo={ strconv.FormatBool(event.HideCrossPromo) } data-event-detail-url={ strings.Replace(strings.Replace(helpers.SitePages["event-detail"].Slug, helpers.EVENT_ID_KEY, "", 1), "{trailingslash:\\/?}", "", 1) } data-competition-config-id={ event.CompetitionConfigId } data-is-competition-admin={ strconv.FormatBool(isCompetitionAdmin) } data-round-empty-event-id={ helpers.COMP_UNASSIGNED_ROUND_EVENT_ID } data-unpub-suffix={ helpers.UNPUB_SUFFIX } data-published-suffix={ helpers.PUBLISHED_SUFFIX }>
+		<script id="add-edit-event" data-event-id={ event.Id } data-event-owners={ string(helpers.ToJSON(event.EventOwners)) } data-event-owner-name={ event.EventOwnerName } data-event-owner-delimiter={ helpers.EventOwnerNameDelimiter } data-event-tags={ string(helpers.ToJSON(event.Tags)) } data-event-categories={ string(helpers.ToJSON(event.Categories)) } data-event-type-single={ helpers.ES_SINGLE_EVENT } data-event-type-series-parent={ helpers.ES_SERIES_PARENT } data-event-type-series-child={ helpers.ES_EVENT_SERIES } data-event-lat={ strconv.FormatFloat(event.Lat, 'f', -1, 64) } data-event-long={ strconv.FormatFloat(event.Long, 'f', -1, 64) } data-event-address={ event.Address } data-event-source-id={ event.EventSourceId } data-payee-id={ event.PayeeId } data-event-hide-cross-promo={ strconv.FormatBool(event.HideCrossPromo) } data-event-detail-url={ strings.Replace(strings.Replace(helpers.SitePages["event-detail"].Slug, helpers.EVENT_ID_KEY, "", 1), "{trailingslash:\\/?}", "", 1) } data-competition-config-id={ event.CompetitionConfigId } data-is-competition-admin={ strconv.FormatBool(isCompetitionAdmin) } data-round-empty-event-id={ helpers.COMP_UNASSIGNED_ROUND_EVENT_ID } data-unpub-suffix={ helpers.UNPUB_SUFFIX } data-published-suffix={ helpers.PUBLISHED_SUFFIX } data-current-user-id={ userInfo.Sub } data-current-user-display-name={ userInfo.Name }>
+
 
 	function getAddEditEventState() {
 		return {
@@ -1001,6 +1002,10 @@ templ AddOrEditEventPage(pageObj helpers.SitePage, event types.Event, isEditor b
 								this.owners = ownerIds.map((ownerId, idx) => {
 									return { label: ownerNames?.[idx], value: ownerId };
 								});
+								if (this.owners.length < 1) {
+									this.owners.push({ label: this.currentUserDisplayName, value: this.currentUserId })
+								}
+
 								this.allOptions = this.owners
 
 								if (this.formData.event.hasPurchasable) {
@@ -1185,6 +1190,8 @@ templ AddOrEditEventPage(pageObj helpers.SitePage, event types.Event, isEditor b
 						type: '',
 						message: ' updated successfully',
 					},
+					currentUserId: document.querySelector('#add-edit-event').getAttribute('data-current-user-id') ?? null,
+					currentUserDisplayName: document.querySelector('#add-edit-event').getAttribute('data-current-user-display-name') ?? null,
 					eventOwnerDelimiter: document.querySelector('#add-edit-event').getAttribute('data-event-owner-delimiter'),
 					eventTypeSingleConstant: document.querySelector("#add-edit-event").getAttribute('data-event-type-single'),
 					eventTypeSeriesParentConstant: document.querySelector("#add-edit-event").getAttribute('data-event-type-series-parent'),

--- a/functions/gateway/templates/pages/event_add_edit_templ_test.go
+++ b/functions/gateway/templates/pages/event_add_edit_templ_test.go
@@ -14,8 +14,13 @@ import (
 
 func TestAddOrEditEventPage(t *testing.T) {
 	lALoc, _ := time.LoadLocation("America/Los_Angeles")
+	userInfo := helpers.UserInfo{
+		Sub:  "abc-uuid",
+		Name: "Test User",
+	}
 	tests := []struct {
 		name               string
+		userInfo           helpers.UserInfo
 		event              types.Event
 		isEditor           bool
 		isCompetitionAdmin bool
@@ -27,6 +32,7 @@ func TestAddOrEditEventPage(t *testing.T) {
 	}{
 		{
 			name:               "New event form",
+			userInfo:           userInfo,
 			event:              types.Event{},
 			isEditor:           false,
 			isCompetitionAdmin: false,
@@ -41,10 +47,12 @@ func TestAddOrEditEventPage(t *testing.T) {
 				"End Date &amp; Time",
 				"Publish",
 				"Address",
+				"Test User", // via chip for default in `owners` array
 			},
 		},
 		{
 			name:               "New event form, with admin user geolocation",
+			userInfo:           userInfo,
 			event:              types.Event{},
 			isEditor:           false,
 			isCompetitionAdmin: false,
@@ -64,14 +72,15 @@ func TestAddOrEditEventPage(t *testing.T) {
 			},
 		},
 		{
-			name: "Edit existing event",
+			name:     "Edit existing event",
+			userInfo: userInfo,
 			event: types.Event{
 				Id:                  "123",
 				Name:                "Test Event",
 				Description:         "This is a test event",
 				Address:             "123 Test St",
-				CompetitionConfigId: "abc-uuid",
-				EventOwners:         []string{"abc-uuid"},
+				CompetitionConfigId: "def-uuid",
+				EventOwners:         []string{"xyz-uuid"},
 				EventOwnerName:      "Brians Pub",
 				Timezone:            *lALoc,
 			},
@@ -90,7 +99,8 @@ func TestAddOrEditEventPage(t *testing.T) {
 				"Publish",
 				"This is a test event",
 				"123 Test St",
-				"abc-uuid",
+				"def-uuid",
+				`data-event-owners="[&#34;xyz-uuid&#34;]`, // NOTE: this intentionally omits the current user
 				"data-cf-lat=\"39.764252\"",
 				"data-cf-lon=\"-104.937511\"",
 				"Only competition admins can modify competition config settings",
@@ -100,7 +110,8 @@ func TestAddOrEditEventPage(t *testing.T) {
 			},
 		},
 		{
-			name: "Edit existing event, as competition admin",
+			name:     "Edit existing event, as competition admin",
+			userInfo: userInfo,
 			event: types.Event{
 				Id:                  "123",
 				Name:                "Test Event",
@@ -133,7 +144,8 @@ func TestAddOrEditEventPage(t *testing.T) {
 			},
 		},
 		{
-			name: "Edit unpublished event",
+			name:     "Edit unpublished event",
+			userInfo: userInfo,
 			event: types.Event{
 				Id:                  "123",
 				Name:                "Test Event",
@@ -158,7 +170,7 @@ func TestAddOrEditEventPage(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			component := AddOrEditEventPage(helpers.SitePages["event-detail"], tt.event, tt.isEditor, tt.cfLat, tt.cfLon, tt.isCompetitionAdmin)
+			component := AddOrEditEventPage(helpers.SitePages["event-detail"], tt.userInfo, tt.event, tt.isEditor, tt.cfLat, tt.cfLon, tt.isCompetitionAdmin)
 
 			// Render the component to a string
 			var buf bytes.Buffer

--- a/functions/gateway/templates/pages/home.templ
+++ b/functions/gateway/templates/pages/home.templ
@@ -41,7 +41,7 @@ templ EventsInner(events []types.Event, mode string) {
 				No events found, try changing your filters like location, date, and time, or
 				<br/>
 				<br/>
-				<a class="btn btn-primary btn-small" href="/?radius=500">Expand Your Search</a>
+				<a class="btn btn-primary btn-small" href={ templ.SafeURL("/?radius=" + strconv.FormatFloat(helpers.DEFAULT_EXPANDED_SEARCH_RADIUS, 'f', -1, 64)) }>Expand Your Search</a>
 			</p>
 		} else {
 			for _, ev := range events {
@@ -140,7 +140,7 @@ templ EventsInner(events []types.Event, mode string) {
 
 func GetCityCountryFromLocation(cfLocation helpers.CdnLocation, latStr, lonStr, origLat, origLon string) string {
 	if cfLocation.City == "" && origLat != "" && origLon != "" {
-		return "Geocoordinates: " + origLat + ", " + origLat
+		return "Geocoordinates: " + origLat + ", " + origLon
 	} else if cfLocation.City != "" && cfLocation.CCA2 != "" {
 		return cfLocation.City + ", " + cfLocation.CCA2
 	}

--- a/functions/gateway/templates/pages/home.templ
+++ b/functions/gateway/templates/pages/home.templ
@@ -104,7 +104,7 @@ templ EventsInner(events []types.Event, mode string) {
 				No events found.
 				<br/>
 				<br/>
-				<a class="btn btn-primary btn-small" href="/?radius=500">Expand Your Search</a>
+				<a class="btn btn-primary btn-small" href={ templ.SafeURL("/?radius=" + strconv.FormatFloat(helpers.DEFAULT_EXPANDED_SEARCH_RADIUS, 'f', -1, 64)) }>Expand Your Search</a>
 			</p>
 		} else {
 			for _, ev := range events {
@@ -262,7 +262,9 @@ templ HomePage(events []types.Event, pageUser *types.UserSearchResult, cfLocatio
 			</template>
 		</div>
 	}
-	<div class="min-h-screen">
+	<div
+		class="min-h-screen"
+	>
 		if pageUser == nil {
 			<header class="flex justify-between p-4 bg-black border-b border-gray-700">
 				<nav class="flex space-x-4">
@@ -285,196 +287,224 @@ templ HomePage(events []types.Event, pageUser *types.UserSearchResult, cfLocatio
 				@FilterButton()
 			</header>
 		}
-		// Source: https://www.penguinui.com/components/combobox
-		<div x-data="getLocationSearchState()" class="flex w-full max-w-xs flex-col gap-1" x-on:keydown="handleKeydownOnOptions($event)" x-on:keydown.esc.window="isOpen = false, openedWithKeyboard = false" x-init="options = allOptions">
-			<div class="relative px-4">
-				<!-- trigger button  -->
-				<button
-					type="button"
-					class="inline-flex w-full items-center justify-between gap-2 border border-slate-300 rounded-md bg-slate-100 mt-2 px-4 py-2 text-sm font-medium tracking-wide text-slate-700 transition hover:opacity-75 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-green-700 dark:border-slate-700 dark:bg-slate-800/50 dark:text-slate-300 dark:focus-visible:outline-green-600"
-					role="combobox"
-					aria-controls="makesList"
-					aria-haspopup="listbox"
-					x-on:click="isOpen = ! isOpen"
-					x-on:keydown.down.prevent="openedWithKeyboard = true"
-					x-on:keydown.enter.prevent="openedWithKeyboard = true"
-					x-on:keydown.space.prevent="openedWithKeyboard = true"
-					x-bind:aria-expanded="isOpen || openedWithKeyboard"
-					x-bind:aria-label="selectedOption.label ? '' : ''"
-				>
-					<span
-						class="text-sm font-normal"
-						x-text="selectedOption?.label ? selectedOption.label : 'Location: Please Select'"
-					></span>
-					<span
-						class="sr-only"
-						x-text="selectedOption?.label ? selectedOption.label : 'Location: Please Select'"
-					></span>
-					<!-- Chevron  -->
-					<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="size-5" aria-hidden="true">
-						<path fill-rule="evenodd" d="M5.22 8.22a.75.75 0 0 1 1.06 0L10 11.94l3.72-3.72a.75.75 0 1 1 1.06 1.06l-4.25 4.25a.75.75 0 0 1-1.06 0L5.22 9.28a.75.75 0 0 1 0-1.06Z" clip-rule="evenodd"></path>
-					</svg>
-				</button>
-				<!-- Hidden Input To Grab The Selected Value  -->
-				<input id="make" name="make" x-ref="hiddenTextField" hidden=""/>
-				<div
-					x-show="isOpen || openedWithKeyboard"
-					:class="{'opacity-100': isOpen || openedWithKeyboard}"
-					class="w-full opacity-0 transition-all absolute left-4 top-12 z-10 overflow-hidden rounded-md border border-slate-300 bg-slate-100"
-					id="makesList"
-					role="listbox"
-					aria-label="locations list"
-					x-on:click.outside="isOpen = false, openedWithKeyboard = false"
-					x-on:keydown.down.prevent="$focus.wrap().next()"
-					x-on:keydown.up.prevent="$focus.wrap().previous()"
-					x-transition
-					x-trap="openedWithKeyboard"
-				>
-					<!-- Search  -->
-					<div class="relative">
-						<svg
-							xmlns="http://www.w3.org/2000/svg"
-							viewBox="0 0 24 24"
-							stroke="currentColor"
-							fill="none"
-							stroke-width="1.5"
-							class="absolute left-4 top-1/2 size-5 -translate-y-1/2 text-slate-700/50 dark:text-slate-300/50"
-							aria-hidden="true"
+		<div
+			x-data="getHomeState()"
+			@location-selected.window="handleLocationSelected"
+		>
+			<div class="flex space-x-4 justify-between">
+				// Source: https://www.penguinui.com/components/combobox
+				<div x-data="getLocationSearchState()" class="flex w-full max-w-xs flex-col gap-1" x-on:keydown="handleKeydownOnOptions($event)" x-on:keydown.esc.window="isOpen = false, openedWithKeyboard = false" x-init="options = allOptions">
+					<div class="relative px-4">
+						<!-- trigger button  -->
+						<button
+							type="button"
+							class="inline-flex w-full items-center justify-between gap-2 border border-slate-300 rounded-md bg-slate-100 mt-2 px-4 py-2 text-sm font-medium tracking-wide text-slate-700 transition hover:opacity-75 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-green-700 dark:border-slate-700 dark:bg-slate-800/50 dark:text-slate-300 dark:focus-visible:outline-green-600"
+							role="combobox"
+							aria-controls="makesList"
+							aria-haspopup="listbox"
+							x-on:click="isOpen = ! isOpen"
+							x-on:keydown.down.prevent="openedWithKeyboard = true"
+							x-on:keydown.enter.prevent="openedWithKeyboard = true"
+							x-on:keydown.space.prevent="openedWithKeyboard = true"
+							x-bind:aria-expanded="isOpen || openedWithKeyboard"
+							x-bind:aria-label="selectedOption.label ? '' : ''"
 						>
-							<path stroke-linecap="round" stroke-linejoin="round" d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z"></path>
-						</svg>
-						<input
-							type="text"
-							class="w-full border-b border-slate-300 bg-slate-100 py-2.5 pl-11 pr-4 text-sm text-slate-700 focus:outline-none focus-visible:border-green-700 disabled:cursor-not-allowed disabled:opacity-75 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-300 dark:focus-visible:border-green-600"
-							name="loc_search"
-							aria-label="Search"
-							@input.throttle="fetchLocations($event.target.value)"
-							x-ref="loc_search"
-							placeholder="Search"
-						/>
-					</div>
-					<!-- Options  -->
-					<ul class="flex max-h-44 flex-col overflow-y-auto">
-						<li class="hidden px-4 py-2 text-sm text-slate-700 dark:text-slate-300" x-ref="noResultsMessage">
-							<span>No matches found</span>
-						</li>
-						<template x-for="(item, index) in options" :key="index">
-							<li
-								class="combobox-option inline-flex cursor-pointer justify-between gap-6 bg-slate-100 px-4 py-2 text-sm text-slate-700 hover:bg-slate-800/5 hover:text-black focus-visible:bg-slate-800/5 focus-visible:text-black focus-visible:outline-none dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-100/5 dark:hover:text-white dark:focus-visible:bg-slate-100/10 dark:focus-visible:text-white"
-								role="option"
-								@click="setSelectedOption(item)"
-								@keydown.enter="setSelectedOption(item)"
-								:id="'option-' + index"
-								tabindex="0"
-							>
-								<!-- Label  -->
-								<span :class="selectedOption && selectedOption.value == item.value ? 'font-bold' : null" x-text="item.label"></span>
-								<!-- Screen reader 'selected' indicator  -->
-								<span class="sr-only" x-text="selectedOption && selectedOption.value == item.value ? 'selected' : null"></span>
-								<!-- Checkmark  -->
-								<svg x-cloak x-show="selectedOption && selectedOption.value == item.value" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" stroke="currentColor" fill="none" stroke-width="2" class="size-4" aria-hidden="true">
-									<path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5"></path>
+							<span
+								class="text-sm font-normal"
+								x-text="selectedOption?.label ? selectedOption.label : 'Location: Please Select'"
+							></span>
+							<span
+								class="sr-only"
+								x-text="selectedOption?.label ? selectedOption.label : 'Location: Please Select'"
+							></span>
+							<!-- Chevron  -->
+							<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="size-5" aria-hidden="true">
+								<path fill-rule="evenodd" d="M5.22 8.22a.75.75 0 0 1 1.06 0L10 11.94l3.72-3.72a.75.75 0 1 1 1.06 1.06l-4.25 4.25a.75.75 0 0 1-1.06 0L5.22 9.28a.75.75 0 0 1 0-1.06Z" clip-rule="evenodd"></path>
+							</svg>
+						</button>
+						<!-- Hidden Input To Grab The Selected Value  -->
+						<input id="make" name="make" x-ref="hiddenTextField" hidden=""/>
+						<div
+							x-show="isOpen || openedWithKeyboard"
+							:class="{'opacity-100': isOpen || openedWithKeyboard}"
+							class="w-full opacity-0 transition-all absolute left-4 top-12 z-10 overflow-hidden rounded-md border border-slate-300 bg-slate-100"
+							id="makesList"
+							role="listbox"
+							aria-label="locations list"
+							x-on:click.outside="isOpen = false, openedWithKeyboard = false"
+							x-on:keydown.down.prevent="$focus.wrap().next()"
+							x-on:keydown.up.prevent="$focus.wrap().previous()"
+							x-transition
+							x-trap="openedWithKeyboard"
+						>
+							<!-- Search  -->
+							<div class="relative">
+								<svg
+									xmlns="http://www.w3.org/2000/svg"
+									viewBox="0 0 24 24"
+									stroke="currentColor"
+									fill="none"
+									stroke-width="1.5"
+									class="absolute left-4 top-1/2 size-5 -translate-y-1/2 text-slate-700/50 dark:text-slate-300/50"
+									aria-hidden="true"
+								>
+									<path stroke-linecap="round" stroke-linejoin="round" d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z"></path>
 								</svg>
-							</li>
-						</template>
-					</ul>
+								<input
+									type="text"
+									class="w-full border-b border-slate-300 bg-slate-100 py-2.5 pl-11 pr-4 text-sm text-slate-700 focus:outline-none focus-visible:border-green-700 disabled:cursor-not-allowed disabled:opacity-75 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-300 dark:focus-visible:border-green-600"
+									name="loc_search"
+									aria-label="Search"
+									@input.throttle="fetchLocations($event.target.value)"
+									x-ref="loc_search"
+									placeholder="Search"
+								/>
+							</div>
+							<!-- Options  -->
+							<ul class="flex max-h-44 flex-col overflow-y-auto">
+								<li class="hidden px-4 py-2 text-sm text-slate-700 dark:text-slate-300" x-ref="noResultsMessage">
+									<span>No matches found</span>
+								</li>
+								<template x-for="(item, index) in options" :key="index">
+									<li
+										class="combobox-option inline-flex cursor-pointer justify-between gap-6 bg-slate-100 px-4 py-2 text-sm text-slate-700 hover:bg-slate-800/5 hover:text-black focus-visible:bg-slate-800/5 focus-visible:text-black focus-visible:outline-none dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-100/5 dark:hover:text-white dark:focus-visible:bg-slate-100/10 dark:focus-visible:text-white"
+										role="option"
+										@click="setSelectedOption(item)"
+										@keydown.enter="setSelectedOption(item)"
+										:id="'option-' + index"
+										tabindex="0"
+									>
+										<!-- Label  -->
+										<span :class="selectedOption && selectedOption.value == item.value ? 'font-bold' : null" x-text="item.label"></span>
+										<!-- Screen reader 'selected' indicator  -->
+										<span class="sr-only" x-text="selectedOption && selectedOption.value == item.value ? 'selected' : null"></span>
+										<!-- Checkmark  -->
+										<svg x-cloak x-show="selectedOption && selectedOption.value == item.value" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" stroke="currentColor" fill="none" stroke-width="2" class="size-4" aria-hidden="true">
+											<path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5"></path>
+										</svg>
+									</li>
+								</template>
+							</ul>
+						</div>
+					</div>
+				</div>
+				<div class="flex items-center">
+					<svg xmlns="http://www.w3.org/2000/svg" class="stroke-none h-8 w-8 mr-4" fill="currentColor" viewBox="0 0 24 24">
+						<path d="M6.5,8.11C5.61,8.11 4.89,7.39 4.89,6.5A1.61,1.61 0 0,1 6.5,4.89C7.39,4.89 8.11,5.61 8.11,6.5V6.5A1.61,1.61 0 0,1 6.5,8.11M6.5,2C4,2 2,4 2,6.5C2,9.87 6.5,14.86 6.5,14.86C6.5,14.86 11,9.87 11,6.5C11,4 9,2 6.5,2M17.5,8.11A1.61,1.61 0 0,1 15.89,6.5C15.89,5.61 16.61,4.89 17.5,4.89C18.39,4.89 19.11,5.61 19.11,6.5A1.61,1.61 0 0,1 17.5,8.11M17.5,2C15,2 13,4 13,6.5C13,9.87 17.5,14.86 17.5,14.86C17.5,14.86 22,9.87 22,6.5C22,4 20,2 17.5,2M17.5,16C16.23,16 15.1,16.8 14.68,18H9.32C8.77,16.44 7.05,15.62 5.5,16.17C3.93,16.72 3.11,18.44 3.66,20C4.22,21.56 5.93,22.38 7.5,21.83C8.35,21.53 9,20.85 9.32,20H14.69C15.24,21.56 16.96,22.38 18.5,21.83C20.08,21.28 20.9,19.56 20.35,18C19.92,16.8 18.78,16 17.5,16V16M17.5,20.5A1.5,1.5 0 0,1 16,19A1.5,1.5 0 0,1 17.5,17.5A1.5,1.5 0 0,1 19,19A1.5,1.5 0 0,1 17.5,20.5Z"></path>
+					</svg>
+					<label class="form-control w-full max-w-xs">
+						<select
+							x-model="radius"
+							class="select select-bordered w-full max-w-xs"
+							@change="pushToQueryParams('radius', radius)"
+						>
+							<option value="10">10 mi</option>
+							<option value="25">25 mi</option>
+							<option value="50">50 mi</option>
+							<option value="100">100 mi</option>
+							<option value="250">250 mi</option>
+							<option value="500">500 mi</option>
+							<option value="1000">1,000 mi</option>
+							<option value="25000">Global</option>
+						</select>
+					</label>
 				</div>
 			</div>
-		</div>
-		<div x-data="getHomeState()" class="p-4" @location-selected.window="handleLocationSelected">
-			<form
-				id="event-search-form"
-				class="flex"
-				novalidate
-				if pageUser == nil {
-					hx-get="/api/html/events"
-				} else {
-					hx-get={ `/api/html/events?list_mode=` + helpers.EV_MODE_LIST }
-				}
-				hx-indicator="#events-container"
-				hx-ext="json-enc"
-				hx-target="#events-container-inner"
-				hx-disabled-elt="button[type='submit']"
-				@submit.prevent=""
-				hx-vals="js:{...sendParmsFromQs()}"
-			>
-				<input
-					x-model="start_time"
-					id="start_time"
-					type="hidden"
-				/>
-				<input
-					x-model="end_time"
-					id="end_time"
-					type="hidden"
-				/>
-				<input
-					x-model="q"
-					id="q"
-					type="hidden"
-				/>
-				<input
-					x-model="radius"
-					id="radius"
-					type="hidden"
-				/>
-				<input
-					x-model="lat"
-					id="lat"
-					type="hidden"
-				/>
-				<input
-					x-model="lon"
-					id="lon"
-					type="hidden"
-				/>
-				<div class="flex flex-auto space-x-2">
-					<button
-						type="submit"
-						:class="{
+			<div class="p-4">
+				<form
+					id="event-search-form"
+					class="flex"
+					novalidate
+					if pageUser == nil {
+						hx-get="/api/html/events"
+					} else {
+						hx-get={ `/api/html/events?list_mode=` + helpers.EV_MODE_LIST }
+					}
+					hx-indicator="#events-container"
+					hx-ext="json-enc"
+					hx-target="#events-container-inner"
+					hx-disabled-elt="button[type='submit']"
+					@submit.prevent=""
+					hx-vals="js:{...sendParmsFromQs()}"
+				>
+					<input
+						x-model="start_time"
+						id="start_time"
+						type="hidden"
+					/>
+					<input
+						x-model="end_time"
+						id="end_time"
+						type="hidden"
+					/>
+					<input
+						x-model="q"
+						id="q"
+						type="hidden"
+					/>
+					<input
+						x-model="radius"
+						id="radius"
+						type="hidden"
+					/>
+					<input
+						x-model="lat"
+						id="lat"
+						type="hidden"
+					/>
+					<input
+						x-model="lon"
+						id="lon"
+						type="hidden"
+					/>
+					<div class="flex flex-auto space-x-2">
+						<button
+							type="submit"
+							:class="{
 							'btn-primary': start_time === 'this_month',
 							'hover:text-black hover:bg-gray-500 text-black bg-gray-200': start_time !== 'this_month'
 						}"
-						class="btn grow px-4 py-2 text-md md:text-xl "
-						@click="pushToQueryParams('start_time', 'this_month')"
-					>
-						THIS MONTH
-					</button>
-					<button
-						type="submit"
-						:class="{
+							class="btn grow px-4 py-2 text-md md:text-xl "
+							@click="pushToQueryParams('start_time', 'this_month')"
+						>
+							THIS MONTH
+						</button>
+						<button
+							type="submit"
+							:class="{
 							'btn-primary': start_time === 'today',
 							'hover:text-black hover:bg-gray-500 text-black bg-gray-200': start_time !== 'today'
 						}"
-						class="btn grow px-4 py-2 text-md md:text-xl "
-						@click="pushToQueryParams('start_time', 'today')"
-					>
-						TODAY
-					</button>
-					<button
-						type="submit"
-						:class="{
+							class="btn grow px-4 py-2 text-md md:text-xl "
+							@click="pushToQueryParams('start_time', 'today')"
+						>
+							TODAY
+						</button>
+						<button
+							type="submit"
+							:class="{
 							'btn-primary': start_time === 'tomorrow',
 							'hover:text-black hover:bg-gray-500 text-black bg-gray-200': start_time !== 'tomorrow'
 						}"
-						class="btn grow px-4 py-2 text-md md:text-xl "
-						@click="pushToQueryParams('start_time', 'tomorrow')"
-					>
-						TOMORROW
-					</button>
-					<button
-						type="submit"
-						:class="{
+							class="btn grow px-4 py-2 text-md md:text-xl "
+							@click="pushToQueryParams('start_time', 'tomorrow')"
+						>
+							TOMORROW
+						</button>
+						<button
+							type="submit"
+							:class="{
 							'btn-primary': start_time === 'this_week',
 							'hover:text-black hover:bg-gray-500 text-black bg-gray-200': start_time !== 'this_week'
 						}"
-						class="btn grow px-4 py-2 text-md md:text-xl "
-						@click="pushToQueryParams('start_time', 'this_week')"
-					>
-						THIS WEEK
-					</button>
-				</div>
-			</form>
+							class="btn grow px-4 py-2 text-md md:text-xl "
+							@click="pushToQueryParams('start_time', 'this_week')"
+						>
+							THIS WEEK
+						</button>
+					</div>
+				</form>
+			</div>
 		</div>
 		<main id="events-container">
 			if pageUser == nil {
@@ -514,7 +544,7 @@ templ HomePage(events []types.Event, pageUser *types.UserSearchResult, cfLocatio
 			}
 		</main>
 	</div>
-	<script id="alpine-state" data-cities-default-list={ GetCitiesAsJsonStr() } data-city-label-initial={ GetCityCountryFromLocation(cfLocation, latStr, lonStr, origLat, origLong) } data-page-user-id={ GetPageUserID(pageUser) } data-fake-event-id={ helpers.COMP_UNASSIGNED_ROUND_EVENT_ID } data-apex-url={ os.Getenv("APEX_URL") }>
+	<script id="alpine-state" data-cities-default-list={ GetCitiesAsJsonStr() } data-city-label-initial={ GetCityCountryFromLocation(cfLocation, latStr, lonStr, origLat, origLong) } data-page-user-id={ GetPageUserID(pageUser) } data-fake-event-id={ helpers.COMP_UNASSIGNED_ROUND_EVENT_ID } data-apex-url={ os.Getenv("APEX_URL") } data-default-radius={ strconv.FormatFloat(helpers.DEFAULT_SEARCH_RADIUS, 'f', -1, 64) }>
 		// NOTE: this is used by htmx to get the data-attributes
 		// eslint-disable-next-line no-unused-vars
 		function sendParmsFromQs() {
@@ -619,6 +649,7 @@ templ HomePage(events []types.Event, pageUser *types.UserSearchResult, cfLocatio
 					});
 				},
 				pageUserId: document.querySelector('#alpine-state').getAttribute('data-page-user-id'),
+				defaultRadius: document.querySelector('#alpine-state').getAttribute('data-default-radius'),
 				start_time: null,
 				end_time: null,
 				q: null,
@@ -641,7 +672,7 @@ templ HomePage(events []types.Event, pageUser *types.UserSearchResult, cfLocatio
 					this.start_time = urlParams.get('start_time') || '';
 					this.end_time = urlParams.get('end_time') || '';
 					this.q = urlParams.get('q') || '';
-					this.radius = urlParams.get('radius') || '';
+					this.radius = urlParams.get('radius') || this.defaultRadius;
 					this.lat = urlParams.get('lat') || '';
 					this.lon = urlParams.get('lon') || '';
 					// these come from the sidebar

--- a/functions/gateway/templates/pages/layout.templ
+++ b/functions/gateway/templates/pages/layout.templ
@@ -23,7 +23,7 @@ templ Layout(sitePage helpers.SitePage, userInfo helpers.UserInfo, pageContent t
 			<link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400&family=Ubuntu+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Anton&family=Unbounded:wght@900&display=swap" rel="stylesheet"/>
 			// 🚨 WARNING 🚨 This filename is automatically updated by PostCSS
 			// ✅ DO commit it to version control whenever you see it change
-			<link rel="stylesheet" href={ templ.EscapeString(os.Getenv("STATIC_BASE_URL") + "/assets/styles.a616b883.css") }/>
+			<link rel="stylesheet" href={ templ.EscapeString(os.Getenv("STATIC_BASE_URL") + "/assets/styles.91c19089.css") }/>
 			<meta name="viewport" content="width=device-width, initial-scale=1"/>
 			<script src="https://unpkg.com/htmx.org@1.9.12"></script>
 			<script src="https://unpkg.com/htmx.org@1.9.12/dist/ext/json-enc.js"></script>

--- a/functions/gateway/templates/partials/events_admin_children.templ
+++ b/functions/gateway/templates/partials/events_admin_children.templ
@@ -3,7 +3,6 @@ package partials
 import (
 	"github.com/meetnearme/api/functions/gateway/helpers"
 	"github.com/meetnearme/api/functions/gateway/types"
-	"log"
 	"reflect"
 	"strconv"
 	"strings"
@@ -41,8 +40,6 @@ func GetChildEventFields(parent types.Event, child types.Event) []FieldDiff {
 		parentField := parentVal.Field(i).Interface()
 		childField := childVal.Field(i).Interface()
 
-		log.Println("parentField", parentField)
-		log.Println("childField", childField)
 		// Only add if values are different
 		if !reflect.DeepEqual(parentField, childField) ||
 			helpers.ArrFindFirst([]string{field.Name}, AlwaysShowEventDiffFields) != "" {

--- a/go.mod
+++ b/go.mod
@@ -60,6 +60,7 @@ require (
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-playground/validator/v10 v10.22.0 // indirect
 	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
+	github.com/golang/geo v0.0.0-20250404181303-07d601f131f3 // indirect
 	github.com/google/pprof v0.0.0-20241210010833-40e02aabc2ad // indirect
 	github.com/gorilla/securecookie v1.1.2 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -108,8 +108,11 @@ github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1v
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
 github.com/golang-jwt/jwt/v4 v4.5.0 h1:7cYmW1XlMY7h7ii7UhUyChSgS5wUJEnm9uZVTGqOWzg=
 github.com/golang-jwt/jwt/v4 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
+github.com/golang/geo v0.0.0-20250404181303-07d601f131f3 h1:8COTSTFIIXnaD81+kfCw4dRANNAKuCp06EdYLqwX30g=
+github.com/golang/geo v0.0.0-20250404181303-07d601f131f3/go.mod h1:J+F9/3Ofc8ysEOY2/cNjxTMl2eB1gvPIywEHUplPgDA=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/pprof v0.0.0-20240903155634-a8630aee4ab9 h1:q5g0N9eal4bmJwXHC5z0QCKs8qhS35hFfq0BAYsIwZI=


### PR DESCRIPTION
* Search geolocation bounds had incorrect calculation and incorrect wraparound behavior, fix and add tests
* Automatically set zitadel `familyName` / `secondPartName` to `.` and override if second value is present in team user creation
* Default `owners` array to current user for NEW event
* Fix regex string matching in `GetGeo` service
* Only require `paarentEventId` in `HasPurchaseForEventHandler`
* Use [golag/geo packag](https://github.com/meetnearme/api/pull/366/commits/bcf89f06464727f474d3b0eb5fe515fad93b7cd6) for spherical (lat / long) geometry
* Adjust default radius to `500` because Cloudflare geolocation can be way off (needs a better long-term fix)
* Use constants for consistency with search radius and defaults
* Improve test coverage for event search
* Fix bug with geocoordinate display in UI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced event search with dynamic default radius, refined location filtering, and updated search expansion links.
  - Improved event and competition pages by integrating current user details and auto-assigning ownership, while disabling scoring controls during saves.
  - Added constants for default search radius values to improve maintainability.
  - Introduced spatial filtering capabilities in event searches.

- **Bug Fixes**
  - Updated error messaging for purchase validation and adjusted purchase filtering.
  - Refined display name processing and geolocation extraction for more accurate results.

- **Style**
  - Refreshed page styling for a consistent and improved layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->