### PR TITLE
[fix] cloudflare location override

### DIFF
--- a/functions/gateway/templates/pages/home.templ
+++ b/functions/gateway/templates/pages/home.templ
@@ -141,6 +141,8 @@ templ EventsInner(events []types.Event, mode string) {
 func GetCityCountryFromLocation(cfLocation helpers.CdnLocation, latStr, lonStr, origLat, origLon, origQueryLocation string) string {
 	if origQueryLocation != "" {
 		return origQueryLocation
+	} else if latStr != "" && lonStr != "" {
+		return latStr + ", " + lonStr
 	} else if cfLocation.City == "" && origLat != "" && origLon != "" {
 		return origLat + ", " + origLon
 	} else if cfLocation.City != "" && cfLocation.CCA2 != "" {


### PR DESCRIPTION
Cloudflare location should not override `lat` and `lon` values manually set via query params

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved handling of geographic input: When both latitude and longitude values are provided without a preset location query, the system now returns a formatted location string combining these coordinates for more reliable location determination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->