### PR TITLE
[fix] Fix error thrown on event add / edit page when `registrationFields` are empty

### DIFF
--- a/functions/gateway/templates/components/navbar.templ
+++ b/functions/gateway/templates/components/navbar.templ
@@ -740,7 +740,7 @@ templ Navbar(userInfo helpers.UserInfo, subnavTabs []string, event types.Event) 
 							});
 
 							// Remove the copied fields from the main registration fields
-							this.registrationFields = this.registrationFields.filter(field => !fieldsToRemove.has(field.name));
+							this.registrationFields = this.registrationFields?.filter?.(field => !fieldsToRemove.has(field.name));
 						}
 					},
 					validateOneField(field, fieldName, includeIdx) {

--- a/functions/gateway/templates/pages/event_add_edit.templ
+++ b/functions/gateway/templates/pages/event_add_edit.templ
@@ -1041,7 +1041,7 @@ templ AddOrEditEventPage(pageObj helpers.SitePage, userInfo helpers.UserInfo, ev
 									try {
 										const registrationFieldsResponse = await fetch(`/api/registration-fields/${this.formData.event.id}`);
 										const registrationFields = await registrationFieldsResponse.json();
-										this.registrationFields = registrationFields?.fields.map((field, index) => ({
+										this.registrationFields = registrationFields?.fields?.map?.((field, index) => ({
 											...field,
 											optionsText: field.options ? field.options.join('\n') : '',
 											order: index,


### PR DESCRIPTION
This only happens when `hasRegistrationFields` field on event is `true`, which means the Dynamo `registrationFields` table doesn't have a corresponding item for the event

# Before fix

![Screen_Recording_2025-05-01_at_6 46 56 AM](https://github.com/user-attachments/assets/d95647dc-de66-48b5-91be-023e9917c3bc)


# After fix
![Screen_Recording_2025-05-01_at_6 47 33 AM](https://github.com/user-attachments/assets/5ff28e00-2a85-4060-a4db-d3645c219c53)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling to prevent potential issues when registration fields are missing or not properly loaded in event and cart registration interfaces. This ensures a smoother experience when editing events or managing cart registrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->