### PR TITLE
Feature/add weaviate schema to docker

### DIFF
--- a/Dockerfile.go.prod
+++ b/Dockerfile.go.prod
@@ -40,6 +40,7 @@ RUN find . -name "*templ.go"
 
 # -ldflags="-w -s" strips debug symbols, making the binary smaller.
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-w -s" -o ./docker_build/main ./functions/gateway/main.go
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-w -s" -o ./create_weaviate_schema ./cmd/weaviate-setup/main.go
 
 # The go binary will be mounted from ./docker_build to continue enabling the watchGolang script
 FROM alpine:latest

--- a/Dockerfile.go.prod
+++ b/Dockerfile.go.prod
@@ -40,7 +40,7 @@ RUN find . -name "*templ.go"
 
 # -ldflags="-w -s" strips debug symbols, making the binary smaller.
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-w -s" -o ./docker_build/main ./functions/gateway/main.go
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-w -s" -o ./create_weaviate_schema ./cmd/weaviate-setup/main.go
+RUN CGO_ENABLED=0 GOOS=linux go build -o ./docker_build/create_weaviate_schema ./cmd/weaviate-setup/main.go
 
 # The go binary will be mounted from ./docker_build to continue enabling the watchGolang script
 FROM alpine:latest
@@ -65,9 +65,12 @@ RUN mkdir -p /app-static && touch /app-static/.env
 WORKDIR /go-app
 
 COPY --from=base /go-app/docker_build/main /go-app/main
+COPY --from=base /go-app/docker_build/create_weaviate_schema /go-app/create_weaviate_schema
 
 # Ensure proper permissions for appuser
 RUN chown -R appuser:appgroup /go-app /app-static
+RUN chown -R appuser:appgroup /go-app /app-static && \
+    chmod +x /go-app/main /go-app/create_weaviate_schema
 
 CMD [ "/bin/sh", "-c", "cp /app-static/.env /go-app/.env && exec /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf -n" ]
 

--- a/functions/gateway/services/weaviate_service.go
+++ b/functions/gateway/services/weaviate_service.go
@@ -96,11 +96,7 @@ func DefineWeaviateSchema(ctx context.Context, client *weaviate.Client) error {
 		return fmt.Errorf("failed checking class existence: %w", err)
 	}
 	if exists {
-		log.Printf("WARN: Class '%s' exists. Deleting.", eventClassName)
-		if err = client.Schema().ClassDeleter().WithClassName(eventClassName).Do(ctx); err != nil {
-			return fmt.Errorf("failed deleting class '%s': %w", eventClassName, err)
-		}
-		log.Printf("INFO: Class '%s' deleted.", eventClassName)
+		log.Fatalf("FATAL: Class '%s' exists.", eventClassName)
 	}
 
 	// Define class structure using models.Property and string data types


### PR DESCRIPTION
The PR adds a small change to the Dockerfile.go.prod in order to build the binary for the create weaviate schema program. It also modifies the schema creation in order to do a hard fail if the class is already present in the DB. 

One note: this will not work with the current hot reloading setup on the develop branch as the volume mounting overwrites the weaviate schema program. This will be addressed in a different way following the #413 merge into the main branch. 