### PR TITLE
Fix: Geo Service Tests

### DIFF
--- a/functions/gateway/services/geo_service_test.go
+++ b/functions/gateway/services/geo_service_test.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"testing"
@@ -44,21 +45,20 @@ func TestGetGeo(t *testing.T) {
 			expectedLon:  "-74.0060",
 			expectedAddr: "New York, NY 10001, USA",
 		},
-        // TODO: issues with the mock for the below cases so will not pass
-		// {
-		// 	name:           "Invalid location",
-		// 	location:       "Invalid",
-		// 	baseURL:        "http://example.com",
-		// 	mockError:      errors.New("location is not valid"),
-		// 	expectedErrMsg: "location is not valid",
-		// },
-		// {
-		// 	name:           "Empty base URL",
-		// 	location:       "New York",
-		// 	baseURL:        "",
-		// 	mockError:      errors.New("base URL is empty"),
-		// 	expectedErrMsg: "base URL is empty",
-		// },
+		{
+			name:           "Invalid location",
+			location:       "Invalid",
+			baseURL:        "http://example.com",
+			mockError:      errors.New("location is not valid"),
+			expectedErrMsg: "location is not valid",
+		},
+		{
+			name:           "Empty base URL",
+			location:       "New York",
+			baseURL:        "",
+			mockError:      errors.New("base URL is empty"),
+			expectedErrMsg: "base URL is empty",
+		},
 	}
 
 	for _, tt := range tests {

--- a/functions/gateway/test_helpers/mocks.go
+++ b/functions/gateway/test_helpers/mocks.go
@@ -93,7 +93,7 @@ func (m *MockGeoService) GetGeo(location, baseUrl string) (string, string, strin
 	if m.GetGeoFunc != nil {
 		return m.GetGeoFunc(location, baseUrl)
 	}
-	return "", "", "", fmt.Errorf("no mock function provided")
+	return "40.7128", "-74.0060", "New York, NY 10001, USA", nil
 }
 
 // MochSeshuService mocks the UpdateSeshuSession function

--- a/functions/gateway/test_helpers/mocks.go
+++ b/functions/gateway/test_helpers/mocks.go
@@ -90,7 +90,10 @@ type MockGeoService struct {
 }
 
 func (m *MockGeoService) GetGeo(location, baseUrl string) (string, string, string, error) {
-	return "40.7128", "-74.0060", "New York, NY 10001, USA", nil
+	if m.GetGeoFunc != nil {
+		return m.GetGeoFunc(location, baseUrl)
+	}
+	return "", "", "", fmt.Errorf("no mock function provided")
 }
 
 // MochSeshuService mocks the UpdateSeshuSession function

--- a/functions/gateway/test_helpers/mocks_test.go
+++ b/functions/gateway/test_helpers/mocks_test.go
@@ -90,7 +90,12 @@ func TestMockDynamoDBClient_UpdateItem(t *testing.T) {
 }
 
 func TestMockGeoService_GetGeo(t *testing.T) {
-	mockGeoService := &MockGeoService{}
+
+	mockGeoService := &MockGeoService{
+		GetGeoFunc: func(location, baseUrl string) (string, string, string, error) {
+			return "40.7128", "-74.0060", "New York, NY 10001, USA", nil
+		},
+	}
 
 	lat, long, address, err := mockGeoService.GetGeo("New York", "http://example.com")
 	if err != nil {


### PR DESCRIPTION
I updated the MockGeoService to use custom GetGeoFunc behavior provided by each individual test instead of returning the same default data for all tests.

Previously:
- MockGeoService returned the same hardcoded values for all tests
- Only 1 test was passing because mock behavior couldn't be customized per test
- Test-specific mock values in geo_service_test.go were ignored/overridden by the defaults in mocks.go

Now:
- MockGeoService uses the GetGeoFunc field to execute custom behavior provided by each test
- All 3 tests are passing with mock values defined for each individual test. 
- If no custom behavior is specified, MockGeoService will still return the default mocked values (this prevents other tests like TestGeoLookup from breaking that were expecting these values) 
<img width="510" height="163" alt="image" src="https://github.com/user-attachments/assets/5eb0484b-a168-4195-b99b-01323f821ed1" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Fixed and uncommented broken test cases covering invalid locations and empty base URLs.
  * Added an injectable mock behavior for geo lookups to simulate success and failure scenarios.
  * Ensured deterministic geo test outputs for consistent, reliable results.
  * No changes to user-facing functionality or public APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->