### PR TITLE
[fix] UI fix for event start / end time search boundaries + active time filters

### DIFF
--- a/functions/gateway/handlers/page_handlers.go
+++ b/functions/gateway/handlers/page_handlers.go
@@ -35,10 +35,10 @@ func ParseStartEndTime(startTimeStr, endTimeStr string) (_startTimeUnix, _endTim
 
 	// NOTE: This assumes the UI home page default is "THIS MONTH" and the absence
 	// of an explicit start_time query param ...
-	if (startTimeStr == "" && endTimeStr == "") || strings.ToLower(startTimeStr) == "this_year" {
+	if startTimeStr == "" && endTimeStr == "" {
 		startTime = time.Now()
 		// NOTE: default to 1 month
-		endTime = startTime.AddDate(0, 1, 0)
+		endTime = startTime.AddDate(0, 3, 0)
 	} else if strings.ToLower(startTimeStr) == "this_month" {
 		startTime = time.Now()
 		endTime = startTime.AddDate(0, 1, 0)

--- a/functions/gateway/templates/pages/home.templ
+++ b/functions/gateway/templates/pages/home.templ
@@ -361,8 +361,8 @@ templ HomePage(events []types.Event, pageUser *types.UserSearchResult, cfLocatio
 						<button
 							type="submit"
 							:class="{
-							'btn-primary': start_time === 'this_month',
-							'hover:text-black hover:bg-gray-500 text-black bg-gray-200': start_time !== 'this_month'
+							'btn-primary': $store.queryParams.start_time === 'this_month',
+							'hover:text-black hover:bg-gray-500 text-black bg-gray-200': $store.queryParams.start_time !== 'this_month'
 						}"
 							class="btn grow px-2 py-2 text-md md:text-xl "
 							@click="Alpine.store('queryParams').pushToQueryParams('start_time', 'this_month')"
@@ -372,8 +372,8 @@ templ HomePage(events []types.Event, pageUser *types.UserSearchResult, cfLocatio
 						<button
 							type="submit"
 							:class="{
-							'btn-primary': start_time === 'today',
-							'hover:text-black hover:bg-gray-500 text-black bg-gray-200': start_time !== 'today'
+							'btn-primary': $store.queryParams.start_time === 'today',
+							'hover:text-black hover:bg-gray-500 text-black bg-gray-200': $store.queryParams.start_time !== 'today'
 						}"
 							class="btn grow px-2 py-2 text-md md:text-xl "
 							@click="Alpine.store('queryParams').pushToQueryParams('start_time', 'today')"
@@ -383,8 +383,8 @@ templ HomePage(events []types.Event, pageUser *types.UserSearchResult, cfLocatio
 						<button
 							type="submit"
 							:class="{
-							'btn-primary': start_time === 'tomorrow',
-							'hover:text-black hover:bg-gray-500 text-black bg-gray-200': start_time !== 'tomorrow'
+							'btn-primary': $store.queryParams.start_time === 'tomorrow',
+							'hover:text-black hover:bg-gray-500 text-black bg-gray-200': $store.queryParams.start_time !== 'tomorrow'
 						}"
 							class="btn grow px-2 py-2 text-md md:text-xl "
 							@click="Alpine.store('queryParams').pushToQueryParams('start_time', 'tomorrow')"
@@ -394,8 +394,8 @@ templ HomePage(events []types.Event, pageUser *types.UserSearchResult, cfLocatio
 						<button
 							type="submit"
 							:class="{
-							'btn-primary': start_time === 'this_week',
-							'hover:text-black hover:bg-gray-500 text-black bg-gray-200': start_time !== 'this_week'
+							'btn-primary': $store.queryParams.start_time === 'this_week',
+							'hover:text-black hover:bg-gray-500 text-black bg-gray-200': $store.queryParams.start_time !== 'this_week'
 						}"
 							class="btn grow px-2 py-2 text-md md:text-xl "
 							@click="Alpine.store('queryParams').pushToQueryParams('start_time', 'this_week')"


### PR DESCRIPTION
* Fix default time boundaries for search (default to `90 days` with no parameter)

* Fix active THIS MONTH // TODAY // TOMORROW UI filters

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated default time filters so that, when no dates are specified, the end date now extends to three months ahead.
  
- **Style**
  - Refined home page filter buttons to consistently reflect the current global time selection state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->