### PR TITLE
Feat: Locate Me and City Lookup Endpoint 

### DIFF
--- a/functions/gateway/handlers/partial_handlers.go
+++ b/functions/gateway/handlers/partial_handlers.go
@@ -302,27 +302,22 @@ func CityLookup(w http.ResponseWriter, r *http.Request) http.HandlerFunc {
 	location := r.URL.Query().Get("location")
 	latAndLonAreValid := true
 	if location != "" {
-		if strings.Contains(location, "+") && len(strings.Fields(location)) == 2 {
-			var latStr, lonStr string
+		var latStr, lonStr string
 
-			if strings.Contains(location, "+") {
-				parts := strings.Split(location, "+")
-				if len(parts) == 2 {
-					latStr = parts[0]
-					lonStr = parts[1]
-				} else {
-					return transport.SendHtmlRes(w, []byte(`Location must be in the format "lat+lon"`), http.StatusBadRequest, "partial", nil)
-				}
+		if strings.Contains(location, "+") {
+			parts := strings.Split(location, "+")
+			if len(parts) == 2 {
+				latStr = parts[0]
+				lonStr = parts[1]
+			} else {
+				return transport.SendHtmlRes(w, []byte(`Location must be in the format "lat+lon"`), http.StatusBadRequest, "partial", nil)
 			}
+		}
 
-			// Validate latitude and longitude ranges using math
-			if latStr != "" && lonStr != "" {
-				if lat, err := strconv.ParseFloat(latStr, 64); err == nil {
-					if lon, err := strconv.ParseFloat(lonStr, 64); err == nil {
-						// Latitude: -90 to +90
-						// Longitude: -180 to +180
-						latAndLonAreValid = lat >= -90 && lat <= 90 && lon >= -180 && lon <= 180
-					}
+		if latStr != "" && lonStr != "" {
+			if lat, err := strconv.ParseFloat(latStr, 64); err == nil {
+				if lon, err := strconv.ParseFloat(lonStr, 64); err == nil {
+					latAndLonAreValid = lat >= -90 && lat <= 90 && lon >= -180 && lon <= 180
 				}
 			}
 		}
@@ -351,11 +346,10 @@ func CityLookup(w http.ResponseWriter, r *http.Request) http.HandlerFunc {
 		log.Println("CityLookup city:", city)
 	}
 
-	return transport.SendHtmlRes(w, response, status, "partial", nil)
-	// w.Header().Set("Content-Type", "application/json")
-	// w.WriteHeader(status)
-	// w.Write(response)
-	// return func(w http.ResponseWriter, r *http.Request) {}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	w.Write(response)
+	return func(w http.ResponseWriter, r *http.Request) {}
 }
 
 func GeoThenPatchSeshuSession(w http.ResponseWriter, r *http.Request) http.HandlerFunc {

--- a/functions/gateway/handlers/partial_handlers.go
+++ b/functions/gateway/handlers/partial_handlers.go
@@ -309,6 +309,7 @@ func CityLookup(w http.ResponseWriter, r *http.Request) http.HandlerFunc {
 				parts := strings.Split(location, "+")
 				if len(parts) == 2 {
 					latStr = parts[0]
+					lonStr = parts[1]
 				} else {
 					return transport.SendHtmlRes(w, []byte(`Location must be in the format "lat+lon"`), http.StatusBadRequest, "partial", nil)
 				}

--- a/functions/gateway/handlers/partial_handlers_test.go
+++ b/functions/gateway/handlers/partial_handlers_test.go
@@ -346,6 +346,98 @@ func TestGeoLookup(t *testing.T) {
 	}
 }
 
+func TestCityLookup(t *testing.T) {
+	// Initialize and setup environment
+	originalDeploymentTarget := os.Getenv("DEPLOYMENT_TARGET")
+	originalGoEnv := os.Getenv("GO_ENV")
+	defer func() {
+		os.Setenv("DEPLOYMENT_TARGET", originalDeploymentTarget)
+		os.Setenv("GO_ENV", originalGoEnv)
+		services.ResetCityService() // Reset service singleton
+	}()
+
+	// Set environment for test mode
+	os.Setenv("GO_ENV", "test")
+	os.Setenv("DEPLOYMENT_TARGET", helpers.ACT)
+
+	tests := []struct {
+		name           string
+		location       string
+		expectedStatus int
+		shouldContain  []string
+	}{
+		{
+			name:           "Successful lookup with valid coordinates",
+			location:       "40.7+-74.0",
+			expectedStatus: http.StatusOK,
+			shouldContain:  []string{"New York"}, // Mock cityService returns "New York"
+		},
+		{
+			name:           "Missing location parameter",
+			location:       "",
+			expectedStatus: http.StatusBadRequest,
+			shouldContain:  []string{"Location parameter is required"},
+		},
+		{
+			name:           "Invalid coordinates - latitude too high",
+			location:       "91.0+0.0",
+			expectedStatus: http.StatusBadRequest,
+			shouldContain:  []string{"Latitude and Longitude are invalid"},
+		},
+		{
+			name:           "Invalid coordinates - longitude too high",
+			location:       "0.0+181.0",
+			expectedStatus: http.StatusBadRequest,
+			shouldContain:  []string{"Latitude and Longitude are invalid"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Reset service for each test
+			services.ResetCityService()
+
+			// Create request with proper URL and query parameters
+			requestURL := "/api/location/city"
+			if tt.location != "" {
+				requestURL += "?location=" + url.QueryEscape(tt.location)
+			}
+
+			req := httptest.NewRequest("GET", requestURL, nil)
+			req.Header.Set("Host", "localhost:"+helpers.GO_ACT_SERVER_PORT)
+
+			// Add AWS Lambda context (required for transport layer)
+			ctx := context.WithValue(req.Context(), helpers.ApiGwV2ReqKey, events.APIGatewayV2HTTPRequest{
+				PathParameters: map[string]string{},
+			})
+			req = req.WithContext(ctx)
+
+			rr := httptest.NewRecorder()
+
+			// Execute handler
+			handler := CityLookup(rr, req)
+			handler(rr, req)
+
+			// Verify response
+			if rr.Code != tt.expectedStatus {
+				t.Errorf("Expected status %d, got %d", tt.expectedStatus, rr.Code)
+			}
+
+			// Log the response for debugging
+			t.Logf("Response status: %d", rr.Code)
+			t.Logf("Response body: %s", rr.Body.String())
+
+			// Check all required strings are present
+			responseBody := rr.Body.String()
+			for _, expectedStr := range tt.shouldContain {
+				if !strings.Contains(responseBody, expectedStr) {
+					t.Errorf("Expected response to contain '%s', got '%s'", expectedStr, responseBody)
+				}
+			}
+		})
+	}
+}
+
 func TestGetEventsPartial(t *testing.T) {
 	// Save original environment variables
 	originalWeaviateHost := os.Getenv("WEAVIATE_HOST")

--- a/functions/gateway/interfaces/service_interfaces.go
+++ b/functions/gateway/interfaces/service_interfaces.go
@@ -12,6 +12,10 @@ type GeoServiceInterface interface {
 	GetGeo(location, baseUrl string) (string, string, string, error)
 }
 
+type CityServiceInterface interface {
+	GetCity(location, baseUrl string) (string, error)
+}
+
 type SeshuServiceInterface interface {
 	GetSeshuSession(ctx context.Context, db types.DynamoDBAPI, seshuPayload types.SeshuSessionGet) (*types.SeshuSession, error)
 	InsertSeshuSession(ctx context.Context, db types.DynamoDBAPI, seshuPayload types.SeshuSessionInput) (*types.SeshuSessionInsert, error)

--- a/functions/gateway/main.go
+++ b/functions/gateway/main.go
@@ -112,6 +112,7 @@ func (app *App) InitRoutes() []Route {
 		// TODO: delete this comment once user location is implemented in profile,
 		// "/api/location/geo" is for use there
 		{"/api/location/geo{trailingslash:\\/?}", "POST", handlers.GeoLookup, None},
+		{"/api/location/geo{trailingslash:\\/?}", "GET", handlers.CityLookup, None},
 		{"/api/user-search{trailingslash:\\/?}", "GET", handlers.SearchUsersHandler, Require},
 		{"/api/users{trailingslash:\\/?}", "GET", handlers.GetUsersHandler, None},
 		{"/api/html/events{trailingslash:\\/?}", "GET", handlers.GetEventsPartial, None},

--- a/functions/gateway/main.go
+++ b/functions/gateway/main.go
@@ -112,7 +112,7 @@ func (app *App) InitRoutes() []Route {
 		// TODO: delete this comment once user location is implemented in profile,
 		// "/api/location/geo" is for use there
 		{"/api/location/geo{trailingslash:\\/?}", "POST", handlers.GeoLookup, None},
-		{"/api/location/geo{trailingslash:\\/?}", "GET", handlers.CityLookup, None},
+		{"/api/location/city{trailingslash:\\/?}", "GET", handlers.CityLookup, None},
 		{"/api/user-search{trailingslash:\\/?}", "GET", handlers.SearchUsersHandler, Require},
 		{"/api/users{trailingslash:\\/?}", "GET", handlers.GetUsersHandler, None},
 		{"/api/html/events{trailingslash:\\/?}", "GET", handlers.GetEventsPartial, None},

--- a/functions/gateway/services/city_service.go
+++ b/functions/gateway/services/city_service.go
@@ -16,7 +16,7 @@ func GetCity(location string, baseUrl string) (city string, err error) {
 }
 
 func (s *RealCityService) GetCity(location string, baseUrl string) (city string, err error) {
-	// TODO: this needs to be parameterized!
+
 	if baseUrl == "" {
 		return "", fmt.Errorf("base URL is empty")
 	}
@@ -27,7 +27,7 @@ func (s *RealCityService) GetCity(location string, baseUrl string) (city string,
 		return "", err
 	}
 
-	// this regex captures the city which appears after the string H8X2 X2R within a group
+	// this regex captures the city which appears after the string H8X2 X2R within a group denoted by () or []
 	re := regexp.MustCompile(`H8X2\+X2R\s+([^"]+)`)
 
 	matches := re.FindStringSubmatch(htmlString)

--- a/functions/gateway/services/city_service.go
+++ b/functions/gateway/services/city_service.go
@@ -1,0 +1,42 @@
+package services
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+
+	"github.com/meetnearme/api/functions/gateway/helpers"
+	"github.com/meetnearme/api/functions/gateway/types"
+)
+
+const ()
+
+func GetCity(location string, baseUrl string) (city string, err error) {
+	return GetCityService().GetCity(location, baseUrl)
+}
+
+func (s *RealCityService) GetCity(location string, baseUrl string) (city string, err error) {
+	// TODO: this needs to be parameterized!
+	if baseUrl == "" {
+		return "", fmt.Errorf("base URL is empty")
+	}
+	targetUrl := helpers.GEO_BASE_URL + "?address=" + location
+	log.Println("targetUrl", targetUrl)
+	htmlString, err := GetHTMLFromURL(types.SeshuJob{NormalizedUrlKey: targetUrl}, 0, true, "")
+	if err != nil {
+		return "", err
+	}
+
+	// this regex captures the city which appears after the string H8X2 X2R within a group
+	re := regexp.MustCompile(`H8X2\+X2R\s+([^"]+)`)
+
+	matches := re.FindStringSubmatch(htmlString)
+	if len(matches) < 2 {
+		return "", fmt.Errorf("location is not valid")
+	}
+
+	city = matches[1]
+	fmt.Printf(city)
+
+	return city, nil
+}

--- a/functions/gateway/services/city_service.go
+++ b/functions/gateway/services/city_service.go
@@ -4,12 +4,73 @@ import (
 	"fmt"
 	"log"
 	"regexp"
+	"strings"
 
 	"github.com/meetnearme/api/functions/gateway/helpers"
 	"github.com/meetnearme/api/functions/gateway/types"
 )
 
+// HTMLFetcher interface allows us to mock the HTML fetching behavior
+type CityHTMLFetcher interface {
+	GetHTMLFromURL(seshuJob types.SeshuJob, waitMs int, jsRender bool, waitFor string) (string, error)
+}
+
+// RealHTMLFetcher wraps the actual GetHTMLFromURL function
+type RealCityHTMLFetcher struct{}
+
+func (r *RealCityHTMLFetcher) GetHTMLFromURL(seshuJob types.SeshuJob, waitMs int, jsRender bool, waitFor string) (string, error) {
+	return GetHTMLFromURL(seshuJob, waitMs, jsRender, waitFor)
+}
+
 const ()
+
+// extractCityAndState extracts city and state from a full address
+// Examples:
+// "1st street New York, NY 10001, USA" -> "New York, NY"
+// "123 Main St, San Francisco, CA 94102, USA" -> "San Francisco, CA"
+// "Georgetown, TX" -> "Georgetown, TX"
+func extractCityAndState(fullAddress string) string {
+	// Split by commas to get address parts
+	parts := strings.Split(fullAddress, ",")
+
+	// If we have at least 2 parts, look for city, state pattern
+	if len(parts) >= 2 {
+		// Look for the pattern "City, State" in the middle parts
+		for i := 0; i < len(parts)-1; i++ {
+			cityPart := strings.TrimSpace(parts[i])
+			statePart := strings.TrimSpace(parts[i+1])
+
+			// Check if state part looks like a state (2-3 letters, possibly with zip)
+			stateRegex := regexp.MustCompile(`^[A-Z]{2,3}(\s+\d{5})?$`)
+			if stateRegex.MatchString(statePart) {
+				// Found city, state pattern
+				return cityPart + ", " + strings.Fields(statePart)[0] // Remove zip if present
+			}
+		}
+	}
+
+	// If no clear city, state pattern found, try to extract from the end
+	// Look for pattern like "City, State" at the end
+	if len(parts) >= 2 {
+		lastPart := strings.TrimSpace(parts[len(parts)-1])
+
+		// Check if last part is a country (USA, United States, etc.)
+		countryRegex := regexp.MustCompile(`(?i)^(usa|united states|us)$`)
+		if countryRegex.MatchString(lastPart) && len(parts) >= 3 {
+			// Look at the part before the country
+			statePart := strings.TrimSpace(parts[len(parts)-2])
+			cityPart := strings.TrimSpace(parts[len(parts)-3])
+
+			stateRegex := regexp.MustCompile(`^[A-Z]{2,3}(\s+\d{5})?$`)
+			if stateRegex.MatchString(statePart) {
+				return cityPart + ", " + strings.Fields(statePart)[0]
+			}
+		}
+	}
+
+	// Fallback: if we can't parse it properly, return the original address
+	return fullAddress
+}
 
 func GetCity(location string, baseUrl string) (city string, err error) {
 	return GetCityService().GetCity(location, baseUrl)
@@ -17,25 +78,61 @@ func GetCity(location string, baseUrl string) (city string, err error) {
 
 func (s *RealCityService) GetCity(location string, baseUrl string) (city string, err error) {
 
+	htmlFetcher := s.htmlFetcher
+	if htmlFetcher == nil {
+		htmlFetcher = &RealHTMLFetcher{}
+	}
+
 	if baseUrl == "" {
 		return "", fmt.Errorf("base URL is empty")
 	}
 	targetUrl := helpers.GEO_BASE_URL + "?address=" + location
 	log.Println("targetUrl", targetUrl)
-	htmlString, err := GetHTMLFromURL(types.SeshuJob{NormalizedUrlKey: targetUrl}, 0, true, "")
+	htmlString, err := htmlFetcher.GetHTMLFromURL(types.SeshuJob{NormalizedUrlKey: targetUrl}, 0, true, "")
 	if err != nil {
 		return "", err
 	}
 
 	// this regex captures the city which appears after the string H8X2 X2R within a group denoted by () or []
-	re := regexp.MustCompile(`H8X2\+X2R\s+([^"]+)`)
+	// re := regexp.MustCompile(`H8X2\+X2R\s+([^"]+)`)
 
-	matches := re.FindStringSubmatch(htmlString)
-	if len(matches) < 2 {
+	// matches := re.FindStringSubmatch(htmlString)
+	// fmt.Printf("matches are %#v", matches)
+	// if len(matches) < 1 {
+	// 	return "", fmt.Errorf("location is not valid")
+	// }
+
+	// this regex specifically captures the pattern of a lat/lon pair e.g. [40.7128, -74.0060]
+	re := regexp.MustCompile(`\[(\-?(?:[1-8]?\d(?:\.\d+)?|90(?:\.0+)?)),\s*(\-?(?:180(?:\.0+)?|(?:1[0-7]\d|[1-9]?\d)(?:\.\d+)?))\]`)
+
+	coordMatches := re.FindStringSubmatch(htmlString)
+	foundValidCoordinates := len(coordMatches) >= 3
+	if !foundValidCoordinates {
 		return "", fmt.Errorf("location is not valid")
 	}
 
-	city = matches[1]
+	lat := coordMatches[1]
+	lon := coordMatches[2]
+
+	// This regex captures the pattern of an address string that is wrapped in double quotes
+	// and followed by a lat/lon pair e.g. "123 Main St", [40.7128, -74.0060]
+	// Use (?s) flag to make . match newlines, and clean up whitespace in the captured address
+	pattern := `"((?s)[^"]*)"\s*,\s*\[\s*` + regexp.QuoteMeta(lat) + `\s*,\s*` + regexp.QuoteMeta(lon) + `\s*\]`
+	re = regexp.MustCompile(pattern)
+	addressMatches := re.FindStringSubmatch(htmlString) // can be a city or an actual address
+	if len(addressMatches) > 0 {
+		// Clean up the address by replacing newlines and extra whitespace with single spaces
+		fullAddress := strings.TrimSpace(strings.ReplaceAll(addressMatches[1], "\n", " "))
+		// Remove any multiple consecutive spaces
+		fullAddress = regexp.MustCompile(`\s+`).ReplaceAllString(fullAddress, " ")
+
+		// Extract city and state from the full address
+		city = extractCityAndState(fullAddress)
+	} else {
+		city = "No address found"
+	}
+
+	//city = matches[1]
 	fmt.Print(city)
 
 	return city, nil

--- a/functions/gateway/services/city_service.go
+++ b/functions/gateway/services/city_service.go
@@ -36,7 +36,7 @@ func (s *RealCityService) GetCity(location string, baseUrl string) (city string,
 	}
 
 	city = matches[1]
-	fmt.Printf(city)
+	fmt.Print(city)
 
 	return city, nil
 }

--- a/functions/gateway/services/city_service.go
+++ b/functions/gateway/services/city_service.go
@@ -24,11 +24,11 @@ func (r *RealCityHTMLFetcher) GetHTMLFromURL(seshuJob types.SeshuJob, waitMs int
 
 const ()
 
-func GetCity(location string, baseUrl string) (city string, err error) {
-	return GetCityService().GetCity(location, baseUrl)
+func GetCity(locationQuery string, baseUrl string) (city string, err error) {
+	return GetCityService().GetCity(locationQuery, baseUrl)
 }
 
-func (s *RealCityService) GetCity(location string, baseUrl string) (city string, err error) {
+func (s *RealCityService) GetCity(locationQuery string, baseUrl string) (city string, err error) {
 
 	htmlFetcher := s.htmlFetcher
 	if htmlFetcher == nil {
@@ -38,7 +38,7 @@ func (s *RealCityService) GetCity(location string, baseUrl string) (city string,
 	if baseUrl == "" {
 		return "", fmt.Errorf("base URL is empty")
 	}
-	targetUrl := helpers.GEO_BASE_URL + "?address=" + location
+	targetUrl := helpers.GEO_BASE_URL + "?address=" + locationQuery
 	log.Println("targetUrl", targetUrl)
 	htmlString, err := htmlFetcher.GetHTMLFromURL(types.SeshuJob{NormalizedUrlKey: targetUrl}, 0, true, "")
 	if err != nil {

--- a/functions/gateway/services/city_service_test.go
+++ b/functions/gateway/services/city_service_test.go
@@ -29,28 +29,13 @@ func TestGetCity(t *testing.T) {
 		expectedErrMsg string
 	}{
 		{
-			name:         "Valid location",
+			name:         "City Test 1",
 			location:     "New York",
 			baseURL:      "http://example.com",
-			expectedCity:
+			expectedCity: "New York",
+		},
+	}
 
-		// TODO: issues with the mock for the below cases so will not pass
-		// {
-		// 	name:           "Invalid location",
-		// 	location:       "Invalid",
-		// 	baseURL:        "http://example.com",
-		// 	mockError:      errors.New("location is not valid"),
-		// 	expectedErrMsg: "location is not valid",
-		// },
-		// {
-		// 	name:           "Empty base URL",
-		// 	location:       "New York",
-		// 	baseURL:        "",
-		// 	mockError:      errors.New("base URL is empty"),
-		// 	expectedErrMsg: "base URL is empty",
-		// },
-	//}
-	fmt.Printf("testing")
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ResetCityService()
@@ -67,7 +52,7 @@ func TestGetCity(t *testing.T) {
 						return "", fmt.Errorf("location is not valid")
 					}
 
-					return tt.mockLat, tt.mockLon, tt.mockAddress, nil
+					return "Hi", nil
 				},
 			}
 
@@ -77,8 +62,11 @@ func TestGetCity(t *testing.T) {
 			}
 
 			// Call the function we're testing
-			city err := GetCity(tt.location, tt.baseURL)
-
+			city, err := GetCity(tt.location, tt.baseURL)
+			fmt.Printf("city is %s and err is %v", city, err)
+			if 1 == 1 {
+				fmt.Print("Yay we pass!")
+			}
 			// // Check the results
 			// if tt.expectedErrMsg != "" {
 			// 	if err == nil || err.Error() != tt.expectedErrMsg {
@@ -99,6 +87,4 @@ func TestGetCity(t *testing.T) {
 			// }
 		})
 	}
-}
-}
 }

--- a/functions/gateway/services/city_service_test.go
+++ b/functions/gateway/services/city_service_test.go
@@ -85,7 +85,7 @@ func TestCityService(t *testing.T) {
 			expectedError: true,
 		},
 		{
-			name:          "invalid plus code",
+			name:          "invalid plus code", // The city always comes after a valid plus code
 			location:      "Invalid Location",
 			baseURL:       "https://example.com",
 			mockHTML:      `"JRQ+  TVW NotACity, HI"`,

--- a/functions/gateway/services/city_service_test.go
+++ b/functions/gateway/services/city_service_test.go
@@ -1,90 +1,146 @@
 package services
 
 import (
-	"fmt"
+	_ "embed"
+	"errors"
 	"os"
 	"testing"
 
-	"github.com/meetnearme/api/functions/gateway/helpers"
-	"github.com/meetnearme/api/functions/gateway/interfaces"
-	"github.com/meetnearme/api/functions/gateway/test_helpers"
+	"github.com/meetnearme/api/functions/gateway/types"
 )
 
-func TestGetCity(t *testing.T) {
-	// Save the original environment variable
+//go:embed geo_service_test_mock_html1.html
+var cityMockHTML1 string
+
+//go:embed geo_service_test_mock_html2.html
+var cityMockHTML2 string
+
+type cityMockHTMLFetcher struct {
+	HTMLResponse string
+	Error        error
+}
+
+func (m *cityMockHTMLFetcher) GetHTMLFromURL(seshuJob types.SeshuJob, waitMs int, jsRender bool, waitFor string) (string, error) {
+	return m.HTMLResponse, m.Error
+}
+
+func TestCityService(t *testing.T) {
 	origEnv := os.Getenv("GO_ENV")
-
-	// Set the environment to "test"
-	os.Setenv("GO_ENV", helpers.GO_TEST_ENV)
-
-	// Ensure we reset the environment after the test
 	defer os.Setenv("GO_ENV", origEnv)
+	os.Setenv("GO_ENV", "test")
 
 	tests := []struct {
-		name           string
-		location       string
-		baseURL        string
-		mockError      error
-		expectedCity   string
-		expectedErrMsg string
+		name          string
+		location      string
+		baseURL       string
+		mockHTML      string
+		mockError     error
+		expectedCity  string
+		expectedError bool
 	}{
 		{
-			name:         "City Test 1",
-			location:     "New York",
-			baseURL:      "http://example.com",
-			expectedCity: "New York",
+			name:          "successful geocoding with city only",
+			location:      "Georgetown, TX", // I manually copied the html using this location
+			baseURL:       "https://example.com",
+			mockHTML:      cityMockHTML1,
+			mockError:     nil,
+			expectedCity:  "Georgetown, TX",
+			expectedError: false,
+		},
+		{
+			name:          "successful geocoding with full address",
+			location:      "3400 Wolf Ranch Pkwy, Georgetown, Texas", // I manually copied the html using this location
+			baseURL:       "https://example.com",
+			mockHTML:      cityMockHTML2,
+			mockError:     nil,
+			expectedCity:  "Georgetown, TX",
+			expectedError: false,
+		},
+		{
+			name:     "successful geocoding with newline in HTML",
+			location: "Doesntmatter, NY",
+			baseURL:  "https://example.com",
+			mockHTML: `random words "New York,
+			                  NY 10001, USA", [40.712800, -74.006000] random words []]`,
+			mockError:     nil,
+			expectedCity:  "New York, NY",
+			expectedError: false,
+		},
+		{
+			name:          "HTML fetch error",
+			location:      "Doesntmatter",
+			baseURL:       "https://example.com",
+			mockHTML:      "",
+			mockError:     errors.New("network error"),
+			expectedCity:  "",
+			expectedError: true,
+		},
+		{
+			name:          "invalid HTML format - no coordinates",
+			location:      "Invalid Location",
+			baseURL:       "https://example.com",
+			mockHTML:      `"Some text without coordinates"`,
+			mockError:     nil,
+			expectedCity:  "",
+			expectedError: true,
+		},
+		{
+			name:          "valid coordinates but no address",
+			location:      "Doesntmatter",
+			baseURL:       "https://example.com",
+			mockHTML:      `[40.712800, -74.006000]`,
+			mockError:     nil,
+			expectedCity:  "",
+			expectedError: true,
+		},
+		{
+			name:          "out of bounds longitude is not captured",
+			location:      "Doesntmatter",
+			baseURL:       "https://example.com",
+			mockHTML:      `[40.7, 181.006000]`,
+			mockError:     nil,
+			expectedCity:  "",
+			expectedError: true,
+		},
+		{
+			name:          "empty base URL",
+			location:      "Doesntmatter",
+			baseURL:       "",
+			mockHTML:      "",
+			mockError:     nil,
+			expectedCity:  "",
+			expectedError: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ResetCityService()
-			// Set up the mock
-			mockCityService := &test_helpers.MockCityService{
-				GetCityFunc: func(location, baseUrl string) (string, error) {
-					// check for empty base URL first
-					if baseUrl == "" {
-						return "", fmt.Errorf("base URL is empty")
-					}
-
-					// Then check for invalid location
-					if location == "Invalid" {
-						return "", fmt.Errorf("location is not valid")
-					}
-
-					return "Hi", nil
-				},
+			mockFetcher := &cityMockHTMLFetcher{
+				HTMLResponse: tt.mockHTML,
+				Error:        tt.mockError,
 			}
 
-			// Override the getMockGeoService function
-			getMockCityService = func() interfaces.CityServiceInterface {
-				return mockCityService
+			service := &RealCityService{
+				htmlFetcher: mockFetcher,
 			}
 
-			// Call the function we're testing
-			city, err := GetCity(tt.location, tt.baseURL)
-			fmt.Printf("city is %s and err is %v", city, err)
-			if 1 == 1 {
-				fmt.Print("Yay we pass!")
+			city, err := service.GetCity(tt.location, tt.baseURL)
+
+			if tt.expectedError {
+				if err == nil {
+					t.Errorf("Expected error but got none")
+				}
+				return
 			}
-			// // Check the results
-			// if tt.expectedErrMsg != "" {
-			// 	if err == nil || err.Error() != tt.expectedErrMsg {
-			// 		t.Errorf("Expected error '%s', got '%v'", tt.expectedErrMsg, err)
-			// 	}
-			// } else if err != nil {
-			// 	t.Errorf("Unexpected error: %v", err)
-			// } else {
-			// 	if lat != tt.expectedLat {
-			// 		t.Errorf("Expected lat %s, got %s", tt.expectedLat, lat)
-			// 	}
-			// 	if lon != tt.expectedLon {
-			// 		t.Errorf("Expected lon %s, got %s", tt.expectedLon, lon)
-			// 	}
-			// 	if addr != tt.expectedAddr {
-			// 		t.Errorf("Expected address '%s', got '%s'", tt.expectedAddr, addr)
-			// 	}
-			// }
+
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+				return
+			}
+
+			if city != tt.expectedCity {
+				t.Errorf("Expected %s, got %s", tt.expectedCity, city)
+			}
 		})
 	}
 }

--- a/functions/gateway/services/city_service_test.go
+++ b/functions/gateway/services/city_service_test.go
@@ -9,10 +9,10 @@ import (
 	"github.com/meetnearme/api/functions/gateway/types"
 )
 
-//go:embed geo_service_test_mock_html1.html
+//go:embed city_service_test_mock_html1.html
 var cityMockHTML1 string
 
-//go:embed geo_service_test_mock_html2.html
+//go:embed city_service_test_mock_html2.html
 var cityMockHTML2 string
 
 type cityMockHTMLFetcher struct {
@@ -39,31 +39,40 @@ func TestCityService(t *testing.T) {
 		expectedError bool
 	}{
 		{
-			name:          "successful geocoding with city only",
-			location:      "Georgetown, TX", // I manually copied the html using this location
+			name:          "lat+lon in Georgetown, TX",
+			location:      "30.631799878085577+-97.70332501413287", // I manually copied the html using this location
 			baseURL:       "https://example.com",
 			mockHTML:      cityMockHTML1,
 			mockError:     nil,
-			expectedCity:  "Georgetown, TX",
+			expectedCity:  "Georgetown, Texas",
 			expectedError: false,
 		},
 		{
-			name:          "successful geocoding with full address",
-			location:      "3400 Wolf Ranch Pkwy, Georgetown, Texas", // I manually copied the html using this location
+			name:          "lat+lon in Badr, Egypt",
+			location:      "30.6317+30.703325", // I manually copied the html using this location
 			baseURL:       "https://example.com",
 			mockHTML:      cityMockHTML2,
 			mockError:     nil,
-			expectedCity:  "Georgetown, TX",
+			expectedCity:  "Badr, Egypt",
 			expectedError: false,
 		},
 		{
-			name:     "successful geocoding with newline in HTML",
-			location: "Doesntmatter, NY",
-			baseURL:  "https://example.com",
-			mockHTML: `random words "New York,
-			                  NY 10001, USA", [40.712800, -74.006000] random words []]`,
+			name:          "lat+lon in Mexico City, Mexico",
+			location:      "19.4326077+-99.133208", // I manually copied the html using this location
+			baseURL:       "https://example.com",
+			mockHTML:      `["76F2CVM8+2PV"],["CVM8+2PV Mexico City, Mexico"],1]]],null,null,null,`,
 			mockError:     nil,
-			expectedCity:  "New York, NY",
+			expectedCity:  "Mexico City, Mexico",
+			expectedError: false,
+		},
+		{
+			name:     "lat+lon with newline and spaces and two word city",
+			location: "",
+			baseURL:  "https://example.com",
+			mockHTML: `XXFC+MF Copperas Cove,
+										       Texas"]]],null,null`,
+			mockError:     nil,
+			expectedCity:  "Copperas Cove, Texas",
 			expectedError: false,
 		},
 		{
@@ -76,35 +85,26 @@ func TestCityService(t *testing.T) {
 			expectedError: true,
 		},
 		{
-			name:          "invalid HTML format - no coordinates",
+			name:          "invalid plus code",
 			location:      "Invalid Location",
 			baseURL:       "https://example.com",
-			mockHTML:      `"Some text without coordinates"`,
+			mockHTML:      `"JRQ+  TVW NotACity, HI"`,
 			mockError:     nil,
 			expectedCity:  "",
 			expectedError: true,
 		},
 		{
-			name:          "valid coordinates but no address",
-			location:      "Doesntmatter",
+			name:          "Invalid lat+lon",
+			location:      "",
 			baseURL:       "https://example.com",
-			mockHTML:      `[40.712800, -74.006000]`,
-			mockError:     nil,
-			expectedCity:  "",
-			expectedError: true,
-		},
-		{
-			name:          "out of bounds longitude is not captured",
-			location:      "Doesntmatter",
-			baseURL:       "https://example.com",
-			mockHTML:      `[40.7, 181.006000]`,
+			mockHTML:      `null,null,null,null,null,null,null,null,null,null,null,null,[[[120000000,0,0],null,null,13.10000038146973],null,0],null,null,null`,
 			mockError:     nil,
 			expectedCity:  "",
 			expectedError: true,
 		},
 		{
 			name:          "empty base URL",
-			location:      "Doesntmatter",
+			location:      "",
 			baseURL:       "",
 			mockHTML:      "",
 			mockError:     nil,
@@ -139,7 +139,7 @@ func TestCityService(t *testing.T) {
 			}
 
 			if city != tt.expectedCity {
-				t.Errorf("Expected %s, got %s", tt.expectedCity, city)
+				t.Errorf("Expected %#v, got %#v", tt.expectedCity, city)
 			}
 		})
 	}

--- a/functions/gateway/services/city_service_test.go
+++ b/functions/gateway/services/city_service_test.go
@@ -1,0 +1,104 @@
+package services
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/meetnearme/api/functions/gateway/helpers"
+	"github.com/meetnearme/api/functions/gateway/interfaces"
+	"github.com/meetnearme/api/functions/gateway/test_helpers"
+)
+
+func TestGetCity(t *testing.T) {
+	// Save the original environment variable
+	origEnv := os.Getenv("GO_ENV")
+
+	// Set the environment to "test"
+	os.Setenv("GO_ENV", helpers.GO_TEST_ENV)
+
+	// Ensure we reset the environment after the test
+	defer os.Setenv("GO_ENV", origEnv)
+
+	tests := []struct {
+		name           string
+		location       string
+		baseURL        string
+		mockError      error
+		expectedCity   string
+		expectedErrMsg string
+	}{
+		{
+			name:         "Valid location",
+			location:     "New York",
+			baseURL:      "http://example.com",
+			expectedCity:
+
+		// TODO: issues with the mock for the below cases so will not pass
+		// {
+		// 	name:           "Invalid location",
+		// 	location:       "Invalid",
+		// 	baseURL:        "http://example.com",
+		// 	mockError:      errors.New("location is not valid"),
+		// 	expectedErrMsg: "location is not valid",
+		// },
+		// {
+		// 	name:           "Empty base URL",
+		// 	location:       "New York",
+		// 	baseURL:        "",
+		// 	mockError:      errors.New("base URL is empty"),
+		// 	expectedErrMsg: "base URL is empty",
+		// },
+	//}
+	fmt.Printf("testing")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ResetCityService()
+			// Set up the mock
+			mockCityService := &test_helpers.MockCityService{
+				GetCityFunc: func(location, baseUrl string) (string, error) {
+					// check for empty base URL first
+					if baseUrl == "" {
+						return "", fmt.Errorf("base URL is empty")
+					}
+
+					// Then check for invalid location
+					if location == "Invalid" {
+						return "", fmt.Errorf("location is not valid")
+					}
+
+					return tt.mockLat, tt.mockLon, tt.mockAddress, nil
+				},
+			}
+
+			// Override the getMockGeoService function
+			getMockCityService = func() interfaces.CityServiceInterface {
+				return mockCityService
+			}
+
+			// Call the function we're testing
+			city err := GetCity(tt.location, tt.baseURL)
+
+			// // Check the results
+			// if tt.expectedErrMsg != "" {
+			// 	if err == nil || err.Error() != tt.expectedErrMsg {
+			// 		t.Errorf("Expected error '%s', got '%v'", tt.expectedErrMsg, err)
+			// 	}
+			// } else if err != nil {
+			// 	t.Errorf("Unexpected error: %v", err)
+			// } else {
+			// 	if lat != tt.expectedLat {
+			// 		t.Errorf("Expected lat %s, got %s", tt.expectedLat, lat)
+			// 	}
+			// 	if lon != tt.expectedLon {
+			// 		t.Errorf("Expected lon %s, got %s", tt.expectedLon, lon)
+			// 	}
+			// 	if addr != tt.expectedAddr {
+			// 		t.Errorf("Expected address '%s', got '%s'", tt.expectedAddr, addr)
+			// 	}
+			// }
+		})
+	}
+}
+}
+}

--- a/functions/gateway/services/city_service_test_mock_html1.html
+++ b/functions/gateway/services/city_service_test_mock_html1.html
@@ -1,0 +1,5 @@
+ull,[[[3433.076456955112,-97.70332499999999,30.6317999],[0,0,0],null,13.10000038146973],null,0,[[null,"30°37'54.5\"N
+97°42'12.0\"W",[30.6317999,-97.70332499999999]],"30°37'54.5\"N 97°42'12.0\"W",["30.631800,
+-97.703325"],null,null,null,null,null,null,null,null,null,null,"J7JW+PM7 Georgetown,
+Texas",null,null,null,null,null,null,null,null,null,1,null,null,null,null,null,null,"0ahUKEwiQ27SOj-WPAxX8MtAFHQWHIcYQ8BcIAygA",null,null,null,null,null,null,null,["0ahUKEwiQ27SOj-WPAxX8MtAFHQWHIcYQqtMBCAcoAw",["8624J7JW+PM7"],["J7JW+PM7
+Georgetown, Texas"],1]]],null,null,null,0,null,null,null,null,null,null,[1]]);

--- a/functions/gateway/services/city_service_test_mock_html2.html
+++ b/functions/gateway/services/city_service_test_mock_html2.html
@@ -1,0 +1,12 @@
+function onEmbedLoad() {
+initEmbed([null,null,null,null,null,[[[2,"spotlit",null,null,null,null,null,[null,null,null,null,null,null,null,null,null,null,11,null,[null,null,null,null,null,null,null,null,null,null,null,null,null,1]]]],null,null,[[null,null,null,null,null,null,null,null,null,null,null,null,null,[[["0","17168596847005355893"],"/fake_latlng_mid",null,[306317999,307033250],null,null,null,1],0,null,null,null,0,null,0]]]],null,["en_US"],[null,null,null,"/maps/api/js/ApplicationService.GetEntityDetails","/maps/embed/upgrade204",null,"/maps/embed/record204"],null,null,null,null,null,null,null,null,"143NaJyyFsPmwN4Pkfq0uAs",null,null,null,[[[3433.076456955112,30.70332499999999,30.6317999],[0,0,0],null,13.10000038146973],null,0,[[null,"30°37'54.5\"N
+30°42'12.0\"E",[30.6317999,30.703325]],"30°37'54.5\"N 30°42'12.0\"E",["30.631800,
+30.703325"],null,null,null,null,null,null,null,null,null,null,"JPJ3+P88 Badr,
+Egypt",null,null,null,null,null,null,null,null,null,1,null,null,null,null,null,null,"0ahUKEwjc-c2MqOWPAxVDM9AFHRE9DbcQ8BcIAygA",null,null,null,null,null,null,null,["0ahUKEwjc-c2MqOWPAxVDM9AFHRE9DbcQqtMBCAcoAw",["8G2GJPJ3+P88"],["JPJ3+P88
+Badr, Egypt"],1]]],null,null,null,0,null,null,null,null,null,null,[1]]);
+}
+function onApiLoad() {
+var embed = document.createElement('script');
+embed.src = "https://maps.gstatic.com/maps-api-v3/embed/js/62/6d/init_embed.js";
+document.body.appendChild(embed);
+}

--- a/functions/gateway/services/geo_service.go
+++ b/functions/gateway/services/geo_service.go
@@ -27,11 +27,11 @@ const (
 	LongitudeRegex = `^[-+]?((1[0-7]\d)|([1-9]?\d))(\.\d+)?$`
 )
 
-func GetGeo(location string, baseUrl string) (lat string, lon string, address string, err error) {
-	return GetGeoService().GetGeo(location, baseUrl)
+func GetGeo(locationQuery string, baseUrl string) (lat string, lon string, address string, err error) {
+	return GetGeoService().GetGeo(locationQuery, baseUrl)
 }
 
-func (s *RealGeoService) GetGeo(location string, baseUrl string) (lat string, lon string, address string, err error) {
+func (s *RealGeoService) GetGeo(locationQuery string, baseUrl string) (lat string, lon string, address string, err error) {
 
 	htmlFetcher := s.htmlFetcher
 	if htmlFetcher == nil {
@@ -41,12 +41,13 @@ func (s *RealGeoService) GetGeo(location string, baseUrl string) (lat string, lo
 	if baseUrl == "" {
 		return "", "", "", fmt.Errorf("base URL is empty")
 	}
-	targetUrl := helpers.GEO_BASE_URL + "?address=" + location
+	targetUrl := helpers.GEO_BASE_URL + "?address=" + locationQuery
 	log.Println("targetUrl", targetUrl)
 	// Log escaped for clarity (scraper will escape internally)
 	// escaped := url.QueryEscape(targetUrl)
 	// log.Println("targetUrl (escaped)", escaped)
 	htmlString, err := htmlFetcher.GetHTMLFromURL(types.SeshuJob{NormalizedUrlKey: targetUrl}, 0, true, "")
+	log.Printf("html string is %s", htmlString)
 	if err != nil {
 		return "", "", "", err
 	}

--- a/functions/gateway/services/mock_providers.go
+++ b/functions/gateway/services/mock_providers.go
@@ -6,9 +6,13 @@ import (
 )
 
 var getMockGeoService = func() interfaces.GeoServiceInterface {
-    return  &test_helpers.MockGeoService{}
+	return &test_helpers.MockGeoService{}
+}
+
+var getMockCityService = func() interfaces.CityServiceInterface {
+	return &test_helpers.MockCityService{}
 }
 
 func getMockSeshuService() interfaces.SeshuServiceInterface {
-    return &test_helpers.MockSeshuService{}
+	return &test_helpers.MockSeshuService{}
 }

--- a/functions/gateway/services/service_providers.go
+++ b/functions/gateway/services/service_providers.go
@@ -13,6 +13,9 @@ var (
 	geoService     interfaces.GeoServiceInterface
 	geoServiceOnce sync.Once
 
+	cityService     interfaces.CityServiceInterface
+	cityServiceOnce sync.Once
+
 	seshuService     interfaces.SeshuServiceInterface
 	seshuServiceOnce sync.Once
 )
@@ -28,9 +31,25 @@ func GetGeoService() interfaces.GeoServiceInterface {
 	return geoService
 }
 
+func GetCityService() interfaces.CityServiceInterface {
+	cityServiceOnce.Do(func() {
+		if os.Getenv("GO_ENV") == "test" {
+			cityService = getMockCityService()
+		} else {
+			cityService = &RealCityService{}
+		}
+	})
+	return cityService
+}
+
 func ResetGeoService() {
 	geoService = nil
 	geoServiceOnce = sync.Once{}
+}
+
+func ResetCityService() {
+	cityService = nil
+	cityServiceOnce = sync.Once{}
 }
 
 func GetSeshuService() interfaces.SeshuServiceInterface {
@@ -45,6 +64,7 @@ func GetSeshuService() interfaces.SeshuServiceInterface {
 }
 
 type RealGeoService struct{}
+type RealCityService struct{}
 type RealSeshuService struct{}
 
 func (s *RealSeshuService) GetSeshuSession(ctx context.Context, db internal_types.DynamoDBAPI, seshuPayload internal_types.SeshuSessionGet) (*internal_types.SeshuSession, error) {

--- a/functions/gateway/services/service_providers.go
+++ b/functions/gateway/services/service_providers.go
@@ -66,6 +66,9 @@ func GetSeshuService() interfaces.SeshuServiceInterface {
 type RealGeoService struct {
 	htmlFetcher HTMLFetcher // Can be nil for production use
 }
+type RealCityService struct {
+	htmlFetcher HTMLFetcher // Can be nil for production use
+}
 type RealSeshuService struct{}
 
 func (s *RealSeshuService) GetSeshuSession(ctx context.Context, db internal_types.DynamoDBAPI, seshuPayload internal_types.SeshuSessionGet) (*internal_types.SeshuSession, error) {

--- a/functions/gateway/templates/components/navbar.templ
+++ b/functions/gateway/templates/components/navbar.templ
@@ -394,7 +394,7 @@ templ Navbar(userInfo helpers.UserInfo, subnavTabs []string, event types.Event, 
 								// @click function call is a global shared from home_details.templ
 								<button
 									type="submit"
-									class="btn btn-primary w-full sticky top-0 z-[10]"
+									class="btn btn-red-500 w-full sticky top-0 z-[10]"
 									@click.prevent="handleFilterSubmit"
 								>
 									Apply Filters
@@ -475,6 +475,16 @@ templ Navbar(userInfo helpers.UserInfo, subnavTabs []string, event types.Event, 
 											<ul class="flex max-h-44 flex-col overflow-y-auto">
 												<li class="hidden px-4 py-2 text-sm" x-ref="noResultsMessage">
 													<span>No matches found</span>
+												</li>
+												<li
+													class="px-4 py-2 text-sm cursor-pointer
+                        bg-primary hover:text-secondary
+                        focus-visible:bg-secondary
+                         focus-visible:outline-none"
+													tabindex="0"
+													role="button"
+												>
+													<span>Locate Me</span>
 												</li>
 												<template x-for="(item, index) in options" :key="index">
 													<li

--- a/functions/gateway/templates/components/navbar.templ
+++ b/functions/gateway/templates/components/navbar.templ
@@ -477,12 +477,12 @@ templ Navbar(userInfo helpers.UserInfo, subnavTabs []string, event types.Event, 
 													<span>No matches found</span>
 												</li>
 												<li
-													class="px-4 py-2 text-sm cursor-pointer
-                        bg-primary hover:text-secondary
-                        focus-visible:bg-secondary
-                         focus-visible:outline-none"
+													class="px-4 py-2 text-sm cursor-pointer bg-primary hover:text-secondary focus-visible:bg-secondary focus-visible:outline-none"
 													tabindex="0"
 													role="button"
+													@click="findAndSetLocation"
+													@keydown.enter="findAndSetLocation"
+													:id="'option-locateme'"
 												>
 													<span>Locate Me</span>
 												</li>

--- a/functions/gateway/templates/components/navbar.templ
+++ b/functions/gateway/templates/components/navbar.templ
@@ -404,6 +404,9 @@ templ Navbar(userInfo helpers.UserInfo, subnavTabs []string, event types.Event, 
 									<h3 class="text-xl my-3">
 										Location <span x-text="selectedOption?.label?.match?.(/^[0-9]|\-/)?.length > 0 ? '(Geocoordinates)' : '' "></span>
 									</h3>
+									<span x-show="true" class="text-error text-sm mb-2">
+										Location access was declined.
+									</span>
 									<div class="relative">
 										<!-- trigger button  -->
 										<button
@@ -484,7 +487,10 @@ templ Navbar(userInfo helpers.UserInfo, subnavTabs []string, event types.Event, 
 													@keydown.enter="findAndSetLocation"
 													:id="'option-locateme'"
 												>
-													<span>Locate Me</span>
+													<span class="flex gap-2">
+														@Icon("location")
+														Locate Me
+													</span>
 												</li>
 												<template x-for="(item, index) in options" :key="index">
 													<li

--- a/functions/gateway/templates/components/navbar.templ
+++ b/functions/gateway/templates/components/navbar.templ
@@ -404,7 +404,7 @@ templ Navbar(userInfo helpers.UserInfo, subnavTabs []string, event types.Event, 
 									<h3 class="text-xl my-3">
 										Location <span x-text="selectedOption?.label?.match?.(/^[0-9]|\-/)?.length > 0 ? '(Geocoordinates)' : '' "></span>
 									</h3>
-									<span x-show="true" class="text-error text-sm mb-2">
+									<span x-show="locationAccessDeclined" class="text-error text-sm mb-2">
 										Location access was declined.
 									</span>
 									<div class="relative">

--- a/functions/gateway/templates/pages/home.templ
+++ b/functions/gateway/templates/pages/home.templ
@@ -848,8 +848,17 @@ templ HomePage(ctx context.Context, events []types.Event, pageUser *types.UserSe
 
 				const success = async (position) => {
 					// call getGeo function here
+          // make this work with production server too
+          const response = await fetch("http://localhost:8000/api/location/city?location=30.6317+-97.7033")
+          const data = await response.json()
+          console.log("data is", data)
+          let city = "failed"
+          if (data.city) {
+            city = data.city;
+            console.log(city)
+          }
 					this.selectedOption = {
-						label: "Test City, Texas, US",
+						label: city,
 						latitude: position.coords.latitude.toFixed(6),
 						longitude: position.coords.longitude.toFixed(6),
 						value: "123456"

--- a/functions/gateway/templates/pages/home.templ
+++ b/functions/gateway/templates/pages/home.templ
@@ -835,8 +835,7 @@ templ HomePage(ctx context.Context, events []types.Event, pageUser *types.UserSe
 					}
 				},
 				setSelectedOption(option) {
-	this.selectedOption = option
-
+					this.selectedOption = option
 					this.isOpen = false
 					this.openedWithKeyboard = false
 					this.$refs.hiddenTextField.value = option.value
@@ -846,27 +845,28 @@ templ HomePage(ctx context.Context, events []types.Event, pageUser *types.UserSe
 
 				findAndSetLocation() {
 
-				const success = async (position) => {
-					// call getGeo function here
-          // make this work with production server too
-          const response = await fetch("http://localhost:8000/api/location/city?location=30.6317+-97.7033")
-          const data = await response.json()
-          console.log("data is", data)
-          let city = "failed"
+				const success = (position) => {
+					const latitude = position.coords.latitude.toFixed(3);
+					const longitude = position.coords.longitude.toFixed(3);
+					fetch(`/api/location/city?location=${latitude}+${longitude}`)
+					.then(response => response.json())
+					.then(data => {
           if (data.city) {
-            city = data.city;
-            console.log(city)
-          }
 					this.selectedOption = {
-						label: city,
-						latitude: position.coords.latitude.toFixed(6),
-						longitude: position.coords.longitude.toFixed(6),
-						value: "123456"
+						label: data.city,
+						latitude: latitude,
+						longitude: longitude,
 					}
-					console.log("Fake city with real lat and lon:", this.selectedOption);
+					}
+					})
+					.catch(error => {
+					// eslint-disable-next-line no-console
+					console.error("Error fetching city", error);
+				})
 				}
 
 				const error = (err) => {
+					// eslint-disable-next-line no-console
 					console.warn(`ERROR(${err.code}): ${err.message}`);
 				}
 

--- a/functions/gateway/templates/pages/home.templ
+++ b/functions/gateway/templates/pages/home.templ
@@ -832,7 +832,7 @@ templ HomePage(ctx context.Context, events []types.Event, pageUser *types.UserSe
 					}
 				},
 				setSelectedOption(option) {
-					this.selectedOption = option
+	this.selectedOption = option
 
 					this.isOpen = false
 					this.openedWithKeyboard = false
@@ -841,24 +841,27 @@ templ HomePage(ctx context.Context, events []types.Event, pageUser *types.UserSe
 					this.$dispatch('location-dropdown', { option: { ...option } })
 				},
 
-        findAndSetLocation() {
+				findAndSetLocation() {
 
-        const success = async (position) => {
-            this.selectedOption = {
-            label: "Test City, Texas, US",
-            latitude: position.coords.latitude,
-            longitude: position.coords.longitude,
-            value: "123456"
-          }
-          console.log("Fake city with real lat and lon:", this.selectedOption);
-        }
+				const success = async (position) => {
+					// call getGeo function here
+					this.selectedOption = {
+						label: "Test City, Texas, US",
+						latitude: position.coords.latitude.toFixed(6),
+						longitude: position.coords.longitude.toFixed(6),
+						value: "123456"
+					}
+					console.log("Fake city with real lat and lon:", this.selectedOption);
+				}
 
-        const error = (err) => {
-          console.warn(`ERROR(${err.code}): ${err.message}`);
-        }
+				const error = (err) => {
+					console.warn(`ERROR(${err.code}): ${err.message}`);
+				}
 
-        navigator.geolocation.getCurrentPosition(success, error);
-        },
+				navigator.geolocation.getCurrentPosition(success, error);
+				this.isOpen = false
+				this.openedWithKeyboard = false
+				},
 
 				getFilteredOptions(query) {
 					this.options = this.allOptions.filter((option) =>

--- a/functions/gateway/templates/pages/home.templ
+++ b/functions/gateway/templates/pages/home.templ
@@ -840,6 +840,26 @@ templ HomePage(ctx context.Context, events []types.Event, pageUser *types.UserSe
 					// Update lat and lon in the parent component
 					this.$dispatch('location-dropdown', { option: { ...option } })
 				},
+
+        findAndSetLocation() {
+
+        const success = async (position) => {
+            this.selectedOption = {
+            label: "Test City, Texas, US",
+            latitude: position.coords.latitude,
+            longitude: position.coords.longitude,
+            value: "123456"
+          }
+          console.log("Fake city with real lat and lon:", this.selectedOption);
+        }
+
+        const error = (err) => {
+          console.warn(`ERROR(${err.code}): ${err.message}`);
+        }
+
+        navigator.geolocation.getCurrentPosition(success, error);
+        },
+
 				getFilteredOptions(query) {
 					this.options = this.allOptions.filter((option) =>
 						option.label.toLowerCase().includes(query.toLowerCase()),

--- a/functions/gateway/templates/pages/home.templ
+++ b/functions/gateway/templates/pages/home.templ
@@ -843,9 +843,12 @@ templ HomePage(ctx context.Context, events []types.Event, pageUser *types.UserSe
 					this.$dispatch('location-dropdown', { option: { ...option } })
 				},
 
+				locationAccessDeclined: false,
+
 				findAndSetLocation() {
 
 				const success = (position) => {
+					this.locationAccessDeclined = false;
 					const latitude = position.coords.latitude.toFixed(3);
 					const longitude = position.coords.longitude.toFixed(3);
 					fetch(`/api/location/city?location=${latitude}+${longitude}`)
@@ -857,17 +860,18 @@ templ HomePage(ctx context.Context, events []types.Event, pageUser *types.UserSe
 						latitude: latitude,
 						longitude: longitude,
 					}
+					Alpine.store('urlState').setParam('location', this.locationDropdown.label)
+          Alpine.store('location').setSelectedLocation(this.locationDropdown)
 					}
 					})
 					.catch(error => {
 					// eslint-disable-next-line no-console
-					console.error("Error fetching city", error);
+					console.error("Error fetching city:", error);
 				})
 				}
 
 				const error = (err) => {
-					// eslint-disable-next-line no-console
-					console.warn(`ERROR(${err.code}): ${err.message}`);
+					this.locationAccessDeclined = true
 				}
 
 				navigator.geolocation.getCurrentPosition(success, error);

--- a/functions/gateway/test_helpers/mocks.go
+++ b/functions/gateway/test_helpers/mocks.go
@@ -90,6 +90,9 @@ type MockGeoService struct {
 }
 
 func (m *MockGeoService) GetGeo(location, baseUrl string) (string, string, string, error) {
+	if m.GetGeoFunc != nil {
+		return m.GetGeoFunc(location, baseUrl)
+	}
 	return "40.7128", "-74.0060", "New York, NY 10001, USA", nil
 }
 
@@ -98,6 +101,9 @@ type MockCityService struct {
 }
 
 func (m *MockCityService) GetCity(location, baseUrl string) (string, error) {
+	if m.GetCityFunc != nil {
+		return m.GetCityFunc(location, baseUrl)
+	}
 	return "New York, NY 10001, USA", nil
 }
 

--- a/functions/gateway/test_helpers/mocks.go
+++ b/functions/gateway/test_helpers/mocks.go
@@ -90,9 +90,6 @@ type MockGeoService struct {
 }
 
 func (m *MockGeoService) GetGeo(location, baseUrl string) (string, string, string, error) {
-	if m.GetGeoFunc != nil {
-		return m.GetGeoFunc(location, baseUrl)
-	}
 	return "40.7128", "-74.0060", "New York, NY 10001, USA", nil
 }
 
@@ -101,10 +98,7 @@ type MockCityService struct {
 }
 
 func (m *MockCityService) GetCity(location, baseUrl string) (string, error) {
-	if m.GetCityFunc != nil {
-		return m.GetCityFunc(location, baseUrl)
-	}
-	return "New York, NY 10001, USA", nil
+	return "New York", nil
 }
 
 // MochSeshuService mocks the UpdateSeshuSession function

--- a/functions/gateway/test_helpers/mocks.go
+++ b/functions/gateway/test_helpers/mocks.go
@@ -93,6 +93,14 @@ func (m *MockGeoService) GetGeo(location, baseUrl string) (string, string, strin
 	return "40.7128", "-74.0060", "New York, NY 10001, USA", nil
 }
 
+type MockCityService struct {
+	GetCityFunc func(location, baseUrl string) (string, error)
+}
+
+func (m *MockCityService) GetCity(location, baseUrl string) (string, error) {
+	return "New York, NY 10001, USA", nil
+}
+
 // MochSeshuService mocks the UpdateSeshuSession function
 type MockSeshuService struct{}
 


### PR DESCRIPTION
This PR adds a "Locate Me" option to the location dropdown. This prompts the user if they will allow the browser to access their location and uses their latitude and longitude to find the city they're currently in. 
Then their city populates the dropdown as if they selected it manually. And when they click "Apply Filters", it will update the "Showing events within 50 miles of _insert_city_here_" blurb too. 
<img width="363" height="308" alt="image" src="https://github.com/user-attachments/assets/8a3cf320-d718-4c85-860a-8e436b7d9699" />

To make this happen I added a new cityService that finds the city in an iframe when passed the lat+lon. 
Here are the passing tests for that function:
<img width="357" height="217" alt="image" src="https://github.com/user-attachments/assets/4c484e5f-9fa1-4ee9-a810-c5e794a61a0e" />
I also added a new CityLookup endpoint. 
Here are the passing tests for the endpoint: 
<img width="318" height="139" alt="image" src="https://github.com/user-attachments/assets/a69aba15-f45a-46bc-8a21-c8fedfa45844" />