### PR TITLE
[fix] Fix time boundaries for event search queries

### DIFF
--- a/functions/gateway/handlers/page_handlers.go
+++ b/functions/gateway/handlers/page_handlers.go
@@ -37,7 +37,7 @@ func ParseStartEndTime(startTimeStr, endTimeStr string) (_startTimeUnix, _endTim
 	// of an explicit start_time query param ...
 	if startTimeStr == "" && endTimeStr == "" {
 		startTime = time.Now()
-		// NOTE: default to 1 month
+		// NOTE: default to 3 months
 		endTime = startTime.AddDate(0, 3, 0)
 	} else if strings.ToLower(startTimeStr) == "this_month" {
 		startTime = time.Now()

--- a/functions/gateway/services/marqo_service.go
+++ b/functions/gateway/services/marqo_service.go
@@ -453,6 +453,11 @@ func SearchMarqoEvents(client *marqo.Client, query string, userLocation []float6
 	minLat, maxLat, minLong1, maxLong1, minLong2, maxLong2, needsSplit := calculateSearchBounds(userLocation, maxDistance)
 
 	now := time.Now().Unix()
+	loc, _ := time.LoadLocation("America/New_York")
+	endOfTime, err := helpers.UtcToUnix64("2099-12-31T11:59:59Z", loc)
+	if err != nil {
+		log.Printf("Error converting UTC to Unix64: %v", err)
+	}
 
 	// Search for events based on the query
 	searchMethod := "HYBRID"
@@ -512,7 +517,7 @@ func SearchMarqoEvents(client *marqo.Client, query string, userLocation []float6
 		endTime,
 		now,
 		// TODO: this filters on `endTime` ranging from NOW until END_OF_TIME we need to decide on reasonable scope default for this
-		endTime,
+		endOfTime,
 		longitudeFilter,
 		minLat,
 		maxLat,


### PR DESCRIPTION
This PR fixes a bug where "ongoing events" (those with a `startTime` in the past, but an `endTime` in the future) were not shown in search results