### PR TITLE
Fix: Misc fixes

### DIFF
--- a/functions/gateway/handlers/partial_handlers.go
+++ b/functions/gateway/handlers/partial_handlers.go
@@ -845,10 +845,13 @@ func SubmitSeshuSession(w http.ResponseWriter, r *http.Request) http.HandlerFunc
 				}
 			}
 
-			locationTimezone := services.DeriveTimezoneFromCoordinates(session.LocationLatitude, session.LocationLongitude)
-			if locationTimezone == "" {
-				log.Println("Failed to derive timezone from coordinates for URL: ", normalizedUrl)
-				return
+			locationTimezone := ""
+			if session.LocationLatitude != 0 && session.LocationLongitude != 0 {
+				locationTimezone := services.DeriveTimezoneFromCoordinates(session.LocationLatitude, session.LocationLongitude)
+				if locationTimezone == "" {
+					log.Println("Failed to derive timezone from coordinates for URL: ", normalizedUrl)
+					return
+				}
 			}
 
 			seshuJob := internal_types.SeshuJob{

--- a/functions/gateway/handlers/seshusession_handlers.go
+++ b/functions/gateway/handlers/seshusession_handlers.go
@@ -130,11 +130,15 @@ func HandleSeshuSessionSubmit(w http.ResponseWriter, r *http.Request) http.Handl
 	// show the user 50 options and they get confused / overwhelmed
 	limit := 3
 	end := limit
-	if len(events) < end {
-		end = len(events)
+	eventsTruncated := []types.EventInfo{}
+	for i := 0; i < end; i++ {
+		eventsTruncated = append(eventsTruncated, events[i])
+		if i >= end {
+			break
+		}
 	}
 
-	tmpl := partials.EventCandidatesPartial(events)
+	tmpl := partials.EventCandidatesPartial(eventsTruncated)
 	var buf bytes.Buffer
 	if err := tmpl.Render(ctx, &buf); err != nil {
 		return transport.SendHtmlErrorPartial([]byte(err.Error()), http.StatusInternalServerError)

--- a/functions/gateway/services/nats_service.go
+++ b/functions/gateway/services/nats_service.go
@@ -269,6 +269,7 @@ func (s *NatsService) ConsumeMsg(ctx context.Context, workers int) error {
 			// TODO: Update the SeshuJob status and timestamps in database
 			// - Set LastScrapeSuccess to current timestamp
 			// - Update Status to "HEALTHY" if successful
+			// - Update to other status if not successful
 			// - Reset LastScrapeFailureCount to 0
 
 			log.Printf("Successfully processed scraping job for URL: %s", seshuJob.NormalizedUrlKey)

--- a/functions/gateway/services/scraping_service.go
+++ b/functions/gateway/services/scraping_service.go
@@ -606,6 +606,21 @@ func PushExtractedEventsToDB(events []types.EventInfo, seshuJob types.SeshuJob) 
 
 	currentTime := time.Now()
 
+	ownerName := ""
+	// fetch event owner from zitadel
+	owner, err := helpers.GetOtherUserByID(seshuJob.OwnerID)
+	if err != nil {
+		log.Printf("Failed to get event owner from zitadel: %v", err)
+		// Continue with default owner ID if zitadel lookup fails
+		owner = types.UserSearchResult{UserID: seshuJob.OwnerID}
+	}
+
+	if owner.DisplayName != "" {
+		ownerName = owner.DisplayName
+	} else {
+		ownerName = seshuJob.OwnerID
+	}
+
 	// Convert EventInfo to Event types for Weaviate
 	weaviateEvents := make([]RawEvent, 0, len(validEvents))
 	for i, eventInfo := range validEvents {
@@ -725,13 +740,6 @@ func PushExtractedEventsToDB(events []types.EventInfo, seshuJob types.SeshuJob) 
 			}
 		}
 
-		// fetch event owner from zitadel
-		owner, err := helpers.GetOtherUserByID(seshuJob.OwnerID)
-		if err != nil {
-			log.Printf("Failed to get event owner from zitadel: %v", err)
-			// Continue with default owner ID if zitadel lookup fails
-			owner = types.UserSearchResult{UserID: seshuJob.OwnerID}
-		}
 		// Convert EventInfo to RawEvent with JSON-friendly fields
 		// Build RFC3339 strings for times
 		startRFC3339 := startTime.In(tz).Format(time.RFC3339)
@@ -743,17 +751,12 @@ func PushExtractedEventsToDB(events []types.EventInfo, seshuJob types.SeshuJob) 
 			endVal = nil
 		}
 
-		ownerName := owner.DisplayName
-		if ownerName == "" {
-			ownerName = owner.UserID
-		}
-
 		tzString := tz.String()
 		eventSourceID := eventInfo.EventURL
 
 		event := RawEvent{
 			RawEventData: RawEventData{
-				EventOwners:     []string{owner.UserID},
+				EventOwners:     []string{seshuJob.OwnerID},
 				EventOwnerName:  ownerName,
 				EventSourceType: helpers.ES_SINGLE_EVENT,
 				Name:            eventInfo.EventTitle,
@@ -771,8 +774,6 @@ func PushExtractedEventsToDB(events []types.EventInfo, seshuJob types.SeshuJob) 
 	}
 
 	log.Printf("INFO: Successfully processed %d out of %d events for %s", len(weaviateEvents), len(validEvents), seshuJob.NormalizedUrlKey)
-
-	log.Printf("INFO: Weaviate events: %+v", weaviateEvents)
 
 	weaviateEventsStrict, _, err := BulkValidateEvents(weaviateEvents, false)
 	if err != nil {

--- a/functions/gateway/templates/components/navbar.templ
+++ b/functions/gateway/templates/components/navbar.templ
@@ -233,7 +233,7 @@ templ Navbar(userInfo helpers.UserInfo, subnavTabs []string, event types.Event, 
 			<div id="main-nav" class="navbar fixed z-50 top-0 w-full bg-base-100 bg-opacity-75 shadow-md mb-5">
 				<div class="container mx-auto flex items-center">
 					<div class="flex flex-1">
-						<a href="/" class="btn btn-ghost pl-2 text-xl flex flex-col bg-black">
+						<a href="/" class="btn btn-ghost pl-2 text-xl flex flex-col bg-black rounded-lg">
 							<img class="brand-logo" alt="Meet Near Me Logo: 4 faces laughing, looking inward at a location pin" src={ templ.EscapeString(os.Getenv("STATIC_BASE_URL") + "/assets/logo.svg") }/>
 							<img class="brand-type" alt="Meet Near Me" src={ templ.EscapeString(os.Getenv("STATIC_BASE_URL") + "/assets/logotype.svg") }/>
 						</a>

--- a/functions/gateway/templates/pages/event_details.templ
+++ b/functions/gateway/templates/pages/event_details.templ
@@ -175,8 +175,10 @@ templ EventDetailsPage(event types.Event, userInfo helpers.UserInfo, canEdit boo
 			}
 			<br/>
 			<p>
-				if event.EventOwnerName != "" {
+				if event.EventSourceId == "" && event.EventOwnerName != "" {
 					@IconLeftSection("Host", event.EventOwnerName, "community", `/?owners=`+event.EventOwners[0], "OWNER_NAME", event)
+				} else if event.EventSourceId != "" {
+					@IconLeftSection("Curator", event.EventSourceId, "community", `/?owners=`+event.EventOwners[0], "OWNER_NAME", event)
 				}
 				<br/>
 				@IconLeftSection("Venue", event.Address, "location", "/?address="+event.Address, "VENUE", event)

--- a/functions/gateway/templates/pages/home.templ
+++ b/functions/gateway/templates/pages/home.templ
@@ -451,6 +451,9 @@ templ HomePage(ctx context.Context, events []types.Event, pageUser *types.UserSe
 					<template x-if="$store.urlState.start_time">
 						<span>&nbsp;starting <strong x-text="$store.urlState.queryParamToReadableTime($store.urlState.start_time)"></strong></span>
 					</template>
+					<template x-if="$store.urlState.address">
+						<span>&nbsp;at location <strong x-text="$store.urlState.address"></strong></span>
+					</template>
 					&nbsp;
 					<button @click="document.getElementById('flyout-tab-filters').click(); document.getElementById('main-drawer').click();" class="btn btn-xs bg-base-300">Modify</button>
 				</div>

--- a/static/assets/global.css
+++ b/static/assets/global.css
@@ -256,9 +256,9 @@ body:has(.bottom-drawer) {
   transform: translate(100%, -50%);
 }
 
-.btn.btn-bold-outline {
+.btn.btn-bold-outline,
+.btn.btn-bold-outline:hover {
   border: 5px solid oklch(var(--p));
-  color: oklch(var(--pc)) !important;
 }
 
 .btn.btn-primary.btn-bg-inverted {


### PR DESCRIPTION
1. Location Timezone during SeshuJob onboarding was creating a `GMT/Etc` value, we want to skip this if we don't have `lat` and `lon` (indicating the users hasn't assigned a fallback location) 
2. Event candidate truncation logic was not working, fixed to limit of 3 
3. Fixed MAJOR risk by calling `GetOtherUserByID()` *before* events loop, reducing Zitadel usage by perhaps 10X 
4. Add `Curator` instead of host for seshu-ingested events 
5. Fix `address` query param to display in UI as a filter when active 
6. Fix "interested, can't make it" button text color