### PR TITLE
Only show the loading indicator on event details page if rounds are loading / in flight

### DIFF
--- a/functions/gateway/templates/pages/event_details.templ
+++ b/functions/gateway/templates/pages/event_details.templ
@@ -186,7 +186,7 @@ templ EventDetailsPage(event types.Event, userInfo helpers.UserInfo, canEdit boo
 				<template x-if="competitionConfigId && userId">
 					<div class="mt-4" id="voting-section">
 						<h3 class="text-xl">VOTING</h3>
-						<template x-if="!Boolean(rounds?.[0]?.competitorADisplayName)">
+						<template x-if="roundsDataFetching">
 							<div class="mt-2"><span class="loading loading-spinner loading-md text-primary"></span></div>
 						</template>
 						<template x-if="!roundsDataFetching && rounds?.filter(round => round.isVotingOpen).length === 0">


### PR DESCRIPTION
# Before fix
![Screen_Recording_2025-05-01_at_6 13 08 AM](https://github.com/user-attachments/assets/fa2c4a51-7c10-4063-b811-b00bf5d49405)

# After fix
![Screen_Recording_2025-05-01_at_6 12 44 AM](https://github.com/user-attachments/assets/c49e876c-111b-42dc-b096-3381baecd0b5)
