### PR TITLE
fix geocoordinate fallback behavior so that cloudflare city takes precedence

### DIFF
--- a/functions/gateway/templates/pages/home.templ
+++ b/functions/gateway/templates/pages/home.templ
@@ -139,14 +139,16 @@ templ EventsInner(events []types.Event, mode string) {
 }
 
 func GetCityCountryFromLocation(cfLocation helpers.CdnLocation, latStr, lonStr, origLat, origLon, origQueryLocation string) string {
+	log.Printf("GetCityCountryFromLocation: %v, %v, %v, %v, %v, %v", cfLocation, latStr, lonStr, origLat, origLon, origQueryLocation)
+
 	if origQueryLocation != "" {
 		return origQueryLocation
+	} else if cfLocation.City != "" && cfLocation.CCA2 != "" {
+		return cfLocation.City + ", " + cfLocation.CCA2
 	} else if latStr != "" && lonStr != "" {
 		return latStr + ", " + lonStr
 	} else if cfLocation.City == "" && origLat != "" && origLon != "" {
 		return origLat + ", " + origLon
-	} else if cfLocation.City != "" && cfLocation.CCA2 != "" {
-		return cfLocation.City + ", " + cfLocation.CCA2
 	} else {
 		return helpers.Cities[0].City + ", " + helpers.Cities[0].State
 	}

--- a/functions/gateway/templates/pages/home.templ
+++ b/functions/gateway/templates/pages/home.templ
@@ -139,8 +139,6 @@ templ EventsInner(events []types.Event, mode string) {
 }
 
 func GetCityCountryFromLocation(cfLocation helpers.CdnLocation, latStr, lonStr, origLat, origLon, origQueryLocation string) string {
-	log.Printf("GetCityCountryFromLocation: %v, %v, %v, %v, %v, %v", cfLocation, latStr, lonStr, origLat, origLon, origQueryLocation)
-
 	if origQueryLocation != "" {
 		return origQueryLocation
 	} else if cfLocation.City != "" && cfLocation.CCA2 != "" {
@@ -445,7 +443,7 @@ templ HomePage(events []types.Event, pageUser *types.UserSearchResult, cfLocatio
 			}
 		</main>
 	</div>
-	<script id="alpine-state" data-cities-default-list={ GetCitiesAsJsonStr() } data-city-label-initial={ GetCityCountryFromLocation(cfLocation, latStr, lonStr, origLat, origLong, origQueryLocation) } data-city-latitude-initial={ latStr } data-city-longitude-initial={ lonStr } data-page-user-id={ GetPageUserID(pageUser) } data-fake-event-id={ helpers.COMP_UNASSIGNED_ROUND_EVENT_ID } data-apex-url={ os.Getenv("APEX_URL") } data-default-radius={ GetDefaultRadius(cfLocation) } data-cf-location={ templ.JSONString(cfLocation) }>
+	<script id="alpine-state" data-cities-default-list={ GetCitiesAsJsonStr() } data-city-label-initial={ GetCityCountryFromLocation(cfLocation, latStr, lonStr, origLat, origLong, origQueryLocation) } data-city-latitude-initial={ latStr } data-city-longitude-initial={ lonStr } data-page-user-id={ GetPageUserID(pageUser) } data-fake-event-id={ helpers.COMP_UNASSIGNED_ROUND_EVENT_ID } data-apex-url={ os.Getenv("APEX_URL") } data-default-radius={ GetDefaultRadius(cfLocation) }>
 		document.addEventListener('alpine:init', () => {
 
 			const urlParams = new URLSearchParams(window.location.search);


### PR DESCRIPTION
Before this the (not very human friendly / readable `Geocoordinates: 35.35, -75.23`) would show in the UI like this

<img width="757" alt="image" src="https://github.com/user-attachments/assets/c8b58a6f-d014-4082-83fa-f8e28c6cb1d5" />

We want human readable to always take precedence in these situations, so the new priority order is:

1) `location` query param
2) cloudflare location city / country
3) geocoordinates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved location display logic to prioritize showing city and country code when available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->