### PR TITLE
Missing timezone should be permitted in SeshuJob creation

### DIFF
--- a/functions/gateway/handlers/page_handlers.go
+++ b/functions/gateway/handlers/page_handlers.go
@@ -107,8 +107,8 @@ func GetSearchParamsFromReq(r *http.Request) (query string, userLocation []float
 	cfRay := GetCfRay(r)
 	rayCode := ""
 
-	cfLocationLat := services.InitialEmptyLatLong
-	cfLocationLon := services.InitialEmptyLatLong
+	cfLocationLat := helpers.INITIAL_EMPTY_LAT_LONG
+	cfLocationLon := helpers.INITIAL_EMPTY_LAT_LONG
 
 	if len(cfRay) > 2 {
 		rayCode = cfRay[len(cfRay)-3:]
@@ -125,13 +125,13 @@ func GetSearchParamsFromReq(r *http.Request) (query string, userLocation []float
 	if latStr != "" {
 		lat64, _ := strconv.ParseFloat(latStr, 32)
 		lat = float64(lat64)
-	} else if cfLocationLat != services.InitialEmptyLatLong {
+	} else if cfLocationLat != helpers.INITIAL_EMPTY_LAT_LONG {
 		lat = float64(cfLocationLat)
 	}
 	if longStr != "" {
 		long64, _ := strconv.ParseFloat(longStr, 32)
 		long = float64(long64)
-	} else if cfLocationLon != services.InitialEmptyLatLong {
+	} else if cfLocationLon != helpers.INITIAL_EMPTY_LAT_LONG {
 		long = float64(cfLocationLon)
 	}
 
@@ -149,7 +149,7 @@ func GetSearchParamsFromReq(r *http.Request) (query string, userLocation []float
 	// is not the initial empty value (can't use 0.0, a valid lat/lon) we assume
 	// cfLocation has given us a reasonable local guess
 
-	if radius < 0.0001 && (cfLocationLat != services.InitialEmptyLatLong && cfLocationLon != services.InitialEmptyLatLong ||
+	if radius < 0.0001 && (cfLocationLat != helpers.INITIAL_EMPTY_LAT_LONG && cfLocationLon != helpers.INITIAL_EMPTY_LAT_LONG ||
 		lat != US_GEO_DEFAULT_LAT && long != US_GEO_DEFAULT_LONG) {
 		radius = helpers.DEFAULT_SEARCH_RADIUS
 		// we still don't have lat/lon, which means we'll be using "geographic center of US"
@@ -489,8 +489,8 @@ func GetAddOrEditEventPage(w http.ResponseWriter, r *http.Request) http.HandlerF
 	cfRay := GetCfRay(r)
 	rayCode := ""
 	cfLocation := helpers.CdnLocation{}
-	cfLocationLat := services.InitialEmptyLatLong
-	cfLocationLon := services.InitialEmptyLatLong
+	cfLocationLat := helpers.INITIAL_EMPTY_LAT_LONG
+	cfLocationLon := helpers.INITIAL_EMPTY_LAT_LONG
 
 	if len(cfRay) > 2 {
 		rayCode = cfRay[len(cfRay)-3:]

--- a/functions/gateway/handlers/partial_handlers.go
+++ b/functions/gateway/handlers/partial_handlers.go
@@ -846,10 +846,6 @@ func SubmitSeshuSession(w http.ResponseWriter, r *http.Request) http.HandlerFunc
 			}
 
 			locationTimezone := services.DeriveTimezoneFromCoordinates(session.LocationLatitude, session.LocationLongitude)
-			if locationTimezone == "" {
-				log.Println("Failed to derive timezone from coordinates for URL: ", normalizedUrl)
-				return
-			}
 
 			seshuJob := internal_types.SeshuJob{
 				NormalizedUrlKey:         normalizedUrl,

--- a/functions/gateway/handlers/partial_handlers.go
+++ b/functions/gateway/handlers/partial_handlers.go
@@ -684,12 +684,12 @@ func SubmitSeshuSession(w http.ResponseWriter, r *http.Request) http.HandlerFunc
 		if jobAborted {
 			return
 		}
-		// check for valid latitude / longitude that is NOT equal to `services.InitialEmptyLatLong`
+		// check for valid latitude / longitude that is NOT equal to `helpers.INITIAL_EMPTY_LAT_LONG`
 		// which is an intentionally invalid placeholder
 
 		hasDefaultLat := false
 		latMatch, err := regexp.MatchString(services.LatitudeRegex, fmt.Sprint(session.LocationLatitude))
-		if session.LocationLatitude == services.InitialEmptyLatLong {
+		if session.LocationLatitude == helpers.INITIAL_EMPTY_LAT_LONG {
 			hasDefaultLat = false
 		} else if err != nil || !latMatch {
 			hasDefaultLat = true
@@ -697,9 +697,9 @@ func SubmitSeshuSession(w http.ResponseWriter, r *http.Request) http.HandlerFunc
 
 		hasDefaultLon := false
 		lonMatch, err := regexp.MatchString(services.LongitudeRegex, fmt.Sprint(session.LocationLongitude))
-		if session.LocationLongitude == services.InitialEmptyLatLong {
+		if session.LocationLongitude == helpers.INITIAL_EMPTY_LAT_LONG {
 			hasDefaultLon = false
-		} else if err != nil || !lonMatch || session.LocationLongitude == services.InitialEmptyLatLong {
+		} else if err != nil || !lonMatch || session.LocationLongitude == helpers.INITIAL_EMPTY_LAT_LONG {
 			hasDefaultLon = true
 		}
 

--- a/functions/gateway/handlers/seshusession_handlers.go
+++ b/functions/gateway/handlers/seshusession_handlers.go
@@ -194,8 +194,8 @@ func saveSession(ctx context.Context, htmlContent string, urlToScrape, childID, 
 			// zero is the `nil` value in dynamoDB for an undeclared `number` db field,
 			// when we create a new session, we can't allow it to be `0` because that is
 			// a valid value for both latitude and longitude (see "null island")
-			LocationLatitude:  services.InitialEmptyLatLong,
-			LocationLongitude: services.InitialEmptyLatLong,
+			LocationLatitude:  helpers.INITIAL_EMPTY_LAT_LONG,
+			LocationLongitude: helpers.INITIAL_EMPTY_LAT_LONG,
 			EventCandidates:   events,
 			CreatedAt:         now.Unix(),
 			UpdatedAt:         now.Unix(),

--- a/functions/gateway/helpers/constants.go
+++ b/functions/gateway/helpers/constants.go
@@ -60,6 +60,10 @@ const DEFAULT_MAX_RADIUS = 999999
 const DEFAULT_SEARCH_RADIUS = 500.0
 const DEFAULT_EXPANDED_SEARCH_RADIUS = 2500.0
 
+// INITIAL_EMPTY_LAT_LONG represents an intentionally invalid coordinate value
+// used to distinguish between missing location data and valid coordinates (including 0,0 "null island")
+const INITIAL_EMPTY_LAT_LONG = 9e+10
+
 // placeholder for unset end time, December 4th, 292,277,026,596 AD, at 20:10:55 UTC
 const DEFAULT_UNDEFINED_END_TIME = math.MaxInt64
 

--- a/functions/gateway/services/scraping_service.go
+++ b/functions/gateway/services/scraping_service.go
@@ -41,7 +41,13 @@ func DeriveTimezoneFromCoordinates(lat, lng float64) string {
 		return "" // tzf not available
 	}
 
+	// technically this is valid (null island) but we assume it's not intentional
 	if lat == 0 && lng == 0 {
+		return ""
+	}
+
+	// Check for our custom "empty" value
+	if lat == helpers.INITIAL_EMPTY_LAT_LONG || lng == helpers.INITIAL_EMPTY_LAT_LONG {
 		return ""
 	}
 
@@ -650,7 +656,7 @@ func PushExtractedEventsToDB(events []types.EventInfo, seshuJob types.SeshuJob) 
 
 		// Set latitude - use parsed value if available, otherwise fall back to seshuJob location
 		var finalLat float64
-		if lat == "" && seshuJob.LocationLatitude == 0 {
+		if lat == "" && (seshuJob.LocationLatitude == 0 || seshuJob.LocationLatitude == helpers.INITIAL_EMPTY_LAT_LONG) {
 			return fmt.Errorf("ERR: couldn't find latittude for event #%d of %s", i+1, seshuJob.NormalizedUrlKey)
 		} else if latFloat != 0 {
 			finalLat = latFloat
@@ -660,7 +666,7 @@ func PushExtractedEventsToDB(events []types.EventInfo, seshuJob types.SeshuJob) 
 
 		// Set longitude - use parsed value if available, otherwise fall back to seshuJob location
 		var finalLon float64
-		if lon == "" && seshuJob.LocationLongitude == 0 {
+		if lon == "" && (seshuJob.LocationLongitude == 0 || seshuJob.LocationLongitude == helpers.INITIAL_EMPTY_LAT_LONG) {
 			return fmt.Errorf("couldn't find longitude for event #%d of %s", i+1, seshuJob.NormalizedUrlKey)
 		} else if lonFloat != 0 {
 			finalLon = lonFloat

--- a/functions/gateway/services/seshu_service.go
+++ b/functions/gateway/services/seshu_service.go
@@ -33,8 +33,6 @@ const FakeStartTime2 = "Oct 10, 25:00am"
 const FakeEndTime1 = "Sep 26, 27:30pm"
 const FakeEndTime2 = "Oct 10, 26:00am"
 
-const InitialEmptyLatLong = 9e+10
-
 type ChildEventMeta struct {
 	EventTitle       string
 	EventURL         string
@@ -178,13 +176,13 @@ func UpdateSeshuSession(ctx context.Context, db internal_types.DynamoDBAPI, sesh
 		*input.UpdateExpression += " #urlQueryParams = :urlQueryParams,"
 	}
 
-	if seshuPayload.LocationLatitude != InitialEmptyLatLong {
+	if seshuPayload.LocationLatitude != helpers.INITIAL_EMPTY_LAT_LONG {
 		input.ExpressionAttributeNames["#locationLatitude"] = "locationLatitude"
 		input.ExpressionAttributeValues[":locationLatitude"] = &types.AttributeValueMemberN{Value: strconv.FormatFloat(seshuPayload.LocationLatitude, 'f', -1, 64)}
 		*input.UpdateExpression += " #locationLatitude = :locationLatitude,"
 	}
 
-	if seshuPayload.LocationLongitude != InitialEmptyLatLong {
+	if seshuPayload.LocationLongitude != helpers.INITIAL_EMPTY_LAT_LONG {
 		input.ExpressionAttributeNames["#locationLongitude"] = "locationLongitude"
 		input.ExpressionAttributeValues[":locationLongitude"] = &types.AttributeValueMemberN{Value: strconv.FormatFloat(seshuPayload.LocationLongitude, 'f', -1, 64)}
 		*input.UpdateExpression += " #locationLongitude = :locationLongitude,"

--- a/functions/gateway/templates/components/location_lookup.templ
+++ b/functions/gateway/templates/components/location_lookup.templ
@@ -2,7 +2,7 @@ package components
 
 import (
 	"fmt"
-	"github.com/meetnearme/api/functions/gateway/services"
+	"github.com/meetnearme/api/functions/gateway/helpers"
 	"github.com/meetnearme/api/functions/gateway/templates/partials"
 	"os"
 )
@@ -108,7 +108,7 @@ templ LocationLookupPartial(hxMethod string, hxApiPath string, hxAfterReqStr str
 		</template>
 		@partials.GeoLookup(lat, lon, address, "form-hidden")
 	</form>
-	<script id="location-lookup" data-google-api-key={ os.Getenv("GOOGLE_API_KEY") } data-event-address={ address } data-event-lat={ fmt.Sprintf("%.6f", lat) } data-event-lon={ fmt.Sprintf("%.6f", lon) } data-cf-lat={ fmt.Sprintf("%.6f", cfLocationLat) } data-cf-lon={ fmt.Sprintf("%.6f", cfLocationLon) } data-lat-lon-unknown={ fmt.Sprintf("%.6f", services.InitialEmptyLatLong) }>
+	<script id="location-lookup" data-google-api-key={ os.Getenv("GOOGLE_API_KEY") } data-event-address={ address } data-event-lat={ fmt.Sprintf("%.6f", lat) } data-event-lon={ fmt.Sprintf("%.6f", lon) } data-cf-lat={ fmt.Sprintf("%.6f", cfLocationLat) } data-cf-lon={ fmt.Sprintf("%.6f", cfLocationLon) } data-lat-lon-unknown={ fmt.Sprintf("%.6f", helpers.INITIAL_EMPTY_LAT_LONG) }>
 		function getLocationLookupState() {
 			return {
 				cfLocationLat: document.querySelector('#location-lookup').getAttribute('data-cf-lat') ?? 0,

--- a/functions/gateway/templates/components/location_lookup_templ_test.go
+++ b/functions/gateway/templates/components/location_lookup_templ_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/meetnearme/api/functions/gateway/services"
+	"github.com/meetnearme/api/functions/gateway/helpers"
 )
 
 func TestLocationLookupPartial(t *testing.T) {
@@ -41,8 +41,8 @@ func TestLocationLookupPartial(t *testing.T) {
 			lat:            0,
 			lon:            0,
 			address:        "",
-			cfLocationLat:  services.InitialEmptyLatLong,
-			cfLocationLon:  services.InitialEmptyLatLong,
+			cfLocationLat:  helpers.INITIAL_EMPTY_LAT_LONG,
+			cfLocationLon:  helpers.INITIAL_EMPTY_LAT_LONG,
 			expectedContent: []string{
 				"hx-post=\"/api/location/geo\"",
 				"hx-target=\"#location-confirmation\"",

--- a/functions/gateway/templates/pages/event_add_edit_templ_test.go
+++ b/functions/gateway/templates/pages/event_add_edit_templ_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/meetnearme/api/functions/gateway/helpers"
-	"github.com/meetnearme/api/functions/gateway/services"
 	"github.com/meetnearme/api/functions/gateway/types"
 )
 
@@ -37,8 +36,8 @@ func TestAddOrEditEventPage(t *testing.T) {
 			isEditor:           false,
 			isCompetitionAdmin: false,
 			sitePage:           helpers.SitePages["add-event"],
-			cfLat:              services.InitialEmptyLatLong,
-			cfLon:              services.InitialEmptyLatLong,
+			cfLat:              helpers.INITIAL_EMPTY_LAT_LONG,
+			cfLon:              helpers.INITIAL_EMPTY_LAT_LONG,
 			expected: []string{
 				"Event Name",
 				"Description",

--- a/functions/gateway/test_helpers/mocks.go
+++ b/functions/gateway/test_helpers/mocks.go
@@ -103,9 +103,11 @@ func (m *MockSeshuService) UpdateSeshuSession(ctx context.Context, db types.Dyna
 func (m *MockSeshuService) GetSeshuSession(ctx context.Context, db types.DynamoDBAPI, seshuPayload types.SeshuSessionGet) (*types.SeshuSession, error) {
 	// Return mock data
 	return &types.SeshuSession{
-		OwnerId: "mockOwner",
-		Url:     seshuPayload.Url,
-		Status:  "draft",
+		OwnerId:           "mockOwner",
+		Url:               seshuPayload.Url,
+		Status:            "draft",
+		LocationLatitude:  9e+10, // INITIAL_EMPTY_LAT_LONG
+		LocationLongitude: 9e+10, // INITIAL_EMPTY_LAT_LONG
 		EventValidations: []types.EventBoolValid{
 			{
 				EventValidateTitle:       true,
@@ -123,9 +125,11 @@ func (m *MockSeshuService) GetSeshuSession(ctx context.Context, db types.DynamoD
 func (m *MockSeshuService) InsertSeshuSession(ctx context.Context, db types.DynamoDBAPI, seshuPayload types.SeshuSessionInput) (*types.SeshuSessionInsert, error) {
 	// Return mock data
 	return &types.SeshuSessionInsert{
-		OwnerId: seshuPayload.OwnerId,
-		Url:     seshuPayload.Url,
-		Status:  "draft",
+		OwnerId:           seshuPayload.OwnerId,
+		Url:               seshuPayload.Url,
+		Status:            "draft",
+		LocationLatitude:  seshuPayload.LocationLatitude,
+		LocationLongitude: seshuPayload.LocationLongitude,
 		// Fill in other fields as needed
 	}, nil
 }


### PR DESCRIPTION
Should save `""` empty string for `SeshuJob.LocationTimezone` if `lat` and `lon` are missing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Submissions no longer abort when a timezone can't be derived from location coordinates; processing continues to validation and persistence, reducing premature failures.

- **New Features**
  - Improved backend content retrieval to enhance scraping reliability and retries for external pages.

- **Data/Location Handling**
  - Unified handling of "missing" coordinates so empty location values are consistently detected, avoiding misinterpretation of valid 0,0 coordinates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->