### PR TITLE
Fix: Unpublished events showing in main search results

### DIFF
--- a/functions/gateway/handlers/data_handlers_test.go
+++ b/functions/gateway/handlers/data_handlers_test.go
@@ -116,7 +116,7 @@ func TestPostEventHandler(t *testing.T) {
 			mockResponse := models.GraphQLResponse{
 				Data: map[string]models.JSONObject{
 					"Get": map[string]interface{}{
-						"EventStrict": []interface{}{
+						helpers.WeaviateEventClassName: []interface{}{
 							map[string]interface{}{
 								"name":        "Test Event",
 								"description": "A test event",
@@ -595,7 +595,7 @@ func TestSearchEvents(t *testing.T) {
 				mockResponse = models.GraphQLResponse{
 					Data: map[string]models.JSONObject{
 						"Get": map[string]interface{}{
-							"EventStrict": []interface{}{
+							helpers.WeaviateEventClassName: []interface{}{
 								map[string]interface{}{
 									"name":            "Conference on Go Programming",
 									"description":     "A deep dive into the Go language and its powerful ecosystem.",
@@ -619,7 +619,7 @@ func TestSearchEvents(t *testing.T) {
 				mockResponse = models.GraphQLResponse{
 					Data: map[string]models.JSONObject{
 						"Get": map[string]interface{}{
-							"EventStrict": []interface{}{},
+							helpers.WeaviateEventClassName: []interface{}{},
 						},
 					},
 				}
@@ -628,7 +628,7 @@ func TestSearchEvents(t *testing.T) {
 				mockResponse = models.GraphQLResponse{
 					Data: map[string]models.JSONObject{
 						"Get": map[string]interface{}{
-							"EventStrict": []interface{}{},
+							helpers.WeaviateEventClassName: []interface{}{},
 						},
 					},
 				}

--- a/functions/gateway/handlers/dynamodb_handlers/purchase_handlers_test.go
+++ b/functions/gateway/handlers/dynamodb_handlers/purchase_handlers_test.go
@@ -86,7 +86,7 @@ func TestGetPurchasesByEventID(t *testing.T) {
 			mockResponse := models.GraphQLResponse{
 				Data: map[string]models.JSONObject{
 					"Get": map[string]interface{}{
-						"EventStrict": []interface{}{
+						helpers.WeaviateEventClassName: []interface{}{
 							map[string]interface{}{
 								"name":           testEventName,
 								"description":    testEventDescription,

--- a/functions/gateway/handlers/page_handlers_test.go
+++ b/functions/gateway/handlers/page_handlers_test.go
@@ -60,28 +60,33 @@ func TestGetHomeOrUserPage(t *testing.T) {
 			}
 
 			// Return events for the home page
+			// NOTE: This mock should ONLY return published event types (SLF, SLF_EVS)
+			// The filter logic should already exclude unpublished types (SLF_UNPUB, etc.)
+			// so they shouldn't even be in the Weaviate query results
 			mockResponse := models.GraphQLResponse{
 				Data: map[string]models.JSONObject{
 					"Get": map[string]interface{}{
 						"EventStrict": []interface{}{
 							map[string]interface{}{
-								"name":           "First Test Event",
-								"description":    "Description of the first event",
-								"eventOwners":    []interface{}{"789"},
-								"eventOwnerName": "First Event Host",
-								"startTime":      time.Now().Add(48 * time.Hour).Unix(),
-								"timezone":       "America/New_York",
+								"name":            "First Test Event",
+								"description":     "Description of the first event",
+								"eventOwners":     []interface{}{"789"},
+								"eventOwnerName":  "First Event Host",
+								"eventSourceType": "SLF", // Published single event
+								"startTime":       time.Now().Add(48 * time.Hour).Unix(),
+								"timezone":        "America/New_York",
 								"_additional": map[string]interface{}{
 									"id": "123",
 								},
 							},
 							map[string]interface{}{
-								"name":           "Second Test Event",
-								"description":    "Description of the second event",
-								"eventOwners":    []interface{}{"012"},
-								"eventOwnerName": "Second Event Host",
-								"startTime":      time.Now().Add(72 * time.Hour).Unix(),
-								"timezone":       "America/New_York",
+								"name":            "Second Test Event",
+								"description":     "Description of the second event",
+								"eventOwners":     []interface{}{"012"},
+								"eventOwnerName":  "Second Event Host",
+								"eventSourceType": "SLF_EVS", // Published series parent
+								"startTime":       time.Now().Add(72 * time.Hour).Unix(),
+								"timezone":        "America/New_York",
 								"_additional": map[string]interface{}{
 									"id": "456",
 								},
@@ -163,7 +168,86 @@ func TestGetHomeOrUserPage(t *testing.T) {
 	}
 
 	if !strings.Contains(rr.Body.String(), ">Second Test Event") {
-		t.Errorf("First event title is missing from the page")
+		t.Errorf("Second event title is missing from the page")
+	}
+
+	// Verify that unpublished event types are NOT present
+	// Since our filter uses "field" tokenization and ContainsAny,
+	// it should only match exact values: "SLF" and "SLF_EVS"
+	// Events with type "SLF_UNPUB" should not appear
+	if strings.Contains(rr.Body.String(), "data-event-type=\"SLF_UNPUB\"") {
+		t.Errorf("Unpublished event (SLF_UNPUB) should not appear on home page")
+	}
+	if strings.Contains(rr.Body.String(), "data-event-type=\"SLF_EVS_UNPUB\"") {
+		t.Errorf("Unpublished series event (SLF_EVS_UNPUB) should not appear on home page")
+	}
+}
+
+func TestGetHomeOrUserPage_EventTypeFiltering(t *testing.T) {
+	// ==================================================================================
+	// UNIT TEST: Filter Construction and Default Values
+	// ==================================================================================
+	// This test verifies that:
+	// 1. The home page query uses DEFAULT_SEARCHABLE_EVENT_SOURCE_TYPES
+	// 2. The filter is sent to Weaviate with the correct event source types
+	// 3. Only events with matching types appear in the response
+	//
+	// ==================================================================================
+	// INTEGRATION TEST REQUIRED: Weaviate Tokenization Behavior
+	// ==================================================================================
+	// ⚠️  WHAT THIS TEST CANNOT VERIFY:
+	// This unit test CANNOT verify that Weaviate's "field" tokenization prevents
+	// substring matching. That requires an integration test with a real Weaviate instance.
+	//
+	// 🔍 THE PROBLEM:
+	// With "word" tokenization (default), "SLF_UNPUB" tokenizes to ["SLF", "UNPUB"].
+	// A filter for "SLF" using ContainsAny would match "SLF_UNPUB" (substring match).
+	//
+	// ✅ THE SOLUTION:
+	// With "field" tokenization (configured in weaviate_service.go schema), "SLF_UNPUB"
+	// is treated as a single token. A filter for "SLF" will NOT match "SLF_UNPUB".
+	//
+	// 🧪 TO VALIDATE THE FIX:
+	// 1. Restart the server after changing the schema name to force recreation
+	// 2. Seed events with different types: SLF, SLF_EVS, SLF_UNPUB, etc.
+	// 3. Query the home page: curl localhost:8000
+	// 4. Verify that ONLY SLF and SLF_EVS events appear (not SLF_UNPUB)
+	//
+	// 📝 SCHEMA CONFIGURATION:
+	// See weaviate_service.go line ~178:
+	//   {Name: "eventSourceType", DataType: []string{"text"},
+	//    Tokenization: "field", // ← This is critical for exact matching
+	//    ...
+	//   }
+	// ==================================================================================
+
+	// Verify that DEFAULT_SEARCHABLE_EVENT_SOURCE_TYPES only includes published types
+	expectedTypes := []string{helpers.ES_SERIES_PARENT, helpers.ES_SINGLE_EVENT} // ["SLF_EVS", "SLF"]
+	if len(helpers.DEFAULT_SEARCHABLE_EVENT_SOURCE_TYPES) != len(expectedTypes) {
+		t.Errorf("DEFAULT_SEARCHABLE_EVENT_SOURCE_TYPES length mismatch: got %d, want %d",
+			len(helpers.DEFAULT_SEARCHABLE_EVENT_SOURCE_TYPES), len(expectedTypes))
+	}
+
+	for i, expectedType := range expectedTypes {
+		if helpers.DEFAULT_SEARCHABLE_EVENT_SOURCE_TYPES[i] != expectedType {
+			t.Errorf("DEFAULT_SEARCHABLE_EVENT_SOURCE_TYPES[%d] = %s, want %s",
+				i, helpers.DEFAULT_SEARCHABLE_EVENT_SOURCE_TYPES[i], expectedType)
+		}
+	}
+
+	// Verify that unpublished types are NOT in the default searchable types
+	unpublishedTypes := []string{
+		helpers.ES_SINGLE_EVENT_UNPUB,  // "SLF_UNPUB"
+		helpers.ES_SERIES_PARENT_UNPUB, // "SLF_EVS_UNPUB"
+		helpers.ES_EVENT_SERIES_UNPUB,  // "EVS_UNPUB"
+	}
+
+	for _, unpubType := range unpublishedTypes {
+		for _, searchableType := range helpers.DEFAULT_SEARCHABLE_EVENT_SOURCE_TYPES {
+			if searchableType == unpubType {
+				t.Errorf("DEFAULT_SEARCHABLE_EVENT_SOURCE_TYPES should not include unpublished type: %s", unpubType)
+			}
+		}
 	}
 }
 

--- a/functions/gateway/handlers/page_handlers_test.go
+++ b/functions/gateway/handlers/page_handlers_test.go
@@ -66,7 +66,7 @@ func TestGetHomeOrUserPage(t *testing.T) {
 			mockResponse := models.GraphQLResponse{
 				Data: map[string]models.JSONObject{
 					"Get": map[string]interface{}{
-						"EventStrict": []interface{}{
+						helpers.WeaviateEventClassName: []interface{}{
 							map[string]interface{}{
 								"name":            "First Test Event",
 								"description":     "Description of the first event",
@@ -414,7 +414,7 @@ func TestGetEventDetailsPage(t *testing.T) {
 			mockResponse := models.GraphQLResponse{
 				Data: map[string]models.JSONObject{
 					"Get": map[string]interface{}{
-						"EventStrict": []interface{}{
+						helpers.WeaviateEventClassName: []interface{}{
 							map[string]interface{}{
 								"_additional": map[string]interface{}{
 									"id": "123",
@@ -890,7 +890,7 @@ func TestGetAddOrEditEventPage(t *testing.T) {
 			mockResponse := models.GraphQLResponse{
 				Data: map[string]models.JSONObject{
 					"Get": map[string]interface{}{
-						"EventStrict": []interface{}{
+						helpers.WeaviateEventClassName: []interface{}{
 							map[string]interface{}{
 								"_additional": map[string]interface{}{
 									"id": "123",
@@ -1088,7 +1088,7 @@ func TestGetEventAttendeesPage(t *testing.T) {
 			mockResponse := models.GraphQLResponse{
 				Data: map[string]models.JSONObject{
 					"Get": map[string]interface{}{
-						"EventStrict": []interface{}{
+						helpers.WeaviateEventClassName: []interface{}{
 							map[string]interface{}{
 								"_additional": map[string]interface{}{
 									"id": "123",

--- a/functions/gateway/handlers/partial_handlers_test.go
+++ b/functions/gateway/handlers/partial_handlers_test.go
@@ -491,7 +491,7 @@ func TestGetEventsPartial(t *testing.T) {
 			mockResponse := models.GraphQLResponse{
 				Data: map[string]models.JSONObject{
 					"Get": map[string]interface{}{
-						"EventStrict": events,
+						helpers.WeaviateEventClassName: events,
 					},
 				},
 			}
@@ -1334,7 +1334,7 @@ func TestGetEventAdminChildrenPartial(t *testing.T) {
 				mockResponse := models.GraphQLResponse{
 					Data: map[string]models.JSONObject{
 						"Get": map[string]interface{}{
-							"EventStrict": []interface{}{
+							helpers.WeaviateEventClassName: []interface{}{
 								map[string]interface{}{
 									"name":            "Child Event 1",
 									"description":     "First child event",
@@ -1377,7 +1377,7 @@ func TestGetEventAdminChildrenPartial(t *testing.T) {
 				mockResponse := models.GraphQLResponse{
 					Data: map[string]models.JSONObject{
 						"Get": map[string]interface{}{
-							"EventStrict": []interface{}{
+							helpers.WeaviateEventClassName: []interface{}{
 								map[string]interface{}{
 									"name":            "Parent Event",
 									"description":     "Parent event description",

--- a/functions/gateway/helpers/constants.go
+++ b/functions/gateway/helpers/constants.go
@@ -27,7 +27,8 @@ const CompetitionRoundsTablePrefix = "CompetitionRounds"
 const CompetitionWaitingRoomParticipantTablePrefix = "CompetitionWaitingRoomParticipant"
 const VotesTablePrefix = "Votes"
 
-const WeaviateEventClassName = "EventStrict"
+// const WeaviateEventClassName = "EventStrict" // old version
+const WeaviateEventClassName = "EventStrict_2025_10_4_000000"
 
 const ACT string = "ACT"
 const EVENT_ID_KEY string = "eventId"

--- a/functions/gateway/services/weaviate_service.go
+++ b/functions/gateway/services/weaviate_service.go
@@ -174,7 +174,12 @@ func CreateWeaviateSchemaIfMissing(ctx context.Context, client *weaviate.Client)
 				ModuleConfig: map[string]interface{}{vectorizer: map[string]interface{}{"skip": true}},
 			},
 			{Name: "eventSourceType", DataType: []string{"text"}, Description: "Source system type",
-				Tokenization: "field", // Use "field" tokenization for exact matching (not substring matching)
+				// ⚠️  CRITICAL: "field" tokenization is required for exact matching
+				// Without this, "SLF" would match "SLF_UNPUB" because "word" tokenization (default)
+				// splits "SLF_UNPUB" into ["SLF", "UNPUB"], causing substring matches with ContainsAny.
+				// With "field" tokenization, "SLF_UNPUB" is a single token and won't match "SLF".
+				// See: https://weaviate.io/developers/weaviate/config-refs/schema#property-tokenization
+				Tokenization: "field",
 				ModuleConfig: map[string]interface{}{vectorizer: map[string]interface{}{"skip": true}},
 			},
 			{Name: "startTime", DataType: []string{"int"}, Description: "Event start timestamp (Unix epoch)", // Use "int" for int64
@@ -190,7 +195,8 @@ func CreateWeaviateSchemaIfMissing(ctx context.Context, client *weaviate.Client)
 				ModuleConfig: map[string]interface{}{vectorizer: map[string]interface{}{"skip": true}},
 			},
 			{Name: "eventSourceId", DataType: []string{"text"}, Description: "Optional source system ID",
-				Tokenization: "field", // Use "field" tokenization for exact matching (not substring matching)
+				// "field" tokenization for exact ID matching (prevents partial matches)
+				Tokenization: "field",
 				ModuleConfig: map[string]interface{}{vectorizer: map[string]interface{}{"skip": true}},
 			},
 			{Name: "startingPrice", DataType: []string{"number"}, Description: "Optional starting price", // Using "number" for the int32 -> float64 conversion in ToMap

--- a/functions/gateway/services/weaviate_service.go
+++ b/functions/gateway/services/weaviate_service.go
@@ -162,6 +162,7 @@ func CreateWeaviateSchemaIfMissing(ctx context.Context, client *weaviate.Client)
 			},
 			{Name: "address", DataType: []string{"text"}, Description: "Venue address",
 				ModuleConfig: map[string]interface{}{vectorizer: map[string]interface{}{"skip": false, "vectorizePropertyName": false}},
+				Tokenization: "field", // Use "field" tokenization for exact matching (not substring matching)
 			},
 			// Other fields (NOT vectorized by default)
 			{Name: "eventOwners", DataType: []string{"text[]"}, Description: "List of owner IDs", // Use "text[]" for string arrays
@@ -174,6 +175,7 @@ func CreateWeaviateSchemaIfMissing(ctx context.Context, client *weaviate.Client)
 				ModuleConfig: map[string]interface{}{vectorizer: map[string]interface{}{"skip": true}},
 			},
 			{Name: "eventSourceType", DataType: []string{"text"}, Description: "Source system type",
+				Tokenization: "field", // Use "field" tokenization for exact matching (not substring matching)
 				ModuleConfig: map[string]interface{}{vectorizer: map[string]interface{}{"skip": true}},
 			},
 			{Name: "startTime", DataType: []string{"int"}, Description: "Event start timestamp (Unix epoch)", // Use "int" for int64
@@ -189,6 +191,7 @@ func CreateWeaviateSchemaIfMissing(ctx context.Context, client *weaviate.Client)
 				ModuleConfig: map[string]interface{}{vectorizer: map[string]interface{}{"skip": true}},
 			},
 			{Name: "eventSourceId", DataType: []string{"text"}, Description: "Optional source system ID",
+				Tokenization: "field", // Use "field" tokenization for exact matching (not substring matching)
 				ModuleConfig: map[string]interface{}{vectorizer: map[string]interface{}{"skip": true}},
 			},
 			{Name: "startingPrice", DataType: []string{"number"}, Description: "Optional starting price", // Using "number" for the int32 -> float64 conversion in ToMap
@@ -199,6 +202,7 @@ func CreateWeaviateSchemaIfMissing(ctx context.Context, client *weaviate.Client)
 			},
 			{Name: "payeeId", DataType: []string{"text"}, Description: "Optional payee ID",
 				ModuleConfig: map[string]interface{}{vectorizer: map[string]interface{}{"skip": true}},
+				Tokenization: "field", // Use "field" tokenization for exact matching (not substring matching)
 			},
 			{Name: "hasRegistrationFields", DataType: []string{"boolean"}, Description: "Flag for registration fields", // Use "boolean" for bool
 				ModuleConfig: map[string]interface{}{vectorizer: map[string]interface{}{"skip": true}},
@@ -214,14 +218,13 @@ func CreateWeaviateSchemaIfMissing(ctx context.Context, client *weaviate.Client)
 			},
 			{Name: "categories", DataType: []string{"text[]"}, Description: "Optional list of categories",
 				ModuleConfig: map[string]interface{}{vectorizer: map[string]interface{}{"skip": true}},
+				Tokenization: "field", // Use "field" tokenization for exact matching (not substring matching)
 			},
 			{Name: "tags", DataType: []string{"text[]"}, Description: "Optional list of tags",
 				ModuleConfig: map[string]interface{}{vectorizer: map[string]interface{}{"skip": true}},
+				Tokenization: "field", // Use "field" tokenization for exact matching (not substring matching)
 			},
 			{Name: "updatedBy", DataType: []string{"text"}, Description: "User ID of last updater",
-				ModuleConfig: map[string]interface{}{vectorizer: map[string]interface{}{"skip": true}},
-			},
-			{Name: "refUrl", DataType: []string{"text"}, Description: "Optional reference URL",
 				ModuleConfig: map[string]interface{}{vectorizer: map[string]interface{}{"skip": true}},
 			},
 			{Name: "hideCrossPromo", DataType: []string{"boolean"}, Description: "Flag to hide cross-promotion",
@@ -303,9 +306,6 @@ func EventStructToMap(e types.Event) map[string]interface{} {
 	}
 	if e.UpdatedBy != "" {
 		props["updatedBy"] = e.UpdatedBy
-	}
-	if e.RefUrl != "" {
-		props["refUrl"] = e.RefUrl
 	}
 	if e.CompetitionConfigId != "" {
 		props["competitionConfigId"] = e.CompetitionConfigId
@@ -820,7 +820,7 @@ func BulkGetWeaviateEventByID(ctx context.Context, client *weaviate.Client, docI
 		{Name: "lat"}, {Name: "long"}, {Name: "eventSourceId"}, {Name: "startingPrice"},
 		{Name: "currency"}, {Name: "payeeId"}, {Name: "hasRegistrationFields"}, {Name: "hasPurchasable"},
 		{Name: "imageUrl"}, {Name: "timezone"}, {Name: "categories"}, {Name: "tags"},
-		{Name: "updatedBy"}, {Name: "refUrl"},
+		{Name: "updatedBy"},
 		{Name: "hideCrossPromo"}, {Name: "competitionConfigId"},
 		{Name: "shadowOwners"},
 		{Name: "_additional", Fields: []graphql.Field{

--- a/functions/gateway/services/weaviate_service.go
+++ b/functions/gateway/services/weaviate_service.go
@@ -162,7 +162,6 @@ func CreateWeaviateSchemaIfMissing(ctx context.Context, client *weaviate.Client)
 			},
 			{Name: "address", DataType: []string{"text"}, Description: "Venue address",
 				ModuleConfig: map[string]interface{}{vectorizer: map[string]interface{}{"skip": false, "vectorizePropertyName": false}},
-				Tokenization: "field", // Use "field" tokenization for exact matching (not substring matching)
 			},
 			// Other fields (NOT vectorized by default)
 			{Name: "eventOwners", DataType: []string{"text[]"}, Description: "List of owner IDs", // Use "text[]" for string arrays
@@ -226,6 +225,10 @@ func CreateWeaviateSchemaIfMissing(ctx context.Context, client *weaviate.Client)
 			},
 			{Name: "updatedBy", DataType: []string{"text"}, Description: "User ID of last updater",
 				ModuleConfig: map[string]interface{}{vectorizer: map[string]interface{}{"skip": true}},
+			},
+			{Name: "refUrl", DataType: []string{"text"}, Description: "Optional reference URL",
+				ModuleConfig: map[string]interface{}{vectorizer: map[string]interface{}{"skip": true}},
+				Tokenization: "field", // Use "field" tokenization for exact matching (not substring matching)
 			},
 			{Name: "hideCrossPromo", DataType: []string{"boolean"}, Description: "Flag to hide cross-promotion",
 				ModuleConfig: map[string]interface{}{vectorizer: map[string]interface{}{"skip": true}},
@@ -306,6 +309,9 @@ func EventStructToMap(e types.Event) map[string]interface{} {
 	}
 	if e.UpdatedBy != "" {
 		props["updatedBy"] = e.UpdatedBy
+	}
+	if e.RefUrl != "" {
+		props["refUrl"] = e.RefUrl
 	}
 	if e.CompetitionConfigId != "" {
 		props["competitionConfigId"] = e.CompetitionConfigId
@@ -820,7 +826,7 @@ func BulkGetWeaviateEventByID(ctx context.Context, client *weaviate.Client, docI
 		{Name: "lat"}, {Name: "long"}, {Name: "eventSourceId"}, {Name: "startingPrice"},
 		{Name: "currency"}, {Name: "payeeId"}, {Name: "hasRegistrationFields"}, {Name: "hasPurchasable"},
 		{Name: "imageUrl"}, {Name: "timezone"}, {Name: "categories"}, {Name: "tags"},
-		{Name: "updatedBy"},
+		{Name: "updatedBy"}, {Name: "refUrl"},
 		{Name: "hideCrossPromo"}, {Name: "competitionConfigId"},
 		{Name: "shadowOwners"},
 		{Name: "_additional", Fields: []graphql.Field{

--- a/functions/gateway/services/weaviate_service_test.go
+++ b/functions/gateway/services/weaviate_service_test.go
@@ -300,7 +300,7 @@ func TestSearchWeaviateEvents(t *testing.T) {
 				Data: map[string]models.JSONObject{
 					"Get": map[string]interface{}{
 						// The key here should match the Class name your code expects.
-						"EventStrict": []interface{}{
+						helpers.WeaviateEventClassName: []interface{}{
 							map[string]interface{}{
 								"ClassName":   "Event", // The field your code was looking for.
 								"name":        "Rock Concert",
@@ -523,8 +523,8 @@ func TestGetWeaviateEventByID(t *testing.T) {
 			mockResponse := models.GraphQLResponse{
 				Data: map[string]models.JSONObject{
 					"Get": map[string]interface{}{
-						// The key is the Class Name your code is querying, likely "EventStrict"
-						"EventStrict": []interface{}{
+						// The key is the Class Name your code is querying
+						helpers.WeaviateEventClassName: []interface{}{
 							// This map represents the single event object found
 							map[string]interface{}{
 								"name":        expectedName,
@@ -634,8 +634,8 @@ func TestBulkGetWeaviateEventByID(t *testing.T) {
 			mockResponse := models.GraphQLResponse{
 				Data: map[string]models.JSONObject{
 					"Get": map[string]interface{}{
-						// The key is the Class Name, likely "EventStrict"
-						"EventStrict": []interface{}{
+						// The key is the Class Name
+						helpers.WeaviateEventClassName: []interface{}{
 							// First event object
 							map[string]interface{}{
 								"name":        "First Mock Event",

--- a/functions/gateway/types/events.go
+++ b/functions/gateway/types/events.go
@@ -30,7 +30,6 @@ type Event struct {
 	CreatedAt             int64         `json:"createdAt,omitempty"`
 	UpdatedAt             int64         `json:"updatedAt,omitempty"`
 	UpdatedBy             string        `json:"updatedBy,omitempty"`
-	RefUrl                string        `json:"refUrl,omitempty"`
 	HideCrossPromo        bool          `json:"hideCrossPromo,omitempty"`
 	CompetitionConfigId   string        `json:"competitionConfigId,omitempty"`
 	ShadowOwners          []string      `json:"shadowOwners,omitempty"`

--- a/functions/gateway/types/events.go
+++ b/functions/gateway/types/events.go
@@ -30,6 +30,7 @@ type Event struct {
 	CreatedAt             int64         `json:"createdAt,omitempty"`
 	UpdatedAt             int64         `json:"updatedAt,omitempty"`
 	UpdatedBy             string        `json:"updatedBy,omitempty"`
+	RefUrl                string        `json:"refUrl,omitempty"`
 	HideCrossPromo        bool          `json:"hideCrossPromo,omitempty"`
 	CompetitionConfigId   string        `json:"competitionConfigId,omitempty"`
 	ShadowOwners          []string      `json:"shadowOwners,omitempty"`


### PR DESCRIPTION
we have `SLF` and `SLF_UNPUB` as event types we filter on. the `*_UNPUB` suffixed events are intended to be the "not publicly searchable" version of the event

Unfortunately, the tokenization behavior as [documented in Weaviate here](https://docs.weaviate.io/academy/py/tokenization/options) makes it clear that we've misunderstood tokenization cc @Brandon-G-Tripp because a partial substring match in our Weaviate client filter builder will return BOTH the `SLF` and the `SLF_UNPUB` events when only searching for `SLF` events

I've added better tokenization handling to a number of at-risk text fields

**Changes**

1. Add missing tokenization. The absence of this `Tokenization: field` meant that a partial match on a field would return as positive for a filter. Since we use `SLF` and `SLF_UNPUB` where the `_UNPUB` denotes events that should not show in search results, the partial match on the beginning of the string would yield false positive matches.
2. Also drop `refUrl` which was intended as the field for individual child events, but https://github.com/meetnearme/api/pull/451 introduces `sourceUrl` instead

# Before 

<img width="725" height="655" alt="image" src="https://github.com/user-attachments/assets/3308a63f-8b55-4c37-b1ba-ad94d269a6c7" />


<img width="656" height="882" alt="image" src="https://github.com/user-attachments/assets/bab7b862-ef01-4496-afdb-c5d8c6657496" />


# After

<img width="725" height="655" alt="image" src="https://github.com/user-attachments/assets/4d81bc61-7a3c-4794-b562-b97348bd2c57" />


<img width="663" height="883" alt="image" src="https://github.com/user-attachments/assets/427439d6-c3d5-4997-ae04-cfa5f0281eb7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Event search and filters now use exact field matching (no unintended substring matches) for source type, source ID, payee, categories, tags, and reference URL.
  - Home page no longer displays unpublished event types; search/filter results exclude them.

- Chores
  - Internal event schema/version updated to support the improved matching behavior; no user action required.

- Tests
  - Added/updated tests to validate event-type filtering and exact-match behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->