### PR TITLE
[fix] Contiguous Round Indexes + Cleanup Stray Rounds

### DIFF
--- a/functions/gateway/templates/pages/competition_add_edit.templ
+++ b/functions/gateway/templates/pages/competition_add_edit.templ
@@ -569,7 +569,6 @@ templ AddOrEditCompetitionPage(pageObj helpers.SitePage, competition types.Compe
 					})() : document.querySelector('#add-edit-competition').getAttribute('data-competition-end-time'),
 				},
 				saveReqInFlight: false,
-				// tallyVotesReqInFlight: false,
 				waitingRoom: [],
 				newTeamName: '',
 				teams: [],
@@ -806,6 +805,14 @@ templ AddOrEditCompetitionPage(pageObj helpers.SitePage, competition types.Compe
 							const date = new Date(unixTimestamp * 1000); // Multiply by 1000 to convert seconds to milliseconds
 							return date.toISOString().slice(0, 16); // Get yyyy-MM-ddThh:mm format
 						};
+
+						// re-distribute rounds indexes to ensure they are contiguous
+						this.formData.rounds = this.formData.rounds.map((round, index) => {
+							return {
+								...round,
+								roundNumber: index + 1
+							}
+						})
 
 						const competitionData = {
 							...this.formData,


### PR DESCRIPTION
* re-distribute rounds so that round numbers are contiguous
* introduce deferred cleanup phase in `UpdateCompetitionConfig` that deletes existing rounds of index beyond `lastIndex` of the upserted rounds payload

# Incorrect Behaviors Fixed by this PR
![Screen_Recording_2025-05-02_at_2 48 38 PM](https://github.com/user-attachments/assets/4683d3ea-7d99-4e3a-86c6-65040fdbc24c)

![Screen_Recording_2025-05-02_at_2 49 53 PM](https://github.com/user-attachments/assets/cf3bbdad-f8ab-4fcc-9a89-4a05818bc715)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- When editing a competition, rounds are now automatically re-numbered sequentially before saving, ensuring consistent round numbers.
- **Bug Fixes**
	- Obsolete competition rounds are now properly removed when updating a competition, keeping the stored rounds in sync with the current configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->