### PR TITLE
[fix] Require `endTime` for all competitions

### DIFF
--- a/functions/gateway/types/competitions.go
+++ b/functions/gateway/types/competitions.go
@@ -54,8 +54,8 @@ type CompetitionConfig struct {
 	Status        string             `json:"status" dynamodbav:"status" validate:"required,oneof=DRAFT ACTIVE COMPLETE"`
 	CreatedAt     int64              `json:"createdAt" dynamodbav:"createdAt"`
 	UpdatedAt     int64              `json:"updatedAt" dynamodbav:"updatedAt"`
-	StartTime     int64              `json:"startTime" dynamodbav:"startTime"`
-	EndTime       int64              `json:"endTime" dynamodbav:"endTime"`
+	StartTime     int64              `json:"startTime" dynamodbav:"startTime" validate:"required"`
+	EndTime       int64              `json:"endTime" dynamodbav:"endTime" validate:"required"`
 }
 
 type CompetitionConfigResponse struct {


### PR DESCRIPTION
Since Dynamo indexes on `endTime` for competition configs, we need to enforce that all competitions to be saved must have an end time